### PR TITLE
Jules attempt to fix

### DIFF
--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -111,7 +111,6 @@ class RooAgent:
         Regex matches specific high-frequency commands.
         """
         import re
-        from datetime import date, timedelta
         
         text_lower = text.lower().strip()
         
@@ -131,7 +130,7 @@ class RooAgent:
 
         # 4. Coworking Book Today: "coworking book today"
         if re.match(r'^coworking\s+book\s+today$', text_lower):
-            today = date.today().isoformat()
+            today = self._get_today().isoformat()
             return await self._execute_fast_points(
                 user_id, "book_coworking", 
                 date=today, channel_id=channel_id
@@ -141,13 +140,18 @@ class RooAgent:
         if re.match(r'^coworking\s+cancel$', text_lower):
             # For "cancel", we might need to handle logic in the client or pass a flag
             # The user requirement was "will cancel booking for today"
-            today = date.today().isoformat()
+            today = self._get_today().isoformat()
             return await self._execute_fast_points(
                 user_id, "cancel_coworking", 
                 date=today
             )
             
         return None
+
+    def _get_today(self):
+        """Get today's date respecting the configured timezone."""
+        from roo.utils import get_current_date
+        return get_current_date()
 
     async def _execute_fast_points(self, user_id: str, action: str, **kwargs) -> Dict[str, Any]:
         """Execute a Points action directly."""

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -41,6 +41,7 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     LOG_LEVEL: str = "INFO"
     SKILLS_DIR: str = "skills"
+    TIMEZONE: str = "Australia/Melbourne"
     
     @property
     def default_llm_provider(self) -> str:

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -671,11 +671,14 @@ Keep the response concise but informative."""
             
             # Normalize date aliases
             if booking_date:
-                from datetime import date, timedelta
+                from datetime import timedelta
+                from roo.utils import get_current_date
+                today = get_current_date()
+
                 if booking_date.lower() == "today":
-                    booking_date = date.today().isoformat()
+                    booking_date = today.isoformat()
                 elif booking_date.lower() == "tomorrow":
-                    booking_date = (date.today() + timedelta(days=1)).isoformat()
+                    booking_date = (today + timedelta(days=1)).isoformat()
             
             if not booking_date:
                 import re
@@ -705,11 +708,14 @@ Keep the response concise but informative."""
             
             # Normalize date aliases
             if booking_date:
-                from datetime import date, timedelta
+                from datetime import timedelta
+                from roo.utils import get_current_date
+                today = get_current_date()
+
                 if booking_date.lower() == "today":
-                    booking_date = date.today().isoformat()
+                    booking_date = today.isoformat()
                 elif booking_date.lower() == "tomorrow":
-                    booking_date = (date.today() + timedelta(days=1)).isoformat()
+                    booking_date = (today + timedelta(days=1)).isoformat()
             
             if not booking_date and not booking_id:
                 import re

--- a/roo-standalone/roo/utils.py
+++ b/roo-standalone/roo/utils.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from .config import get_settings
+
+def get_current_date():
+    """Get the current date in the configured timezone."""
+    settings = get_settings()
+    tz = ZoneInfo(settings.TIMEZONE)
+    return datetime.now(tz).date()
+
+def get_current_datetime():
+    """Get the current datetime in the configured timezone."""
+    settings = get_settings()
+    tz = ZoneInfo(settings.TIMEZONE)
+    return datetime.now(tz)

--- a/roo-standalone/skills/mlai_points/client.py
+++ b/roo-standalone/skills/mlai_points/client.py
@@ -198,9 +198,19 @@ class PointsClient:
         slack_channel_id: Optional[str] = None
     ) -> dict:
         """Book a coworking day."""
+        # Inject current server time (in configured timezone) to help backend validation
+        try:
+            from roo.utils import get_current_datetime
+            current_time = get_current_datetime().isoformat()
+        except ImportError:
+            # Fallback if roo.utils not available (e.g. strict isolation)
+            from datetime import datetime
+            current_time = datetime.now().isoformat()
+
         payload = {
             "slack_user_id": slack_user_id,
             "date": booking_date,
+            "current_time": current_time,
         }
         if slack_channel_id:
             payload["slack_channel_id"] = slack_channel_id


### PR DESCRIPTION
Fix coworking booking date timezone issue by passing client time to backend.
- Added `TIMEZONE` setting to `roo/config.py` defaulting to `Australia/Melbourne`.
- Created `roo/utils.py` with `get_current_date` and `get_current_datetime` helper functions.
- Updated `roo/agent.py` and `roo/skills/executor.py` to use timezone-aware date calculation.
- Modified `roo/skills/mlai_points/client.py` to include `current_time` in `book_coworking` payload, allowing the backend to validate requests against the correct user timezone.