### PR TITLE
Disable MedHack daily case scheduler

### DIFF
--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -151,15 +151,15 @@ async def lifespan(app: FastAPI):
     agent = get_agent()
     print(f"   Loaded {len(agent.skills)} skills")
 
-    # Start MedHack daily case scheduler
-    import asyncio
-    medhack_task = asyncio.create_task(_medhack_daily_case_loop())
-    print("   Started MedHack daily case scheduler")
+    # MedHack daily case scheduler (currently disabled)
+    # import asyncio
+    # medhack_task = asyncio.create_task(_medhack_daily_case_loop())
+    # print("   Started MedHack daily case scheduler")
 
     yield
 
-    # Cancel the background task on shutdown
-    medhack_task.cancel()
+    # Cancel the background task on shutdown (disabled)
+    # medhack_task.cancel()
     print("🦘 Roo Standalone shutting down...")
 
 


### PR DESCRIPTION
## Summary
- Disables the background task that generates and posts a new patient case to Slack each day at 10 AM AEST
- The `_medhack_daily_case_loop` function is left in place but no longer started

## Test plan
- [ ] Deploy and confirm logs no longer show "Started MedHack daily case scheduler" or "Next case in X hours"

🤖 Generated with [Claude Code](https://claude.com/claude-code)