### PR TITLE
ensure user exists before points client creation

### DIFF
--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -1801,11 +1801,14 @@ Keep the response concise but informative."""
         # ClientClass = skill.get_client_class("MLAIBackendClient")
         from roo.clients.mlai_backend import MLAIBackendClient
         ClientClass = MLAIBackendClient
-        
-        if ClientClass is None:
-            return "Sorry mate, the Points skill isn't properly configured. Missing implementation."
-        
+
         try:
+            # Ensure user exists before creating points client 
+            await self._ensure_user_exists(user_id)
+
+            if ClientClass is None:
+                return "Sorry mate, the Points skill isn't properly configured. Missing implementation."
+        
             settings = get_settings()
             if not settings.MLAI_BACKEND_URL:
                 return "Sorry mate, the Points API isn't configured. Ask the team to set MLAI_BACKEND_URL."
@@ -1884,7 +1887,17 @@ Keep the response concise but informative."""
             if e.response.status_code == 403:
                 return "Sorry mate, you're not authorized to do that. Only Points Admins can perform that action. 🔒"
             elif e.response.status_code == 404:
-                return "Hmm, couldn't find that. Double-check the ID or date and try again? 🤔"
+                    return await self._handle_points_action(
+                    client=client,
+                    action=action,
+                    params=params,
+                    text=text,
+                    user_id=user_id,
+                    channel_id=channel_id,
+                    thread_ts=thread_ts,
+                    skill=skill
+                )
+                # return "Hmm, couldn't find that. Double-check the ID or date and try again? 🤔"
             elif e.response.status_code == 400:
                 # Handle bad requests (e.g. insufficient funds)
                 try:


### PR DESCRIPTION
I added the `_ensure_user_exists` method before the points client but it's difficult to debug further because the following code captures all exceptions and I cannot check the `stdout` without a dev env. 
```
except Exception as e:
            print(f"Points skill error: {e}")
            import traceback
            traceback.print_exc()
            return f"Had some trouble with the points system: {str(e)}"
```

Regarding the registration endpoint failure:

>  If registration fails, do not hard fail immediately. Continue the points call once, but if it fails too, return a helpful onboarding message.

I cannot check for registration failure because I am unsure what it responds with when it fails to register. I see that 404 is handled in `_execute_mlai_points` method:
```
elif e.response.status_code == 404:
                return "Hmm, couldn't find that. Double-check the ID or date and try again? 🤔"
```
I assume this is where the registration fails and hence I added the call to `_handle_points_action` method. 

Apologies if this PR is not super helpful