### PR TITLE
[codex] Add delegated as-user content factory flows

### DIFF
--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -10,7 +10,12 @@ from typing import Optional, Dict, Any, List
 from pathlib import Path
 
 from .config import get_settings
-from .content_intent import extract_domain, normalize_slack_text, parse_routing_intent
+from .content_intent import (
+    extract_content_factory_delegation,
+    extract_domain,
+    normalize_slack_text,
+    parse_routing_intent,
+)
 from .llm import chat
 from .skills.loader import Skill, load_skills
 from .skills.executor import SkillExecutor
@@ -18,6 +23,7 @@ from .slack_client import get_thread_messages
 
 
 THREAD_CONTEXT_TTL = timedelta(hours=2)
+CONTENT_FACTORY_DELEGATION_ADMIN_SLACK_ID = "U05QPB483K9"
 
 
 class RooAgent:
@@ -72,6 +78,40 @@ class RooAgent:
         # Clean the message
         clean_text = self._clean_mention(text)
         thread_context = self._get_thread_context(channel_id, thread_ts)
+        stripped_text, delegation = extract_content_factory_delegation(clean_text)
+        requested_by_slack_user_id = user_id
+        effective_slack_user_id = user_id
+
+        if delegation:
+            delegated_target = str(delegation.get("effective_slack_user_id") or "").strip()
+            if delegated_target and delegated_target != user_id:
+                if user_id != CONTENT_FACTORY_DELEGATION_ADMIN_SLACK_ID:
+                    return {
+                        "message": "Only <@U05QPB483K9> can run Content Factory as another user.",
+                        "skill_used": "content-factory",
+                        "data": None,
+                    }
+                effective_slack_user_id = delegated_target
+            clean_text = stripped_text
+        elif (
+            thread_context
+            and thread_context.get("skill_name") == "content-factory"
+            and str(thread_context.get("requested_by_slack_user_id") or "").strip() == user_id
+        ):
+            sticky_effective_slack_user_id = str(
+                thread_context.get("effective_slack_user_id") or ""
+            ).strip()
+            sticky_requested_by_slack_user_id = str(
+                thread_context.get("requested_by_slack_user_id") or ""
+            ).strip()
+            if sticky_requested_by_slack_user_id:
+                requested_by_slack_user_id = sticky_requested_by_slack_user_id
+            if sticky_effective_slack_user_id:
+                effective_slack_user_id = sticky_effective_slack_user_id
+
+        is_delegated_content_factory_request = (
+            requested_by_slack_user_id != effective_slack_user_id
+        )
         routing_intent = self._get_routing_intent(clean_text, thread_context)
         
         print(f"🔍 Processing: {clean_text[:100]}...")
@@ -105,13 +145,38 @@ class RooAgent:
 
         if skill:
             print(f"🎯 Selected skill: {skill.name}")
-            self._remember_selected_skill(skill.name, channel_id, thread_ts, clean_text)
+            self._remember_selected_skill(
+                skill.name,
+                channel_id,
+                thread_ts,
+                clean_text,
+                requested_by_slack_user_id=(
+                    requested_by_slack_user_id
+                    if skill.name == "content-factory" and is_delegated_content_factory_request
+                    else None
+                ),
+                effective_slack_user_id=(
+                    effective_slack_user_id
+                    if skill.name == "content-factory" and is_delegated_content_factory_request
+                    else None
+                ),
+            )
             effective_param_overrides = dict(param_overrides or {})
             if routing_intent and skill.name == routing_intent["skill"].name:
                 effective_param_overrides = {
                     **routing_intent.get("params", {}),
                     **effective_param_overrides,
                 }
+            if skill.name == "content-factory":
+                effective_param_overrides = {
+                    **effective_param_overrides,
+                }
+                if is_delegated_content_factory_request:
+                    effective_param_overrides = {
+                        "requested_by_slack_user_id": requested_by_slack_user_id,
+                        "effective_slack_user_id": effective_slack_user_id,
+                        **effective_param_overrides,
+                    }
             result = await self.skill_executor.execute(
                 skill=skill,
                 text=clean_text,
@@ -147,6 +212,8 @@ class RooAgent:
         domain: Optional[str] = None,
         workflow: Optional[str] = None,
         active_job_id: Optional[str] = None,
+        requested_by_slack_user_id: Optional[str] = None,
+        effective_slack_user_id: Optional[str] = None,
     ) -> None:
         """Persist recent thread routing context so follow-ups stay on the right skill."""
         thread_key = self._thread_key(channel_id, thread_ts)
@@ -161,6 +228,16 @@ class RooAgent:
             "active_job_id": (
                 active_job_id if active_job_id is not None else existing.get("active_job_id")
             ),
+            "requested_by_slack_user_id": (
+                requested_by_slack_user_id
+                if requested_by_slack_user_id is not None
+                else existing.get("requested_by_slack_user_id")
+            ),
+            "effective_slack_user_id": (
+                effective_slack_user_id
+                if effective_slack_user_id is not None
+                else existing.get("effective_slack_user_id")
+            ),
             "updated_at": datetime.now(timezone.utc),
         }
 
@@ -170,6 +247,9 @@ class RooAgent:
         channel_id: Optional[str],
         thread_ts: Optional[str],
         text: str,
+        *,
+        requested_by_slack_user_id: Optional[str] = None,
+        effective_slack_user_id: Optional[str] = None,
     ) -> None:
         workflow = None
         text_lower = text.lower()
@@ -190,6 +270,8 @@ class RooAgent:
             thread_ts,
             domain=self._extract_domain(text),
             workflow=workflow,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            effective_slack_user_id=effective_slack_user_id,
         )
 
     def _thread_key(self, channel_id: Optional[str], thread_ts: Optional[str]) -> Optional[str]:
@@ -216,6 +298,14 @@ class RooAgent:
             return None
 
         return context
+
+    def get_thread_context(
+        self,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        """Return remembered thread context for callers outside the agent."""
+        return self._get_thread_context(channel_id, thread_ts)
 
     def _get_skill_by_name(self, skill_name: str) -> Optional[Skill]:
         return next((skill for skill in self.skills if skill.name == skill_name), None)

--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -588,6 +588,7 @@ class MLAIBackendClient:
         user_first_name: Optional[str] = None,
         user_last_name: Optional[str] = None,
         user_avatar_url: Optional[str] = None,
+        requested_by_slack_user_id: Optional[str] = None,
     ) -> dict:
         """
         Trigger article generation via mlai-backend.
@@ -613,6 +614,8 @@ class MLAIBackendClient:
             "context": context,
             "request_source": request_source,
         }
+        if requested_by_slack_user_id:
+            payload["requested_by_slack_user_id"] = self._clean_slack_id(requested_by_slack_user_id)
 
         # Only add topic/keyword if provided (omitting them triggers auto-research)
         if topic:
@@ -713,6 +716,7 @@ class MLAIBackendClient:
         delivery_mode: Optional[str] = None,
         delivery_mode_confirmed: Optional[bool] = None,
         request_source: str = CONTENT_FACTORY_REQUEST_SOURCE,
+        requested_by_slack_user_id: Optional[str] = None,
     ) -> dict:
         """
         Confirm topic selection for article generation.
@@ -738,6 +742,8 @@ class MLAIBackendClient:
             "option_index": option_index,
             "request_source": request_source,
         }
+        if requested_by_slack_user_id:
+            payload["requested_by_slack_user_id"] = self._clean_slack_id(requested_by_slack_user_id)
 
         if confirmed_keyword:
             payload["keyword"] = confirmed_keyword
@@ -1154,6 +1160,7 @@ class MLAIBackendClient:
         slack_thread_ts: Optional[str] = None,
         domain: Optional[str] = None,
         request_source: str = CONTENT_FACTORY_REQUEST_SOURCE,
+        requested_by_slack_user_id: Optional[str] = None,
     ) -> dict:
         """
         Trigger a repository scan for a user via the backend.
@@ -1167,6 +1174,8 @@ class MLAIBackendClient:
                 "slack_user_id": clean_id,
                 "request_source": request_source,
             }
+            if requested_by_slack_user_id:
+                payload["requested_by_slack_user_id"] = self._clean_slack_id(requested_by_slack_user_id)
             if domain:
                 payload["domain"] = domain
             if slack_channel_id:
@@ -1224,7 +1233,8 @@ class MLAIBackendClient:
         domain: str,
         slack_user_id: str,
         slack_channel_id: str,
-        slack_thread_ts: str
+        slack_thread_ts: str,
+        requested_by_slack_user_id: Optional[str] = None,
     ) -> dict:
         """
         Trigger articles directory scaffolding for a domain.
@@ -1248,6 +1258,8 @@ class MLAIBackendClient:
             "slack_channel_id": slack_channel_id,
             "slack_thread_ts": slack_thread_ts
         }
+        if requested_by_slack_user_id:
+            payload["requested_by_slack_user_id"] = self._clean_slack_id(requested_by_slack_user_id)
 
         response = await self._request(
             "POST",
@@ -1270,6 +1282,7 @@ class MLAIBackendClient:
         slack_user_id: str,
         slack_channel_id: str,
         slack_thread_ts: str,
+        requested_by_slack_user_id: Optional[str] = None,
     ) -> dict:
         """Approve or deny scaffold creation for a scan run."""
         if not self.base_url:
@@ -1284,6 +1297,8 @@ class MLAIBackendClient:
             "slack_channel_id": slack_channel_id,
             "slack_thread_ts": slack_thread_ts,
         }
+        if requested_by_slack_user_id:
+            payload["requested_by_slack_user_id"] = self._clean_slack_id(requested_by_slack_user_id)
 
         response = await self._request(
             "POST",
@@ -1303,6 +1318,7 @@ class MLAIBackendClient:
         domain: str,
         slack_user_id: str,
         decision: str,
+        requested_by_slack_user_id: Optional[str] = None,
     ) -> dict:
         """Persist an article-system decision and optionally resume the pending write."""
         if not self.base_url:
@@ -1314,6 +1330,8 @@ class MLAIBackendClient:
             "slack_user_id": clean_id,
             "decision": decision,
         }
+        if requested_by_slack_user_id:
+            payload["requested_by_slack_user_id"] = self._clean_slack_id(requested_by_slack_user_id)
 
         response = await self._request(
             "POST",
@@ -1345,17 +1363,26 @@ class MLAIBackendClient:
         response.raise_for_status()
         return response.json()
 
-    async def publish_article_as_pr(self, job_id: str, slack_user_id: str) -> dict:
+    async def publish_article_as_pr(
+        self,
+        job_id: str,
+        slack_user_id: str,
+        *,
+        requested_by_slack_user_id: Optional[str] = None,
+    ) -> dict:
         """Promote a completed content-only article into a draft-PR publish run."""
         if not self.base_url:
             raise ValueError("MLAI_BACKEND_URL not configured")
 
         clean_id = self._clean_slack_id(slack_user_id)
+        payload = {"slack_user_id": clean_id}
+        if requested_by_slack_user_id:
+            payload["requested_by_slack_user_id"] = self._clean_slack_id(requested_by_slack_user_id)
 
         response = await self._request(
             "POST",
             f"/api/v1/content/jobs/{job_id}/publish-pr",
-            json={"slack_user_id": clean_id},
+            json=payload,
             timeout=60.0,
             circuit_breaker=True,
         )
@@ -1371,6 +1398,7 @@ class MLAIBackendClient:
         requested_action: str,
         domain: Optional[str] = None,
         job_id: Optional[str] = None,
+        requested_by_slack_user_id: Optional[str] = None,
     ) -> dict:
         """Resolve the active content-factory job for a Slack thread."""
         if not self.base_url:
@@ -1382,6 +1410,8 @@ class MLAIBackendClient:
             "slack_thread_ts": slack_thread_ts,
             "requested_action": requested_action,
         }
+        if requested_by_slack_user_id:
+            payload["requested_by_slack_user_id"] = self._clean_slack_id(requested_by_slack_user_id)
         if domain:
             payload["domain"] = domain
         if job_id:

--- a/roo-standalone/roo/content_intent.py
+++ b/roo-standalone/roo/content_intent.py
@@ -9,6 +9,11 @@ from typing import Any, Dict, Optional
 DOMAIN_PATTERN = re.compile(r"\b(?:https?://)?([a-z0-9][a-z0-9.-]+\.[a-z]{2,})\b")
 SLACK_FORMATTED_ENTITY_PATTERN = re.compile(r"<([^>|]+)\|([^>]+)>")
 SLACK_PLAIN_URL_PATTERN = re.compile(r"<((?:https?://|mailto:)[^>]+)>")
+SLACK_USER_MENTION_PATTERN = re.compile(r"<@([A-Z0-9]+)>")
+TRAILING_DELEGATION_PATTERN = re.compile(
+    r"^(?P<body>.+?)\s+(?P<keyword>as|for)\s+(?P<mention><@[A-Z0-9]+>)\s*$",
+    re.IGNORECASE,
+)
 
 SCAN_PATTERNS = (
     r"^(?:please\s+)?(?:re-?scan|scan|analy[sz]e|inspect)\b",
@@ -28,6 +33,7 @@ SCAFFOLD_PATTERNS = (
 )
 RESEARCH_PATTERNS = (
     r"\bresearch\b.*\b(article|topic|keyword|blog(?:\s+post)?)\b",
+    r"\bdiscover\b.*\b(topic|topics|article|keyword|keywords|blog(?:\s+post)?)\b",
     r"\b(?:best|next)\s+article\s+to\s+write\b",
     r"\bwhat\s+should\s+i\s+write\b",
     r"\b(?:recommend|suggest)\s+(?:a\s+)?(?:topic|article|keyword)\b",
@@ -104,6 +110,48 @@ def detect_content_action(text: str) -> Optional[str]:
     if any(re.search(pattern, text_lower) for pattern in WRITE_PATTERNS):
         return "write"
     return None
+
+
+def extract_slack_user_mention(raw_value: str | None) -> Optional[str]:
+    """Extract a Slack user ID from a real mention like <@U123ABC>."""
+    value = str(raw_value or "").strip()
+    match = SLACK_USER_MENTION_PATTERN.fullmatch(value)
+    return match.group(1) if match else None
+
+
+def extract_content_factory_delegation(text: str) -> tuple[str, Optional[Dict[str, Any]]]:
+    """Strip a trailing content-factory delegation clause like `as <@U123>`.
+
+    Returns the cleaned text plus delegation metadata when the clause applies.
+    The backward-compatible `for <@U123>` alias only applies to write/article
+    requests so normal phrasing like `write an article for domain.com` is not
+    misclassified.
+    """
+    normalized = normalize_slack_text(text).strip()
+    if not normalized:
+        return normalized, None
+
+    match = TRAILING_DELEGATION_PATTERN.match(normalized)
+    if not match:
+        return normalized, None
+
+    body = str(match.group("body") or "").strip()
+    keyword = str(match.group("keyword") or "").strip().lower()
+    target_slack_user_id = extract_slack_user_mention(match.group("mention"))
+    if not body or not target_slack_user_id:
+        return normalized, None
+
+    action = detect_content_action(body)
+    if keyword == "for" and action != "write":
+        return normalized, None
+    if action not in {"scan", "scaffold", "research", "publish_pr", "write"}:
+        return normalized, None
+
+    return body, {
+        "effective_slack_user_id": target_slack_user_id,
+        "delegation_keyword": keyword,
+        "content_action": action,
+    }
 
 
 def is_explicit_scan_request(text: str, action: Optional[str] = None) -> bool:

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import hmac
 import hashlib
+import re
 import time
 from contextlib import asynccontextmanager
 from typing import Any, Optional
@@ -58,9 +59,18 @@ CONTENT_FACTORY_WATCHDOG_STOP_STATUSES = {
 
 
 def _pending_intent_key(slack_user_id: Optional[str], domain: Optional[str]) -> Optional[str]:
-    if not slack_user_id or not domain:
+    return _pending_intent_identity_key(slack_user_id, None, domain)
+
+
+def _pending_intent_identity_key(
+    requested_by_slack_user_id: Optional[str],
+    effective_slack_user_id: Optional[str],
+    domain: Optional[str],
+) -> Optional[str]:
+    if not requested_by_slack_user_id or not domain:
         return None
-    return f"{slack_user_id}:{domain}"
+    effective_user = effective_slack_user_id or requested_by_slack_user_id
+    return f"{requested_by_slack_user_id}:{effective_user}:{domain}"
 
 
 def _pop_pending_intent_by_key(intent_key: Optional[str]) -> Optional[dict[str, Any]]:
@@ -91,10 +101,134 @@ def _content_factory_client_request_id(raw_value: Any) -> str:
     return f"content-factory-{uuid4().hex}"
 
 
+def _clean_slack_user_id(raw_value: Any) -> Optional[str]:
+    value = str(raw_value or "").strip()
+    if not value:
+        return None
+    match = re.fullmatch(r"<@([A-Z0-9]+)>", value)
+    if match:
+        return match.group(1)
+    return value
+
+
+def _content_factory_identity_payload(
+    *,
+    requested_by_slack_user_id: Optional[str],
+    effective_slack_user_id: Optional[str],
+    **extra: Any,
+) -> dict[str, Any]:
+    payload = dict(extra)
+    if _is_delegated_content_factory_request(
+        requested_by_slack_user_id,
+        effective_slack_user_id,
+    ):
+        payload["requested_by_slack_user_id"] = requested_by_slack_user_id
+        payload["effective_slack_user_id"] = effective_slack_user_id
+    return payload
+
+
+def _is_delegated_content_factory_request(
+    requested_by_slack_user_id: Optional[str],
+    effective_slack_user_id: Optional[str],
+) -> bool:
+    requested_by = str(requested_by_slack_user_id or "").strip()
+    effective = str(effective_slack_user_id or "").strip()
+    return bool(requested_by and effective and requested_by != effective)
+
+
+def _delegated_content_factory_auth_error_text(
+    *,
+    effective_slack_user_id: Optional[str],
+    domain: Optional[str],
+) -> str:
+    target = f"<@{effective_slack_user_id}>" if effective_slack_user_id else "that user"
+    domain_label = normalize_content_factory_domain(domain) or domain or "this domain"
+    return (
+        f"❌ GitHub auth for {target} isn't available for *{domain_label}*. "
+        f"Ask them to reconnect GitHub, then retry the delegated run."
+    )
+
+
+def _resolve_content_thread_identities(
+    *,
+    value_data: Optional[dict[str, Any]] = None,
+    channel_id: Optional[str] = None,
+    thread_ts: Optional[str] = None,
+    fallback_requested_by_slack_user_id: Optional[str] = None,
+    fallback_effective_slack_user_id: Optional[str] = None,
+) -> tuple[Optional[str], Optional[str]]:
+    resolved_value_data = value_data if isinstance(value_data, dict) else {}
+    requested_by_slack_user_id = _clean_slack_user_id(
+        resolved_value_data.get("requested_by_slack_user_id")
+        or resolved_value_data.get("slack_user_id")
+        or fallback_requested_by_slack_user_id
+    )
+    effective_slack_user_id = _clean_slack_user_id(
+        resolved_value_data.get("effective_slack_user_id")
+        or fallback_effective_slack_user_id
+    )
+
+    if channel_id and thread_ts:
+        try:
+            thread_context = get_agent().get_thread_context(channel_id, thread_ts) or {}
+        except Exception:
+            thread_context = {}
+        requested_by_slack_user_id = requested_by_slack_user_id or _clean_slack_user_id(
+            thread_context.get("requested_by_slack_user_id")
+        )
+        effective_slack_user_id = effective_slack_user_id or _clean_slack_user_id(
+            thread_context.get("effective_slack_user_id")
+        )
+
+    requested_by_slack_user_id = requested_by_slack_user_id or effective_slack_user_id
+    effective_slack_user_id = effective_slack_user_id or requested_by_slack_user_id
+    return requested_by_slack_user_id, effective_slack_user_id
+
+
+def _content_factory_action_denied_response(text: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=200,
+        content={
+            "response_type": "ephemeral",
+            "text": text,
+        },
+    )
+
+
+def _enforce_content_factory_action_owner(
+    *,
+    acting_slack_user_id: Optional[str],
+    requested_by_slack_user_id: Optional[str],
+    denial_text: str,
+) -> Optional[JSONResponse]:
+    if (
+        requested_by_slack_user_id
+        and acting_slack_user_id
+        and acting_slack_user_id != requested_by_slack_user_id
+    ):
+        return _content_factory_action_denied_response(denial_text)
+    return None
+
+
+def _content_factory_delegated_backend_kwargs(
+    requested_by_slack_user_id: Optional[str],
+    effective_slack_user_id: Optional[str],
+) -> dict[str, str]:
+    if _is_delegated_content_factory_request(
+        requested_by_slack_user_id,
+        effective_slack_user_id,
+    ):
+        return {
+            "requested_by_slack_user_id": str(requested_by_slack_user_id or "").strip()
+        }
+    return {}
+
+
 def _remember_pending_intent(
     slack_user_id: Optional[str],
     domain: Optional[str],
     *,
+    effective_slack_user_id: Optional[str] = None,
     intent_data: Optional[dict[str, Any]] = None,
     channel_id: Optional[str] = None,
     thread_ts: Optional[str] = None,
@@ -103,7 +237,15 @@ def _remember_pending_intent(
     clear_job_id: bool = False,
 ) -> Optional[dict[str, Any]]:
     _prune_pending_intents()
-    intent_key = _pending_intent_key(slack_user_id, domain)
+    requested_by_slack_user_id = str(slack_user_id or "").strip() or None
+    effective_slack_user_id = (
+        str(effective_slack_user_id or "").strip() or requested_by_slack_user_id
+    )
+    intent_key = _pending_intent_identity_key(
+        requested_by_slack_user_id,
+        effective_slack_user_id,
+        domain,
+    )
     if not intent_key:
         return None
 
@@ -120,6 +262,8 @@ def _remember_pending_intent(
         pending["channel_id"] = channel_id
     if thread_ts is not None:
         pending["thread_ts"] = thread_ts
+    pending["requested_by_slack_user_id"] = requested_by_slack_user_id
+    pending["effective_slack_user_id"] = effective_slack_user_id
     pending["wait_for"] = wait_for
     pending["created_at"] = pending.get("created_at", now)
     pending["updated_at"] = now
@@ -138,6 +282,7 @@ def _get_pending_intent(
     slack_user_id: Optional[str],
     domain: Optional[str],
     *,
+    effective_slack_user_id: Optional[str] = None,
     job_id: Optional[str] = None,
     wait_for: Optional[str] = None,
     consume: bool = False,
@@ -154,7 +299,11 @@ def _get_pending_intent(
             return None
         return _pop_pending_intent_by_key(intent_key) if consume else pending
 
-    intent_key = _pending_intent_key(slack_user_id, domain)
+    intent_key = _pending_intent_identity_key(
+        str(slack_user_id or "").strip() or None,
+        str(effective_slack_user_id or "").strip() or None,
+        domain,
+    )
     if not intent_key:
         return None
     pending = _pending_intents.get(intent_key)
@@ -250,6 +399,12 @@ async def _maybe_attach_content_factory_progress(
         or ""
     ).strip() or None
     domain = str(result_data.get("content_factory_domain") or "").strip() or None
+    requested_by_slack_user_id = _clean_slack_user_id(
+        result_data.get("requested_by_slack_user_id")
+    )
+    effective_slack_user_id = _clean_slack_user_id(
+        result_data.get("effective_slack_user_id")
+    )
 
     from .clients.mlai_backend import MLAIBackendClient
 
@@ -277,6 +432,8 @@ async def _maybe_attach_content_factory_progress(
         domain,
         workflow or "write",
         active_job_id=job_id,
+        requested_by_slack_user_id=requested_by_slack_user_id,
+        effective_slack_user_id=effective_slack_user_id,
     )
 
     if result_data.get("content_factory_watchdog"):
@@ -286,7 +443,8 @@ async def _maybe_attach_content_factory_progress(
 async def _trigger_article_generation_from_pending(
     pending: dict[str, Any],
     *,
-    slack_user_id: str,
+    requested_by_slack_user_id: str,
+    effective_slack_user_id: str,
     domain: str,
     fallback_channel_id: Optional[str] = None,
     fallback_thread_ts: Optional[str] = None,
@@ -324,6 +482,8 @@ async def _trigger_article_generation_from_pending(
         intent_thread,
         domain,
         "research" if include_decision_stage else "write",
+        requested_by_slack_user_id=requested_by_slack_user_id,
+        effective_slack_user_id=effective_slack_user_id,
     )
 
     from .clients.mlai_backend import MLAIBackendClient
@@ -334,11 +494,15 @@ async def _trigger_article_generation_from_pending(
         api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY
     )
     try:
-        slack_info = get_user_info(slack_user_id)
+        slack_info = get_user_info(requested_by_slack_user_id)
         real_name = str(slack_info.get("real_name") or "").strip()
         name_parts = real_name.split(" ", 1) if real_name else []
+        delegated_backend_kwargs = _content_factory_delegated_backend_kwargs(
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        )
         result = await backend_client.trigger_article_generation(
-            slack_user_id=slack_user_id,
+            slack_user_id=effective_slack_user_id,
             domain=domain,
             topic=topic,
             target_keyword=pending.get("target_keyword"),
@@ -351,6 +515,7 @@ async def _trigger_article_generation_from_pending(
             user_first_name=name_parts[0] if name_parts else None,
             user_last_name=name_parts[1] if len(name_parts) > 1 else None,
             user_avatar_url=str(slack_info.get("image_192") or "").strip() or None,
+            **delegated_backend_kwargs,
         )
         print(f"✅ Auto-generation triggered for {domain}")
         if result.get("job_id") or result.get("run_id"):
@@ -360,6 +525,8 @@ async def _trigger_article_generation_from_pending(
                 domain,
                 "research" if include_decision_stage else "write",
                 active_job_id=result.get("job_id") or result.get("run_id"),
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
             )
             asyncio.create_task(_watch_content_factory_quiet_run(result.get("job_id") or result.get("run_id")))
         return True
@@ -381,19 +548,28 @@ def _remember_content_thread_context(
     workflow: str,
     *,
     active_job_id: str | None = None,
+    requested_by_slack_user_id: str | None = None,
+    effective_slack_user_id: str | None = None,
 ) -> None:
     """Keep content-factory as the active skill for follow-ups in this thread."""
     if not channel_id or not thread_ts:
         return
 
     try:
+        context_kwargs: dict[str, Any] = {
+            "domain": domain,
+            "workflow": workflow,
+            "active_job_id": active_job_id,
+        }
+        if requested_by_slack_user_id is not None:
+            context_kwargs["requested_by_slack_user_id"] = requested_by_slack_user_id
+        if effective_slack_user_id is not None:
+            context_kwargs["effective_slack_user_id"] = effective_slack_user_id
         get_agent().remember_thread_context(
             "content-factory",
             channel_id,
             thread_ts,
-            domain=domain,
-            workflow=workflow,
-            active_job_id=active_job_id,
+            **context_kwargs,
         )
     except Exception as e:
         print(f"⚠️ Failed to persist content thread context: {e}")
@@ -405,6 +581,8 @@ def _build_article_delivery_mode_blocks(
     job_id: str,
     topic: Optional[str] = None,
     recommended_delivery_mode: Optional[str] = None,
+    requested_by_slack_user_id: Optional[str] = None,
+    effective_slack_user_id: Optional[str] = None,
 ) -> list[dict]:
     topic_line = f"*Topic:* {topic}\n" if topic else ""
     recommended_line = ""
@@ -417,13 +595,29 @@ def _build_article_delivery_mode_blocks(
         {
             "type": "button",
             "text": {"type": "plain_text", "text": "Content Only", "emoji": True},
-            "value": json.dumps({"job_id": job_id, "domain": domain, "delivery_mode": "content_only"}),
+            "value": json.dumps(
+                _content_factory_identity_payload(
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
+                    job_id=job_id,
+                    domain=domain,
+                    delivery_mode="content_only",
+                )
+            ),
             "action_id": "select_article_delivery_mode",
         },
         {
             "type": "button",
             "text": {"type": "plain_text", "text": "Publish Via Code", "emoji": True},
-            "value": json.dumps({"job_id": job_id, "domain": domain, "delivery_mode": "publish_code"}),
+            "value": json.dumps(
+                _content_factory_identity_payload(
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
+                    job_id=job_id,
+                    domain=domain,
+                    delivery_mode="publish_code",
+                )
+            ),
             "action_id": "select_article_delivery_mode",
         },
     ]
@@ -512,7 +706,13 @@ def _maybe_schedule_content_factory_watchdog(active_job_id: Optional[str], statu
     asyncio.create_task(_watch_content_factory_quiet_run(active_job_id))
 
 
-def _confirm_topic_json_response(keyword: str, follow_up: dict[str, Any]) -> JSONResponse:
+def _confirm_topic_json_response(
+    keyword: str,
+    follow_up: dict[str, Any],
+    *,
+    requested_by_slack_user_id: Optional[str] = None,
+    effective_slack_user_id: Optional[str] = None,
+) -> JSONResponse:
     if follow_up.get("requires_delivery_mode"):
         return JSONResponse(status_code=200, content={
             "response_type": "ephemeral",
@@ -523,6 +723,8 @@ def _confirm_topic_json_response(keyword: str, follow_up: dict[str, Any]) -> JSO
                 job_id=follow_up["active_job_id"],
                 topic=keyword,
                 recommended_delivery_mode=follow_up.get("recommended_delivery_mode"),
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
             ),
         })
 
@@ -548,14 +750,24 @@ def _confirm_topic_json_response(keyword: str, follow_up: dict[str, Any]) -> JSO
         })
 
     if status_value == "auth_required":
-        message = str(
-            follow_up.get("message")
-            or "GitHub authentication is required before Roo can continue this article."
-        ).strip()
-        auth_url = str(follow_up.get("auth_url") or "").strip()
-        block_text = f"🔐 {message}"
-        if auth_url:
-            block_text = f"{block_text}\n<{auth_url}|Reconnect GitHub>"
+        if _is_delegated_content_factory_request(
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ):
+            message = _delegated_content_factory_auth_error_text(
+                effective_slack_user_id=effective_slack_user_id,
+                domain=follow_up.get("domain"),
+            )
+            block_text = message
+        else:
+            message = str(
+                follow_up.get("message")
+                or "GitHub authentication is required before Roo can continue this article."
+            ).strip()
+            auth_url = str(follow_up.get("auth_url") or "").strip()
+            block_text = f"🔐 {message}"
+            if auth_url:
+                block_text = f"{block_text}\n<{auth_url}|Reconnect GitHub>"
         return JSONResponse(status_code=200, content={
             "response_type": "ephemeral",
             "replace_original": True,
@@ -599,6 +811,7 @@ async def _resolve_confirm_follow_up_after_failure(
     slack_thread_ts: Optional[str],
     domain: Optional[str],
     job_id: str,
+    requested_by_slack_user_id: Optional[str] = None,
 ) -> Optional[dict[str, Any]]:
     resolved_channel_id = str(slack_channel_id or "").strip()
     resolved_thread_ts = str(slack_thread_ts or "").strip()
@@ -606,6 +819,10 @@ async def _resolve_confirm_follow_up_after_failure(
 
     if resolved_channel_id and resolved_thread_ts:
         try:
+            delegated_backend_kwargs = _content_factory_delegated_backend_kwargs(
+                requested_by_slack_user_id,
+                slack_user_id,
+            )
             resolution = await client.resolve_content_thread(
                 slack_user_id=slack_user_id,
                 slack_channel_id=resolved_channel_id,
@@ -613,6 +830,7 @@ async def _resolve_confirm_follow_up_after_failure(
                 requested_action="confirm_topic",
                 domain=resolved_domain,
                 job_id=job_id,
+                **delegated_backend_kwargs,
             )
         except Exception as exc:
             print(f"⚠️ Failed to resolve confirm thread after error for {job_id}: {exc!r}")
@@ -1385,9 +1603,17 @@ async def content_factory_callback(request: Request):
     try:
         payload = await request.json()
         event_type = payload.get("type") or payload.get("event_type")
-        slack_user_id = payload.get("slack_user_id")
+        effective_slack_user_id = _clean_slack_user_id(payload.get("slack_user_id"))
+        requested_by_slack_user_id = (
+            _clean_slack_user_id(payload.get("requested_by_slack_user_id"))
+            or effective_slack_user_id
+        )
+        recipient_slack_user_id = requested_by_slack_user_id or effective_slack_user_id
 
-        print(f"🏭 Content Factory event: {event_type} for {slack_user_id}")
+        print(
+            "🏭 Content Factory event: "
+            f"{event_type} for effective={effective_slack_user_id} recipient={recipient_slack_user_id}"
+        )
 
         # Handle new topic_confirmation_request format
         if event_type == "topic_confirmation_request":
@@ -1468,7 +1694,16 @@ async def content_factory_callback(request: Request):
                         "emoji": True
                     },
                     "style": "primary",
-                    "value": f"confirm:{keyword}:{job_id}",
+                    "value": json.dumps(
+                        _content_factory_identity_payload(
+                            requested_by_slack_user_id=requested_by_slack_user_id,
+                            effective_slack_user_id=effective_slack_user_id,
+                            action="confirm_topic",
+                            keyword=keyword,
+                            job_id=job_id,
+                            domain=domain,
+                        )
+                    ),
                     "action_id": "confirm_topic"
                 }
             ]
@@ -1481,7 +1716,16 @@ async def content_factory_callback(request: Request):
                             "type": "plain_text",
                             "text": alt[:75]  # Slack limit for option text
                         },
-                        "value": f"confirm:{alt}:{job_id}"
+                        "value": json.dumps(
+                            _content_factory_identity_payload(
+                                requested_by_slack_user_id=requested_by_slack_user_id,
+                                effective_slack_user_id=effective_slack_user_id,
+                                action="confirm_topic",
+                                keyword=alt,
+                                job_id=job_id,
+                                domain=domain,
+                            )
+                        ),
                     }
                     for alt in alternatives[:10]  # Limit to 10 options
                 ]
@@ -1505,7 +1749,15 @@ async def content_factory_callback(request: Request):
                     "emoji": True
                 },
                 "style": "danger",
-                "value": f"cancel:{job_id}",
+                "value": json.dumps(
+                    _content_factory_identity_payload(
+                        requested_by_slack_user_id=requested_by_slack_user_id,
+                        effective_slack_user_id=effective_slack_user_id,
+                        action="cancel_topic",
+                        job_id=job_id,
+                        domain=domain,
+                    )
+                ),
                 "action_id": "cancel_topic"
             })
 
@@ -1516,7 +1768,7 @@ async def content_factory_callback(request: Request):
             })
 
             # Send DM
-            dm_channel = from_slack_client_open_dm(slack_user_id)
+            dm_channel = from_slack_client_open_dm(recipient_slack_user_id)
             if dm_channel:
                 post_message(
                     channel=dm_channel,
@@ -1599,7 +1851,16 @@ async def content_factory_callback(request: Request):
                         "emoji": True
                     },
                     "style": "primary",
-                    "value": f"confirm:{keyword}:{job_id}",
+                    "value": json.dumps(
+                        _content_factory_identity_payload(
+                            requested_by_slack_user_id=requested_by_slack_user_id,
+                            effective_slack_user_id=effective_slack_user_id,
+                            action="confirm_topic",
+                            keyword=keyword,
+                            job_id=job_id,
+                            domain=domain,
+                        )
+                    ),
                     "action_id": "confirm_topic"
                 }
             ]
@@ -1611,7 +1872,16 @@ async def content_factory_callback(request: Request):
                             "type": "plain_text",
                             "text": alt[:75]
                         },
-                        "value": f"confirm:{alt}:{job_id}"
+                        "value": json.dumps(
+                            _content_factory_identity_payload(
+                                requested_by_slack_user_id=requested_by_slack_user_id,
+                                effective_slack_user_id=effective_slack_user_id,
+                                action="confirm_topic",
+                                keyword=alt,
+                                job_id=job_id,
+                                domain=domain,
+                            )
+                        ),
                     }
                     for alt in alternatives[:10]
                 ]
@@ -1634,7 +1904,15 @@ async def content_factory_callback(request: Request):
                     "emoji": True
                 },
                 "style": "danger",
-                "value": f"cancel:{job_id}",
+                "value": json.dumps(
+                    _content_factory_identity_payload(
+                        requested_by_slack_user_id=requested_by_slack_user_id,
+                        effective_slack_user_id=effective_slack_user_id,
+                        action="cancel_topic",
+                        job_id=job_id,
+                        domain=domain,
+                    )
+                ),
                 "action_id": "cancel_topic"
             })
 
@@ -1644,7 +1922,7 @@ async def content_factory_callback(request: Request):
                 "elements": action_elements
             })
 
-            dm_channel = from_slack_client_open_dm(slack_user_id)
+            dm_channel = from_slack_client_open_dm(recipient_slack_user_id)
             if dm_channel:
                 post_message(
                     channel=dm_channel,
@@ -1689,7 +1967,7 @@ async def content_factory_callback(request: Request):
                 }
             ]
 
-            dm_channel = from_slack_client_open_dm(slack_user_id)
+            dm_channel = from_slack_client_open_dm(recipient_slack_user_id)
             if dm_channel:
                 post_message(
                     channel=dm_channel,
@@ -1718,7 +1996,14 @@ async def content_factory_callback(request: Request):
             )
 
             print(f"📦 Scan complete for {domain}: {components_count} components, {pillar_count} pillars")
-            _remember_content_thread_context(channel_id, thread_ts, domain, "scan")
+            _remember_content_thread_context(
+                channel_id,
+                thread_ts,
+                domain,
+                "scan",
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
+            )
 
             if components_count > 0:
                 # Build component summary: "ArticleHeroHeader, ArticleCard, ArticleFAQ, +27 more"
@@ -1764,14 +2049,17 @@ async def content_factory_callback(request: Request):
                                         "emoji": True
                                     },
                                     "style": "primary",
-                                    "value": json.dumps({
-                                        "domain": domain,
-                                        "slack_user_id": slack_user_id,
-                                        "channel_id": channel_id,
-                                        "thread_ts": thread_ts,
-                                        "scan_run_id": run_id,
-                                        "client_request_id": f"content-factory-{uuid4().hex}",
-                                    }),
+                                    "value": json.dumps(
+                                        _content_factory_identity_payload(
+                                            requested_by_slack_user_id=requested_by_slack_user_id,
+                                            effective_slack_user_id=effective_slack_user_id,
+                                            domain=domain,
+                                            channel_id=channel_id,
+                                            thread_ts=thread_ts,
+                                            scan_run_id=run_id,
+                                            client_request_id=f"content-factory-{uuid4().hex}",
+                                        )
+                                    ),
                                     "action_id": "scaffold_confirm"
                                 },
                                 {
@@ -1781,13 +2069,16 @@ async def content_factory_callback(request: Request):
                                         "text": "Not Now",
                                         "emoji": True
                                     },
-                                    "value": json.dumps({
-                                        "domain": domain,
-                                        "slack_user_id": slack_user_id,
-                                        "channel_id": channel_id,
-                                        "thread_ts": thread_ts,
-                                        "scan_run_id": run_id,
-                                    }),
+                                    "value": json.dumps(
+                                        _content_factory_identity_payload(
+                                            requested_by_slack_user_id=requested_by_slack_user_id,
+                                            effective_slack_user_id=effective_slack_user_id,
+                                            domain=domain,
+                                            channel_id=channel_id,
+                                            thread_ts=thread_ts,
+                                            scan_run_id=run_id,
+                                        )
+                                    ),
                                     "action_id": "scaffold_skip"
                                 }
                             ]
@@ -1833,7 +2124,7 @@ async def content_factory_callback(request: Request):
                     print(f"✅ Posted scan results to thread {thread_ts}")
                 except Exception as e:
                     print(f"⚠️ Failed to post in thread, falling back to DM: {e}")
-                    dm_channel = from_slack_client_open_dm(slack_user_id)
+                    dm_channel = from_slack_client_open_dm(recipient_slack_user_id)
                     if dm_channel:
                         post_message(
                             channel=dm_channel,
@@ -1842,8 +2133,8 @@ async def content_factory_callback(request: Request):
                         )
             else:
                 # Fallback to DM
-                print(f"⚠️ No thread context, sending DM to {slack_user_id}")
-                dm_channel = from_slack_client_open_dm(slack_user_id)
+                print(f"⚠️ No thread context, sending DM to {recipient_slack_user_id}")
+                dm_channel = from_slack_client_open_dm(recipient_slack_user_id)
                 if dm_channel:
                     post_message(
                         channel=dm_channel,
@@ -1853,8 +2144,9 @@ async def content_factory_callback(request: Request):
 
             # Auto-continue: check for pending intent after scan completes
             pending = _get_pending_intent(
-                slack_user_id,
+                requested_by_slack_user_id,
                 domain,
+                effective_slack_user_id=effective_slack_user_id,
                 job_id=job_id,
                 wait_for="scan_complete",
             )
@@ -1862,6 +2154,12 @@ async def content_factory_callback(request: Request):
                 pending_action = pending.get("action")
                 intent_channel = pending.get("channel_id") or channel_id
                 intent_thread = pending.get("thread_ts") or thread_ts
+                pending_requested_by_slack_user_id = str(
+                    pending.get("requested_by_slack_user_id") or requested_by_slack_user_id or ""
+                ).strip()
+                pending_effective_slack_user_id = str(
+                    pending.get("effective_slack_user_id") or effective_slack_user_id or ""
+                ).strip()
 
                 if approval_required and pending_action in ("scaffold", "write"):
                     print(f"⏸️ Waiting for scaffold approval before continuing {pending_action} for {domain}")
@@ -1870,8 +2168,9 @@ async def content_factory_callback(request: Request):
                         print(f"⏳ Scan already queued scaffold for {domain}; waiting for scaffold completion")
                         if pending_action == "write":
                             _remember_pending_intent(
-                                slack_user_id,
+                                pending_requested_by_slack_user_id,
                                 domain,
+                                effective_slack_user_id=pending_effective_slack_user_id,
                                 intent_data=pending,
                                 channel_id=intent_channel,
                                 thread_ts=intent_thread,
@@ -1887,8 +2186,9 @@ async def content_factory_callback(request: Request):
                                 )
                         else:
                             _get_pending_intent(
-                                slack_user_id,
+                                pending_requested_by_slack_user_id,
                                 domain,
+                                effective_slack_user_id=pending_effective_slack_user_id,
                                 job_id=job_id,
                                 wait_for="scan_complete",
                                 consume=True,
@@ -1901,8 +2201,9 @@ async def content_factory_callback(request: Request):
                                 )
                     elif scaffold_status == "not_needed":
                         consumed = _get_pending_intent(
-                            slack_user_id,
+                            pending_requested_by_slack_user_id,
                             domain,
+                            effective_slack_user_id=pending_effective_slack_user_id,
                             job_id=job_id,
                             wait_for="scan_complete",
                             consume=True,
@@ -1910,7 +2211,8 @@ async def content_factory_callback(request: Request):
                         if pending_action == "write":
                             await _trigger_article_generation_from_pending(
                                 consumed,
-                                slack_user_id=slack_user_id,
+                                requested_by_slack_user_id=pending_requested_by_slack_user_id,
+                                effective_slack_user_id=pending_effective_slack_user_id,
                                 domain=domain,
                                 fallback_channel_id=channel_id,
                                 fallback_thread_ts=thread_ts,
@@ -1923,8 +2225,9 @@ async def content_factory_callback(request: Request):
                             )
                     else:
                         _get_pending_intent(
-                            slack_user_id,
+                            pending_requested_by_slack_user_id,
                             domain,
+                            effective_slack_user_id=pending_effective_slack_user_id,
                             job_id=job_id,
                             wait_for="scan_complete",
                             consume=True,
@@ -1960,7 +2263,14 @@ async def content_factory_callback(request: Request):
             client_request_id = _content_factory_client_request_id(payload.get("client_request_id"))
 
             print(f"📁 Scaffold complete for {domain}: PR={pr_url}")
-            _remember_content_thread_context(channel_id, thread_ts, domain, "scaffold")
+            _remember_content_thread_context(
+                channel_id,
+                thread_ts,
+                domain,
+                "scaffold",
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
+            )
 
             if already_exists:
                 detail_lines = []
@@ -2035,13 +2345,16 @@ async def content_factory_callback(request: Request):
                                     "emoji": True
                                 },
                                 "style": "primary",
-                                "value": json.dumps({
-                                    "domain": domain,
-                                    "slack_user_id": slack_user_id,
-                                    "channel_id": channel_id,
-                                    "thread_ts": thread_ts,
-                                    "client_request_id": client_request_id,
-                                }),
+                                "value": json.dumps(
+                                    _content_factory_identity_payload(
+                                        requested_by_slack_user_id=requested_by_slack_user_id,
+                                        effective_slack_user_id=effective_slack_user_id,
+                                        domain=domain,
+                                        channel_id=channel_id,
+                                        thread_ts=thread_ts,
+                                        client_request_id=client_request_id,
+                                    )
+                                ),
                                 "action_id": "write_first_article"
                             },
                             {
@@ -2051,7 +2364,13 @@ async def content_factory_callback(request: Request):
                                     "text": "Not Now",
                                     "emoji": True
                                 },
-                                "value": json.dumps({"domain": domain}),
+                                "value": json.dumps(
+                                    _content_factory_identity_payload(
+                                        requested_by_slack_user_id=requested_by_slack_user_id,
+                                        effective_slack_user_id=effective_slack_user_id,
+                                        domain=domain,
+                                    )
+                                ),
                                 "action_id": "write_article_skip"
                             }
                         ]
@@ -2080,7 +2399,7 @@ async def content_factory_callback(request: Request):
                     print(f"✅ Posted scaffold results to thread {thread_ts}")
                 except Exception as e:
                     print(f"⚠️ Failed to post in thread, falling back to DM: {e}")
-                    dm_channel = from_slack_client_open_dm(slack_user_id)
+                    dm_channel = from_slack_client_open_dm(recipient_slack_user_id)
                     if dm_channel:
                         post_message(
                             channel=dm_channel,
@@ -2089,8 +2408,8 @@ async def content_factory_callback(request: Request):
                         )
             else:
                 # Fallback to DM
-                print(f"⚠️ No thread context, sending DM to {slack_user_id}")
-                dm_channel = from_slack_client_open_dm(slack_user_id)
+                print(f"⚠️ No thread context, sending DM to {recipient_slack_user_id}")
+                dm_channel = from_slack_client_open_dm(recipient_slack_user_id)
                 if dm_channel:
                     post_message(
                         channel=dm_channel,
@@ -2100,8 +2419,9 @@ async def content_factory_callback(request: Request):
 
             # Auto-continue: check for pending write intent after scaffold completes
             pending = _get_pending_intent(
-                slack_user_id,
+                requested_by_slack_user_id,
                 domain,
+                effective_slack_user_id=effective_slack_user_id,
                 job_id=job_id,
                 wait_for="scaffold_complete",
                 consume=True,
@@ -2109,7 +2429,12 @@ async def content_factory_callback(request: Request):
             if pending and pending.get("action") == "write":
                 await _trigger_article_generation_from_pending(
                     pending,
-                    slack_user_id=slack_user_id,
+                    requested_by_slack_user_id=str(
+                        pending.get("requested_by_slack_user_id") or requested_by_slack_user_id or ""
+                    ).strip(),
+                    effective_slack_user_id=str(
+                        pending.get("effective_slack_user_id") or effective_slack_user_id or ""
+                    ).strip(),
                     domain=domain,
                     fallback_channel_id=channel_id,
                     fallback_thread_ts=thread_ts,
@@ -2133,31 +2458,48 @@ async def content_factory_callback(request: Request):
             }.get(stage)
             if wait_for:
                 cleared_pending = _get_pending_intent(
-                    slack_user_id,
+                    requested_by_slack_user_id,
                     domain,
+                    effective_slack_user_id=effective_slack_user_id,
                     job_id=job_id,
                     wait_for=wait_for,
                     consume=True,
                 )
                 if cleared_pending:
-                    print(f"🧹 Cleared pending intent after {stage} failure for {slack_user_id}:{domain}")
+                    print(
+                        "🧹 Cleared pending intent after "
+                        f"{stage} failure for {requested_by_slack_user_id}:{effective_slack_user_id}:{domain}"
+                    )
 
             # Provide specific error messages based on error_code
             if error_code == "INVALID_CREDENTIALS":
-                user_message = "❌ I need fresh GitHub access. Please reconnect your GitHub account to continue."
-                # Fetch auth URL so we can show a reconnect button
-                try:
-                    from .clients.mlai_backend import MLAIBackendClient
-                    settings = get_settings()
-                    auth_client = MLAIBackendClient(
-                        base_url=settings.MLAI_BACKEND_URL,
-                        api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY
+                if _is_delegated_content_factory_request(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ):
+                    user_message = _delegated_content_factory_auth_error_text(
+                        effective_slack_user_id=effective_slack_user_id,
+                        domain=domain,
                     )
-                    auth_response = await auth_client.get_github_auth_url(slack_user_id, domain=domain)
-                    auth_url = auth_response.get("auth_url")
-                except Exception as auth_err:
-                    print(f"⚠️ Failed to fetch auth URL: {auth_err}")
                     auth_url = None
+                else:
+                    user_message = "❌ I need fresh GitHub access. Please reconnect your GitHub account to continue."
+                    # Fetch auth URL so we can show a reconnect button
+                    try:
+                        from .clients.mlai_backend import MLAIBackendClient
+                        settings = get_settings()
+                        auth_client = MLAIBackendClient(
+                            base_url=settings.MLAI_BACKEND_URL,
+                            api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY
+                        )
+                        auth_response = await auth_client.get_github_auth_url(
+                            effective_slack_user_id,
+                            domain=domain,
+                        )
+                        auth_url = auth_response.get("auth_url")
+                    except Exception as auth_err:
+                        print(f"⚠️ Failed to fetch auth URL: {auth_err}")
+                        auth_url = None
 
                 blocks = [
                     {
@@ -2191,7 +2533,13 @@ async def content_factory_callback(request: Request):
                                     "emoji": True
                                 },
                                 "action_id": "resume_scan",
-                                "value": json.dumps({"domain": domain}),
+                                "value": json.dumps(
+                                    _content_factory_identity_payload(
+                                        requested_by_slack_user_id=requested_by_slack_user_id,
+                                        effective_slack_user_id=effective_slack_user_id,
+                                        domain=domain,
+                                    )
+                                ),
                                 "style": "primary"
                             }
                         ]
@@ -2231,7 +2579,7 @@ async def content_factory_callback(request: Request):
                     print(f"✅ Posted error to thread {thread_ts}")
                 except Exception as e:
                     print(f"⚠️ Failed to post in thread, falling back to DM: {e}")
-                    dm_channel = from_slack_client_open_dm(slack_user_id)
+                    dm_channel = from_slack_client_open_dm(recipient_slack_user_id)
                     if dm_channel:
                         post_message(
                             channel=dm_channel,
@@ -2240,8 +2588,8 @@ async def content_factory_callback(request: Request):
                         )
             else:
                 # Fallback to DM
-                print(f"⚠️ No thread context, sending DM to {slack_user_id}")
-                dm_channel = from_slack_client_open_dm(slack_user_id)
+                print(f"⚠️ No thread context, sending DM to {recipient_slack_user_id}")
+                dm_channel = from_slack_client_open_dm(recipient_slack_user_id)
                 if dm_channel:
                     post_message(
                         channel=dm_channel,
@@ -2355,7 +2703,6 @@ async def slack_actions(request: Request):
 
         job_id = str(value_data.get("job_id") or "").strip()
         domain = value_data.get("domain")
-        original_user_id = value_data.get("slack_user_id")
         value_channel_id = value_data.get("channel_id")
         value_thread_ts = value_data.get("thread_ts")
 
@@ -2363,12 +2710,22 @@ async def slack_actions(request: Request):
         msg_ts = payload.get("message", {}).get("ts")
         reply_channel = value_channel_id or channel_id or msg_channel
         reply_thread_ts = value_thread_ts or payload.get("message", {}).get("thread_ts") or msg_ts
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=reply_channel,
+            thread_ts=reply_thread_ts,
+        )
 
-        if user_id != original_user_id:
-            return JSONResponse(status_code=200, content={
-                "response_type": "ephemeral",
-                "text": "⚠️ Only the user who requested this article can publish it as a PR."
-            })
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this article can publish it as a PR.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         if not job_id:
             if reply_channel:
@@ -2385,6 +2742,8 @@ async def slack_actions(request: Request):
             domain,
             "publish_pr",
             active_job_id=job_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            effective_slack_user_id=effective_slack_user_id,
         )
 
         try:
@@ -2424,11 +2783,24 @@ async def slack_actions(request: Request):
                 "text": "publish this article as a PR",
                 "channel": reply_channel,
                 "thread_ts": reply_thread_ts,
-                "param_overrides": {
-                    "action": "publish_pr",
-                    "job_id": job_id,
-                    "domain": domain,
-                },
+                "param_overrides": (
+                    {
+                        "action": "publish_pr",
+                        "job_id": job_id,
+                        "domain": domain,
+                        "requested_by_slack_user_id": requested_by_slack_user_id or user_id,
+                        "effective_slack_user_id": effective_slack_user_id or user_id,
+                    }
+                    if _is_delegated_content_factory_request(
+                        requested_by_slack_user_id,
+                        effective_slack_user_id,
+                    )
+                    else {
+                        "action": "publish_pr",
+                        "job_id": job_id,
+                        "domain": domain,
+                    }
+                ),
             }
         ))
         return JSONResponse(status_code=200, content={})
@@ -2437,15 +2809,43 @@ async def slack_actions(request: Request):
     # Value format: "confirm:{keyword}:{job_id}"
     if action_id == "confirm_topic":
         value = actions[0].get("value", "")
-        if not value or not value.startswith("confirm:"):
+        value_data: dict[str, Any] = {}
+        keyword: Optional[str] = None
+        job_id: Optional[str] = None
+        domain: Optional[str] = None
+        try:
+            parsed_value = json.loads(value) if value else {}
+        except json.JSONDecodeError:
+            parsed_value = None
+        if isinstance(parsed_value, dict):
+            value_data = parsed_value
+            keyword = str(value_data.get("keyword") or "").strip() or None
+            job_id = str(value_data.get("job_id") or "").strip() or None
+            domain = str(value_data.get("domain") or "").strip() or None
+        elif value and value.startswith("confirm:"):
+            parts = value.split(":", 2)
+            if len(parts) >= 3:
+                keyword = parts[1]
+                job_id = parts[2]
+
+        if not keyword or not job_id:
             return JSONResponse(status_code=400, content={"error": "Invalid value format"})
 
-        parts = value.split(":", 2)  # Split into max 3 parts
-        if len(parts) < 3:
-            return JSONResponse(status_code=400, content={"error": "Invalid value format"})
-
-        keyword = parts[1]
-        job_id = parts[2]
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=payload.get("channel", {}).get("id"),
+            thread_ts=payload.get("message", {}).get("thread_ts") or payload.get("message", {}).get("ts"),
+        )
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this article can confirm the topic.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         print(f"✅ User {user_id} confirmed topic '{keyword}' for job {job_id}")
 
@@ -2457,47 +2857,90 @@ async def slack_actions(request: Request):
         )
 
         try:
-            result = await client.confirm_article_topic(
-                job_id=job_id,
-                slack_user_id=user_id,
-                confirmed_keyword=keyword,
-                request_source=CONTENT_FACTORY_REQUEST_SOURCE,
-            )
+            confirm_kwargs = {
+                "job_id": job_id,
+                "slack_user_id": effective_slack_user_id or user_id,
+                "confirmed_keyword": keyword,
+                "request_source": CONTENT_FACTORY_REQUEST_SOURCE,
+                **_content_factory_delegated_backend_kwargs(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ),
+            }
+            if domain:
+                confirm_kwargs["domain"] = domain
+            result = await client.confirm_article_topic(**confirm_kwargs)
             follow_up = _build_confirm_topic_follow_up(result)
-            return _confirm_topic_json_response(keyword, follow_up)
+            return _confirm_topic_json_response(
+                keyword,
+                follow_up,
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
+            )
         except Exception as e:
             print(f"❌ Failed to confirm topic: {e}")
             import traceback
             traceback.print_exc()
             recovered_follow_up = await _resolve_confirm_follow_up_after_failure(
                 client,
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id or user_id,
                 slack_channel_id=payload.get("channel", {}).get("id"),
                 slack_thread_ts=payload.get("message", {}).get("thread_ts") or payload.get("message", {}).get("ts"),
-                domain=None,
+                domain=domain,
                 job_id=job_id,
+                requested_by_slack_user_id=requested_by_slack_user_id,
             )
             if recovered_follow_up:
-                return _confirm_topic_json_response(keyword, recovered_follow_up)
-            return JSONResponse(status_code=200, content={
-                "response_type": "ephemeral",
-                "text": f"❌ Error confirming topic: {e}"
-            })
+                return _confirm_topic_json_response(
+                    keyword,
+                    recovered_follow_up,
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
+                )
+            return _content_factory_action_denied_response(f"❌ Error confirming topic: {e}")
 
     # Handler for select_alternative (dropdown selection)
     # Value format: "confirm:{keyword}:{job_id}"
     if action_id == "select_alternative":
         selected_option = actions[0].get("selected_option", {})
         value = selected_option.get("value", "")
-        if not value or not value.startswith("confirm:"):
+        value_data: dict[str, Any] = {}
+        keyword: Optional[str] = None
+        job_id: Optional[str] = None
+        domain: Optional[str] = None
+        try:
+            parsed_value = json.loads(value) if value else {}
+        except json.JSONDecodeError:
+            parsed_value = None
+        if isinstance(parsed_value, dict):
+            value_data = parsed_value
+            keyword = str(value_data.get("keyword") or "").strip() or None
+            job_id = str(value_data.get("job_id") or "").strip() or None
+            domain = str(value_data.get("domain") or "").strip() or None
+        elif value and value.startswith("confirm:"):
+            parts = value.split(":", 2)
+            if len(parts) >= 3:
+                keyword = parts[1]
+                job_id = parts[2]
+
+        if not keyword or not job_id:
             return JSONResponse(status_code=400, content={"error": "Invalid value format"})
 
-        parts = value.split(":", 2)
-        if len(parts) < 3:
-            return JSONResponse(status_code=400, content={"error": "Invalid value format"})
-
-        keyword = parts[1]
-        job_id = parts[2]
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=payload.get("channel", {}).get("id"),
+            thread_ts=payload.get("message", {}).get("thread_ts") or payload.get("message", {}).get("ts"),
+        )
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this article can confirm the topic.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         print(f"✅ User {user_id} selected alternative topic '{keyword}' for job {job_id}")
 
@@ -2509,38 +2952,81 @@ async def slack_actions(request: Request):
         )
 
         try:
-            result = await client.confirm_article_topic(
-                job_id=job_id,
-                slack_user_id=user_id,
-                confirmed_keyword=keyword,
-                request_source=CONTENT_FACTORY_REQUEST_SOURCE,
-            )
+            confirm_kwargs = {
+                "job_id": job_id,
+                "slack_user_id": effective_slack_user_id or user_id,
+                "confirmed_keyword": keyword,
+                "request_source": CONTENT_FACTORY_REQUEST_SOURCE,
+                **_content_factory_delegated_backend_kwargs(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ),
+            }
+            if domain:
+                confirm_kwargs["domain"] = domain
+            result = await client.confirm_article_topic(**confirm_kwargs)
             follow_up = _build_confirm_topic_follow_up(result)
-            return _confirm_topic_json_response(keyword, follow_up)
+            return _confirm_topic_json_response(
+                keyword,
+                follow_up,
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
+            )
         except Exception as e:
             print(f"❌ Failed to confirm alternative topic: {e}")
             import traceback
             traceback.print_exc()
             recovered_follow_up = await _resolve_confirm_follow_up_after_failure(
                 client,
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id or user_id,
                 slack_channel_id=payload.get("channel", {}).get("id"),
                 slack_thread_ts=payload.get("message", {}).get("thread_ts") or payload.get("message", {}).get("ts"),
-                domain=None,
+                domain=domain,
                 job_id=job_id,
+                requested_by_slack_user_id=requested_by_slack_user_id,
             )
             if recovered_follow_up:
-                return _confirm_topic_json_response(keyword, recovered_follow_up)
-            return JSONResponse(status_code=200, content={
-                "response_type": "ephemeral",
-                "text": f"❌ Error confirming topic: {e}"
-            })
+                return _confirm_topic_json_response(
+                    keyword,
+                    recovered_follow_up,
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
+                )
+            return _content_factory_action_denied_response(f"❌ Error confirming topic: {e}")
 
     # Handler for cancel_topic (new format)
     # Value format: "cancel:{job_id}"
     if action_id == "cancel_topic":
         value = actions[0].get("value", "")
-        job_id = value.split(":", 1)[1] if ":" in value else None
+        value_data: dict[str, Any] = {}
+        job_id: Optional[str] = None
+        domain: Optional[str] = None
+        try:
+            parsed_value = json.loads(value) if value else {}
+        except json.JSONDecodeError:
+            parsed_value = None
+        if isinstance(parsed_value, dict):
+            value_data = parsed_value
+            job_id = str(value_data.get("job_id") or "").strip() or None
+            domain = str(value_data.get("domain") or "").strip() or None
+        else:
+            job_id = value.split(":", 1)[1] if ":" in value else None
+
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=payload.get("channel", {}).get("id"),
+            thread_ts=payload.get("message", {}).get("thread_ts") or payload.get("message", {}).get("ts"),
+        )
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this article can cancel topic selection.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         print(f"❌ User {user_id} cancelled topic selection for job {job_id}")
 
@@ -2553,7 +3039,7 @@ async def slack_actions(request: Request):
                     base_url=settings.MLAI_BACKEND_URL,
                     api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY
                 )
-                await client.cancel_job(job_id, user_id)
+                await client.cancel_job(job_id, effective_slack_user_id or user_id)
             except Exception as e:
                 print(f"⚠️ Failed to notify backend of cancellation: {e}")
 
@@ -2582,7 +3068,6 @@ async def slack_actions(request: Request):
             return JSONResponse(status_code=400, content={"error": "Invalid JSON value format"})
 
         domain = value_data.get("domain")
-        original_user_id = value_data.get("slack_user_id")
         value_channel_id = value_data.get("channel_id")
         value_thread_ts = value_data.get("thread_ts")
         delivery_mode = value_data.get("delivery_mode")
@@ -2591,19 +3076,26 @@ async def slack_actions(request: Request):
         # Get message context for button removal
         msg_channel = payload.get("channel", {}).get("id")
         msg_ts = payload.get("message", {}).get("ts")
-
-        # Security check: only the original user can confirm
-        if user_id != original_user_id:
-            return JSONResponse(status_code=200, content={
-                "response_type": "ephemeral",
-                "text": "⚠️ Only the user who initiated the scan can confirm this action."
-            })
-
-        print(f"📁 User {user_id} confirmed scaffold for {domain}")
-
-        # Use value's thread context if available, fallback to message context
         reply_channel = value_channel_id or msg_channel
         reply_thread_ts = value_thread_ts or payload.get("message", {}).get("thread_ts") or msg_ts
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=reply_channel,
+            thread_ts=reply_thread_ts,
+        )
+
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who initiated the scan can confirm this action.",
+        )
+        if owner_error is not None:
+            return owner_error
+
+        print(f"📁 User {user_id} confirmed scaffold for {domain}")
 
         if not scan_run_id:
             try:
@@ -2662,9 +3154,13 @@ async def slack_actions(request: Request):
                 scan_run_id=scan_run_id,
                 decision="approve",
                 domain=domain,
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id or user_id,
                 slack_channel_id=reply_channel,
                 slack_thread_ts=reply_thread_ts,
+                **_content_factory_delegated_backend_kwargs(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ),
             )
 
             status_code = result.get("status_code")
@@ -2673,15 +3169,17 @@ async def slack_actions(request: Request):
             if scan_run_id and status_code in {200, 202}:
                 scaffold_job_id = data.get("scaffold_job_id")
                 pending = _get_pending_intent(
-                    user_id,
+                    requested_by_slack_user_id,
                     domain,
                     wait_for="scan_complete",
                     consume=True,
+                    effective_slack_user_id=effective_slack_user_id,
                 )
                 if pending and pending.get("action") == "write" and scaffold_job_id:
                     _remember_pending_intent(
-                        user_id,
+                        requested_by_slack_user_id,
                         domain,
+                        effective_slack_user_id=effective_slack_user_id,
                         intent_data=pending,
                         channel_id=reply_channel,
                         thread_ts=reply_thread_ts,
@@ -2708,11 +3206,20 @@ async def slack_actions(request: Request):
             elif status_code == 400:
                 error = data.get("error", "Unknown error")
                 if data.get("needs_github_auth"):
-                    oauth_url = data.get("oauth_url", "")
                     post_message(
                         channel=reply_channel,
                         thread_ts=reply_thread_ts,
-                        text=f"❌ GitHub authentication required for *{domain}*.\n\nPlease reconnect: {oauth_url}"
+                        text=(
+                            _delegated_content_factory_auth_error_text(
+                                effective_slack_user_id=effective_slack_user_id,
+                                domain=domain,
+                            )
+                            if _is_delegated_content_factory_request(
+                                requested_by_slack_user_id,
+                                effective_slack_user_id,
+                            )
+                            else f"❌ GitHub authentication required for *{domain}*.\n\nPlease reconnect: {data.get('oauth_url', '')}"
+                        ),
                     )
                 else:
                     post_message(
@@ -2764,19 +3271,30 @@ async def slack_actions(request: Request):
             return JSONResponse(status_code=400, content={"error": "Invalid JSON value format"})
 
         domain = value_data.get("domain", "your site")
-        original_user_id = value_data.get("slack_user_id")
         value_channel_id = value_data.get("channel_id")
         value_thread_ts = value_data.get("thread_ts")
         scan_run_id = str(value_data.get("scan_run_id") or "").strip()
 
         msg_channel = payload.get("channel", {}).get("id")
         msg_ts = payload.get("message", {}).get("ts")
+        reply_channel = value_channel_id or msg_channel
+        reply_thread_ts = value_thread_ts or payload.get("message", {}).get("thread_ts") or msg_ts
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=reply_channel,
+            thread_ts=reply_thread_ts,
+        )
 
-        if original_user_id and user_id != original_user_id:
-            return JSONResponse(status_code=200, content={
-                "response_type": "ephemeral",
-                "text": "⚠️ Only the user who initiated the scan can confirm this action."
-            })
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who initiated the scan can confirm this action.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         print(f"⏭️ User {user_id} skipped scaffold for {domain}")
 
@@ -2800,8 +3318,6 @@ async def slack_actions(request: Request):
             print(f"⚠️ Failed to update message: {e}")
 
         if scan_run_id:
-            reply_channel = value_channel_id or msg_channel
-            reply_thread_ts = value_thread_ts or payload.get("message", {}).get("thread_ts") or msg_ts
             from .clients.mlai_backend import MLAIBackendClient
             settings = get_settings()
             backend_client = MLAIBackendClient(
@@ -2813,9 +3329,13 @@ async def slack_actions(request: Request):
                     scan_run_id=scan_run_id,
                     decision="deny",
                     domain=domain,
-                    slack_user_id=user_id,
+                    slack_user_id=effective_slack_user_id or user_id,
                     slack_channel_id=reply_channel,
                     slack_thread_ts=reply_thread_ts,
+                    **_content_factory_delegated_backend_kwargs(
+                        requested_by_slack_user_id,
+                        effective_slack_user_id,
+                    ),
                 )
                 if result.get("status_code") not in {200, 202, 409}:
                     post_message(
@@ -2824,10 +3344,11 @@ async def slack_actions(request: Request):
                         text=f"⚠️ Could not record scaffold skip for *{domain}*."
                     )
                 _get_pending_intent(
-                    user_id,
+                    requested_by_slack_user_id,
                     domain,
                     wait_for="scan_complete",
                     consume=True,
+                    effective_slack_user_id=effective_slack_user_id,
                 )
             except Exception as e:
                 print(f"⚠️ Failed to deny scaffold approval: {e}")
@@ -2844,7 +3365,6 @@ async def slack_actions(request: Request):
             return JSONResponse(status_code=400, content={"error": "Invalid JSON value format"})
 
         domain = value_data.get("domain")
-        original_user_id = value_data.get("slack_user_id")
         value_channel_id = value_data.get("channel_id")
         value_thread_ts = value_data.get("thread_ts")
         client_request_id = _content_factory_client_request_id(value_data.get("client_request_id"))
@@ -2853,17 +3373,26 @@ async def slack_actions(request: Request):
 
         msg_channel = payload.get("channel", {}).get("id")
         msg_ts = payload.get("message", {}).get("ts")
-
-        if user_id != original_user_id:
-            return JSONResponse(status_code=200, content={
-                "response_type": "ephemeral",
-                "text": "⚠️ Only the user who initiated the scan can confirm this action."
-            })
-
-        print(f"✍️ User {user_id} requested first article for {domain}")
-
         reply_channel = value_channel_id or msg_channel
         reply_thread_ts = value_thread_ts or payload.get("message", {}).get("thread_ts") or msg_ts
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=reply_channel,
+            thread_ts=reply_thread_ts,
+        )
+
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who initiated the scan can confirm this action.",
+        )
+        if owner_error is not None:
+            return owner_error
+
+        print(f"✍️ User {user_id} requested first article for {domain}")
 
         # 1. Remove buttons and show status via context block
         try:
@@ -2894,11 +3423,11 @@ async def slack_actions(request: Request):
         )
 
         try:
-            slack_info = get_user_info(user_id)
+            slack_info = get_user_info(requested_by_slack_user_id or user_id)
             real_name = str(slack_info.get("real_name") or "").strip()
             name_parts = real_name.split(" ", 1) if real_name else []
             result = await backend_client.trigger_article_generation(
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id or user_id,
                 domain=domain,
                 delivery_mode=delivery_mode,
                 delivery_mode_confirmed=delivery_mode_confirmed,
@@ -2911,6 +3440,10 @@ async def slack_actions(request: Request):
                 user_first_name=name_parts[0] if name_parts else None,
                 user_last_name=name_parts[1] if len(name_parts) > 1 else None,
                 user_avatar_url=str(slack_info.get("image_192") or "").strip() or None,
+                **_content_factory_delegated_backend_kwargs(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ),
             )
             print(f"✅ Article generation triggered for {domain}: {result}")
             if result.get("job_id") or result.get("run_id"):
@@ -2920,6 +3453,8 @@ async def slack_actions(request: Request):
                     domain,
                     "write",
                     active_job_id=result.get("job_id") or result.get("run_id"),
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
                 )
                 asyncio.create_task(_watch_content_factory_quiet_run(result.get("job_id") or result.get("run_id")))
         except Exception as e:
@@ -2947,6 +3482,21 @@ async def slack_actions(request: Request):
 
         msg_channel = payload.get("channel", {}).get("id")
         msg_ts = payload.get("message", {}).get("ts")
+        (
+            requested_by_slack_user_id,
+            _effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=msg_channel,
+            thread_ts=payload.get("message", {}).get("thread_ts") or msg_ts,
+        )
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this scan can skip the first article prompt.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         print(f"⏭️ User {user_id} skipped first article for {domain}")
 
@@ -2981,7 +3531,6 @@ async def slack_actions(request: Request):
             return JSONResponse(status_code=400, content={"error": "Invalid JSON value format"})
 
         domain = value_data.get("domain")
-        original_user_id = value_data.get("slack_user_id")
         value_channel_id = value_data.get("channel_id")
         value_thread_ts = value_data.get("thread_ts")
         client_request_id = _content_factory_client_request_id(value_data.get("client_request_id"))
@@ -2990,17 +3539,34 @@ async def slack_actions(request: Request):
 
         msg_channel = payload.get("channel", {}).get("id")
         msg_ts = payload.get("message", {}).get("ts")
-
-        if user_id != original_user_id:
-            return JSONResponse(status_code=200, content={
-                "response_type": "ephemeral",
-                "text": "⚠️ Only the user who initiated this request can choose the article direction."
-            })
-
         reply_channel = value_channel_id or msg_channel
         reply_thread_ts = value_thread_ts or payload.get("message", {}).get("thread_ts") or msg_ts
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=reply_channel,
+            thread_ts=reply_thread_ts,
+        )
+
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who initiated this request can choose the article direction.",
+        )
+        if owner_error is not None:
+            return owner_error
+
         print(f"🔍 User {user_id} chose article discovery for {domain}")
-        _remember_content_thread_context(reply_channel, reply_thread_ts, domain, "research")
+        _remember_content_thread_context(
+            reply_channel,
+            reply_thread_ts,
+            domain,
+            "research",
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            effective_slack_user_id=effective_slack_user_id,
+        )
 
         try:
             from .slack_client import get_slack_client
@@ -3029,11 +3595,11 @@ async def slack_actions(request: Request):
             api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY,
         )
         try:
-            slack_info = get_user_info(user_id)
+            slack_info = get_user_info(requested_by_slack_user_id or user_id)
             real_name = str(slack_info.get("real_name") or "").strip()
             name_parts = real_name.split(" ", 1) if real_name else []
             result = await backend_client.trigger_article_generation(
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id or user_id,
                 domain=domain,
                 delivery_mode=delivery_mode,
                 delivery_mode_confirmed=delivery_mode_confirmed,
@@ -3046,6 +3612,10 @@ async def slack_actions(request: Request):
                 user_first_name=name_parts[0] if name_parts else None,
                 user_last_name=name_parts[1] if len(name_parts) > 1 else None,
                 user_avatar_url=str(slack_info.get("image_192") or "").strip() or None,
+                **_content_factory_delegated_backend_kwargs(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ),
             )
             print(f"✅ Article discovery triggered for {domain}: {result}")
             if str(result.get("status") or "").strip().lower() == "awaiting_delivery_mode":
@@ -3055,6 +3625,8 @@ async def slack_actions(request: Request):
                     domain,
                     "awaiting_delivery_mode",
                     active_job_id=result.get("job_id") or result.get("run_id"),
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
                 )
                 try:
                     from .slack_client import get_slack_client
@@ -3066,6 +3638,8 @@ async def slack_actions(request: Request):
                             domain=domain,
                             job_id=result.get("job_id") or result.get("run_id"),
                             recommended_delivery_mode=result.get("recommended_delivery_mode"),
+                            requested_by_slack_user_id=requested_by_slack_user_id,
+                            effective_slack_user_id=effective_slack_user_id,
                         ),
                     )
                 except Exception as update_error:
@@ -3077,6 +3651,8 @@ async def slack_actions(request: Request):
                     domain,
                     "research",
                     active_job_id=result.get("job_id") or result.get("run_id"),
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
                 )
                 asyncio.create_task(_watch_content_factory_quiet_run(result.get("job_id") or result.get("run_id")))
         except Exception as e:
@@ -3098,22 +3674,31 @@ async def slack_actions(request: Request):
             return JSONResponse(status_code=400, content={"error": "Invalid JSON value format"})
 
         domain = value_data.get("domain")
-        original_user_id = value_data.get("slack_user_id")
         value_channel_id = value_data.get("channel_id")
         value_thread_ts = value_data.get("thread_ts")
         delivery_mode = value_data.get("delivery_mode")
 
         msg_channel = payload.get("channel", {}).get("id")
         msg_ts = payload.get("message", {}).get("ts")
-
-        if user_id != original_user_id:
-            return JSONResponse(status_code=200, content={
-                "response_type": "ephemeral",
-                "text": "⚠️ Only the user who initiated this request can choose the article direction."
-            })
-
         reply_channel = value_channel_id or msg_channel
         reply_thread_ts = value_thread_ts or payload.get("message", {}).get("thread_ts") or msg_ts
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=reply_channel,
+            thread_ts=reply_thread_ts,
+        )
+
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who initiated this request can choose the article direction.",
+        )
+        if owner_error is not None:
+            return owner_error
+
         is_dm = bool(reply_channel and reply_channel.startswith("D"))
         normalized_domain = normalize_content_factory_domain(domain) or domain or "this domain"
         article_cost_points = get_content_factory_article_cost_points(domain)
@@ -3137,7 +3722,14 @@ async def slack_actions(request: Request):
             guidance_text += " I'll keep this in publish-via-code mode unless you tell me otherwise."
 
         print(f"📝 User {user_id} will provide the article topic for {domain}")
-        _remember_content_thread_context(reply_channel, reply_thread_ts, domain, "write")
+        _remember_content_thread_context(
+            reply_channel,
+            reply_thread_ts,
+            domain,
+            "write",
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            effective_slack_user_id=effective_slack_user_id,
+        )
 
         try:
             from .slack_client import get_slack_client
@@ -3169,9 +3761,25 @@ async def slack_actions(request: Request):
         job_id = value_data.get("job_id")
         domain = value_data.get("domain")
         delivery_mode = value_data.get("delivery_mode")
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=payload.get("channel", {}).get("id"),
+            thread_ts=payload.get("message", {}).get("thread_ts") or payload.get("message", {}).get("ts"),
+        )
 
         if not job_id or delivery_mode not in {"content_only", "publish_code"}:
             return JSONResponse(status_code=400, content={"error": "job_id and delivery_mode are required"})
+
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this article can choose the delivery mode.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         from .clients.mlai_backend import MLAIBackendClient
 
@@ -3194,6 +3802,8 @@ async def slack_actions(request: Request):
                     domain,
                     "awaiting_delivery_mode",
                     active_job_id=result.get("job_id") or result.get("run_id"),
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
                 )
                 asyncio.create_task(_watch_content_factory_quiet_run(result.get("job_id") or result.get("run_id")))
 
@@ -3220,9 +3830,37 @@ async def slack_actions(request: Request):
                 error_data = {"error": str(exc)}
 
             if exc.response.status_code == 412 and error_data.get("error_code") == "PUBLISH_TARGET_ACTION_REQUIRED":
+                if _is_delegated_content_factory_request(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ):
+                    return JSONResponse(status_code=200, content={
+                        "response_type": "ephemeral",
+                        "replace_original": True,
+                        "text": _delegated_content_factory_auth_error_text(
+                            effective_slack_user_id=effective_slack_user_id,
+                            domain=domain,
+                        ),
+                        "blocks": [
+                            {
+                                "type": "section",
+                                "text": {
+                                    "type": "mrkdwn",
+                                    "text": _delegated_content_factory_auth_error_text(
+                                        effective_slack_user_id=effective_slack_user_id,
+                                        domain=domain,
+                                    ),
+                                },
+                            }
+                        ],
+                    })
+
                 auth_url = None
                 if domain:
-                    auth_response = await client.get_github_auth_url(user_id, domain=domain)
+                    auth_response = await client.get_github_auth_url(
+                        effective_slack_user_id or user_id,
+                        domain=domain,
+                    )
                     auth_url = auth_response.get("auth_url")
 
                 blocks = [
@@ -3283,6 +3921,21 @@ async def slack_actions(request: Request):
 
         reply_channel = value_channel_id or msg_channel
         reply_thread_ts = value_thread_ts or payload.get("message", {}).get("thread_ts") or msg_ts
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=reply_channel,
+            thread_ts=reply_thread_ts,
+        )
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this article can choose the article-system action.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         decision = {
             "article_system_use_detected": "use_detected",
@@ -3328,8 +3981,12 @@ async def slack_actions(request: Request):
         try:
             result = await backend_client.decide_article_system(
                 domain=domain,
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id or user_id,
                 decision=decision,
+                **_content_factory_delegated_backend_kwargs(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ),
             )
             status_code = result.get("status_code")
             data = result.get("data", {})
@@ -3337,8 +3994,9 @@ async def slack_actions(request: Request):
             if status_code in {200, 202}:
                 if original_intent and pending_wait_for:
                     pending = _remember_pending_intent(
-                        user_id,
+                        requested_by_slack_user_id,
                         domain,
+                        effective_slack_user_id=effective_slack_user_id,
                         intent_data=original_intent,
                         channel_id=reply_channel,
                         thread_ts=reply_thread_ts,
@@ -3347,9 +4005,18 @@ async def slack_actions(request: Request):
                         clear_job_id=True,
                     )
                     if pending:
-                        print(f"   📌 Stored pending intent: {original_intent.get('action')} for {user_id}:{domain}")
+                        print(
+                            "   📌 Stored pending intent: "
+                            f"{original_intent.get('action')} for "
+                            f"{requested_by_slack_user_id}:{effective_slack_user_id}:{domain}"
+                        )
                 elif decision == "use_detected":
-                    _get_pending_intent(user_id, domain, consume=True)
+                    _get_pending_intent(
+                        requested_by_slack_user_id,
+                        domain,
+                        consume=True,
+                        effective_slack_user_id=effective_slack_user_id,
+                    )
 
                 if decision == "use_detected":
                     detected = (
@@ -3411,7 +4078,6 @@ async def slack_actions(request: Request):
             return JSONResponse(status_code=400, content={"error": "Invalid JSON value format"})
 
         domain = value_data.get("domain")
-        original_user_id = value_data.get("slack_user_id")
         value_channel_id = value_data.get("channel_id")
         value_thread_ts = value_data.get("thread_ts")
         original_intent = value_data.get("original_intent", {})
@@ -3423,6 +4089,21 @@ async def slack_actions(request: Request):
 
         reply_channel = value_channel_id or msg_channel
         reply_thread_ts = value_thread_ts or payload.get("message", {}).get("thread_ts") or msg_ts
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=reply_channel,
+            thread_ts=reply_thread_ts,
+        )
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this run can start the prerequisite scan.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         # Remove buttons and show status
         try:
@@ -3453,19 +4134,39 @@ async def slack_actions(request: Request):
 
         try:
             result = await backend_client.trigger_repo_scan(
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id or user_id,
                 slack_channel_id=reply_channel,
                 slack_thread_ts=reply_thread_ts,
-                domain=domain
+                domain=domain,
+                **_content_factory_delegated_backend_kwargs(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ),
             )
             if result.get("error"):
                 error_msg = result.get("message", "Unknown error")
                 # Check if auth-related error — show reconnect button
                 if result.get("needs_github_auth"):
+                    if _is_delegated_content_factory_request(
+                        requested_by_slack_user_id,
+                        effective_slack_user_id,
+                    ):
+                        post_message(
+                            channel=reply_channel,
+                            thread_ts=reply_thread_ts,
+                            text=_delegated_content_factory_auth_error_text(
+                                effective_slack_user_id=effective_slack_user_id,
+                                domain=domain,
+                            ),
+                        )
+                        return JSONResponse(status_code=200, content={})
                     oauth_url = result.get("oauth_url")
                     if not oauth_url:
                         try:
-                            auth_resp = await backend_client.get_github_auth_url(user_id, domain=domain)
+                            auth_resp = await backend_client.get_github_auth_url(
+                                effective_slack_user_id or user_id,
+                                domain=domain,
+                            )
                             oauth_url = auth_resp.get("auth_url")
                         except Exception:
                             oauth_url = None
@@ -3521,8 +4222,9 @@ async def slack_actions(request: Request):
             else:
                 if original_intent:
                     pending = _remember_pending_intent(
-                        user_id,
+                        requested_by_slack_user_id,
                         domain,
+                        effective_slack_user_id=effective_slack_user_id,
                         intent_data=original_intent,
                         channel_id=reply_channel,
                         thread_ts=reply_thread_ts,
@@ -3531,7 +4233,11 @@ async def slack_actions(request: Request):
                         clear_job_id=True,
                     )
                     if pending:
-                        print(f"   📌 Stored pending intent: {original_intent.get('action')} for {user_id}:{domain}")
+                        print(
+                            "   📌 Stored pending intent: "
+                            f"{original_intent.get('action')} for "
+                            f"{requested_by_slack_user_id}:{effective_slack_user_id}:{domain}"
+                        )
                 print(f"✅ Scan triggered for {domain}")
         except Exception as e:
             print(f"❌ Failed to trigger scan: {e}")
@@ -3553,7 +4259,6 @@ async def slack_actions(request: Request):
             return JSONResponse(status_code=400, content={"error": "Invalid JSON value format"})
 
         domain = value_data.get("domain")
-        original_user_id = value_data.get("slack_user_id")
         value_channel_id = value_data.get("channel_id")
         value_thread_ts = value_data.get("thread_ts")
         original_intent = value_data.get("original_intent", {})
@@ -3565,6 +4270,21 @@ async def slack_actions(request: Request):
 
         reply_channel = value_channel_id or msg_channel
         reply_thread_ts = value_thread_ts or payload.get("message", {}).get("thread_ts") or msg_ts
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=reply_channel,
+            thread_ts=reply_thread_ts,
+        )
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this run can create the articles directory.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         # Remove buttons and show status
         try:
@@ -3596,9 +4316,13 @@ async def slack_actions(request: Request):
         try:
             result = await backend_client.scaffold_articles(
                 domain=domain,
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id or user_id,
                 slack_channel_id=reply_channel,
-                slack_thread_ts=reply_thread_ts
+                slack_thread_ts=reply_thread_ts,
+                **_content_factory_delegated_backend_kwargs(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ),
             )
 
             status_code = result.get("status_code")
@@ -3613,7 +4337,8 @@ async def slack_actions(request: Request):
                             "channel_id": reply_channel,
                             "thread_ts": reply_thread_ts,
                         },
-                        slack_user_id=user_id,
+                        requested_by_slack_user_id=requested_by_slack_user_id or user_id,
+                        effective_slack_user_id=effective_slack_user_id or user_id,
                         domain=domain,
                         fallback_channel_id=reply_channel,
                         fallback_thread_ts=reply_thread_ts,
@@ -3634,11 +4359,20 @@ async def slack_actions(request: Request):
             elif status_code == 400:
                 error = data.get("error", "Unknown error")
                 if data.get("needs_github_auth"):
-                    oauth_url = data.get("oauth_url", "")
                     post_message(
                         channel=reply_channel,
                         thread_ts=reply_thread_ts,
-                        text=f"❌ GitHub authentication required for *{domain}*.\n\nPlease reconnect: {oauth_url}"
+                        text=(
+                            _delegated_content_factory_auth_error_text(
+                                effective_slack_user_id=effective_slack_user_id,
+                                domain=domain,
+                            )
+                            if _is_delegated_content_factory_request(
+                                requested_by_slack_user_id,
+                                effective_slack_user_id,
+                            )
+                            else f"❌ GitHub authentication required for *{domain}*.\n\nPlease reconnect: {data.get('oauth_url', '')}"
+                        ),
                     )
                 else:
                     post_message(
@@ -3649,8 +4383,9 @@ async def slack_actions(request: Request):
             elif status_code == 202:
                 if original_intent:
                     pending = _remember_pending_intent(
-                        user_id,
+                        requested_by_slack_user_id,
                         domain,
+                        effective_slack_user_id=effective_slack_user_id,
                         intent_data=original_intent,
                         channel_id=reply_channel,
                         thread_ts=reply_thread_ts,
@@ -3659,7 +4394,11 @@ async def slack_actions(request: Request):
                         clear_job_id=True,
                     )
                     if pending:
-                        print(f"   📌 Stored pending intent: {original_intent.get('action')} for {user_id}:{domain}")
+                        print(
+                            "   📌 Stored pending intent: "
+                            f"{original_intent.get('action')} for "
+                            f"{requested_by_slack_user_id}:{effective_slack_user_id}:{domain}"
+                        )
                 print(f"✅ Scaffold initiated for {domain}")
             else:
                 post_message(
@@ -3689,11 +4428,32 @@ async def slack_actions(request: Request):
         domain = value_data.get("domain", "")
         msg_channel = payload.get("channel", {}).get("id")
         msg_ts = payload.get("message", {}).get("ts")
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            value_data=value_data,
+            channel_id=msg_channel,
+            thread_ts=payload.get("message", {}).get("thread_ts") or msg_ts,
+        )
+
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this run can cancel it.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         print(f"⏭️ User {user_id} cancelled prerequisite for {domain}")
 
         # Clear any pending intent
-        _get_pending_intent(user_id, domain, consume=True)
+        _get_pending_intent(
+            requested_by_slack_user_id,
+            domain,
+            consume=True,
+            effective_slack_user_id=effective_slack_user_id,
+        )
 
         # Replace buttons with context block
         try:
@@ -3738,6 +4498,20 @@ async def slack_actions(request: Request):
 
         msg_channel = payload.get("channel", {}).get("id")
         msg_ts = payload.get("message", {}).get("ts")
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            channel_id=msg_channel,
+            thread_ts=payload.get("message", {}).get("thread_ts") or msg_ts,
+        )
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this article can confirm the topic.",
+        )
+        if owner_error is not None:
+            return owner_error
 
         # Call confirm endpoint
         from .clients.mlai_backend import MLAIBackendClient
@@ -3750,9 +4524,13 @@ async def slack_actions(request: Request):
         try:
             result = await client.confirm_article_topic(
                 job_id=job_id,
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id or user_id,
                 option_index=option_index,
                 request_source=CONTENT_FACTORY_REQUEST_SOURCE,
+                **_content_factory_delegated_backend_kwargs(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ),
             )
             print(f"✅ Topic confirmed for job {job_id}")
             follow_up = _build_confirm_topic_follow_up(result)
@@ -3762,6 +4540,8 @@ async def slack_actions(request: Request):
                 follow_up.get("domain"),
                 "awaiting_delivery_mode" if follow_up.get("requires_delivery_mode") else "write",
                 active_job_id=follow_up.get("active_job_id"),
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
             )
 
             try:
@@ -3773,6 +4553,8 @@ async def slack_actions(request: Request):
                         domain=follow_up["domain"],
                         job_id=follow_up["active_job_id"],
                         recommended_delivery_mode=follow_up.get("recommended_delivery_mode"),
+                        requested_by_slack_user_id=requested_by_slack_user_id,
+                        effective_slack_user_id=effective_slack_user_id,
                     )
                     updated_text = f"Choose delivery mode for {follow_up['domain']}"
                 else:
@@ -3804,11 +4586,12 @@ async def slack_actions(request: Request):
             reply_thread_ts = payload.get("message", {}).get("thread_ts") or msg_ts
             recovered_follow_up = await _resolve_confirm_follow_up_after_failure(
                 client,
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id or user_id,
                 slack_channel_id=reply_channel,
                 slack_thread_ts=reply_thread_ts,
                 domain=None,
                 job_id=job_id,
+                requested_by_slack_user_id=requested_by_slack_user_id,
             )
             if recovered_follow_up:
                 try:
@@ -3820,6 +4603,8 @@ async def slack_actions(request: Request):
                             domain=recovered_follow_up["domain"],
                             job_id=recovered_follow_up["active_job_id"],
                             recommended_delivery_mode=recovered_follow_up.get("recommended_delivery_mode"),
+                            requested_by_slack_user_id=requested_by_slack_user_id,
+                            effective_slack_user_id=effective_slack_user_id,
                         )
                         updated_text = f"Choose delivery mode for {recovered_follow_up['domain']}"
                     else:
@@ -3855,10 +4640,24 @@ async def slack_actions(request: Request):
 
     # Handler for cancel_topic_btn
     if action_id == "cancel_topic_btn":
-        print(f"❌ User {user_id} cancelled topic selection")
-
         msg_channel = payload.get("channel", {}).get("id")
         msg_ts = payload.get("message", {}).get("ts")
+        (
+            requested_by_slack_user_id,
+            _effective_slack_user_id,
+        ) = _resolve_content_thread_identities(
+            channel_id=msg_channel,
+            thread_ts=payload.get("message", {}).get("thread_ts") or msg_ts,
+        )
+        owner_error = _enforce_content_factory_action_owner(
+            acting_slack_user_id=user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            denial_text="⚠️ Only the user who requested this article can cancel topic selection.",
+        )
+        if owner_error is not None:
+            return owner_error
+
+        print(f"❌ User {user_id} cancelled topic selection")
 
         # Remove buttons and show cancelled status
         try:

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -229,6 +229,8 @@ JSON:"""
         client_request_id: str,
         delivery_mode: Optional[str] = None,
         delivery_mode_confirmed: bool = False,
+        requested_by_slack_user_id: Optional[str] = None,
+        effective_slack_user_id: Optional[str] = None,
     ) -> list[dict]:
         """Build the preflight prompt for generic article requests."""
         normalized_domain = normalize_content_factory_domain(domain) or domain
@@ -238,13 +240,14 @@ JSON:"""
             if cost_points == 0
             else f"*Cost:* Starting the article run deducts {cost_points} Roo points."
         )
-        button_payload = {
-            "domain": domain,
-            "slack_user_id": user_id,
-            "channel_id": channel_id,
-            "thread_ts": thread_ts,
-            "client_request_id": client_request_id,
-        }
+        button_payload = self._content_factory_identity_payload(
+            requested_by_slack_user_id=requested_by_slack_user_id or user_id,
+            effective_slack_user_id=effective_slack_user_id or user_id,
+            domain=domain,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            client_request_id=client_request_id,
+        )
         if delivery_mode is not None:
             button_payload["delivery_mode"] = delivery_mode
             button_payload["delivery_mode_confirmed"] = delivery_mode_confirmed
@@ -337,6 +340,8 @@ JSON:"""
         job_id: str,
         topic: Optional[str],
         recommended_delivery_mode: Optional[str],
+        requested_by_slack_user_id: Optional[str] = None,
+        effective_slack_user_id: Optional[str] = None,
     ) -> dict:
         topic_line = f"*Topic:* {topic}\n" if topic else ""
         recommended_line = ""
@@ -367,14 +372,30 @@ JSON:"""
                         "type": "button",
                         "text": {"type": "plain_text", "text": "Content Only", "emoji": True},
                         "style": "primary" if recommended_delivery_mode != "publish_code" else None,
-                        "value": json.dumps({"job_id": job_id, "domain": domain, "delivery_mode": "content_only"}),
+                        "value": json.dumps(
+                            self._content_factory_identity_payload(
+                                requested_by_slack_user_id=requested_by_slack_user_id,
+                                effective_slack_user_id=effective_slack_user_id,
+                                job_id=job_id,
+                                domain=domain,
+                                delivery_mode="content_only",
+                            )
+                        ),
                         "action_id": "select_article_delivery_mode",
                     },
                     {
                         "type": "button",
                         "text": {"type": "plain_text", "text": "Publish Via Code", "emoji": True},
                         "style": "primary" if recommended_delivery_mode == "publish_code" else None,
-                        "value": json.dumps({"job_id": job_id, "domain": domain, "delivery_mode": "publish_code"}),
+                        "value": json.dumps(
+                            self._content_factory_identity_payload(
+                                requested_by_slack_user_id=requested_by_slack_user_id,
+                                effective_slack_user_id=effective_slack_user_id,
+                                job_id=job_id,
+                                domain=domain,
+                                delivery_mode="publish_code",
+                            )
+                        ),
                         "action_id": "select_article_delivery_mode",
                     },
                 ],
@@ -393,6 +414,8 @@ JSON:"""
                 "content_factory_watchdog_mode": "awaiting_delivery_mode",
                 "content_factory_domain": domain,
                 "content_factory_workflow": "awaiting_delivery_mode",
+                "requested_by_slack_user_id": requested_by_slack_user_id,
+                "effective_slack_user_id": effective_slack_user_id,
             },
         }
 
@@ -409,6 +432,8 @@ JSON:"""
         user_id: str,
         channel_id: Optional[str],
         thread_ts: Optional[str],
+        requested_by_slack_user_id: Optional[str] = None,
+        effective_slack_user_id: Optional[str] = None,
     ) -> dict:
         """Prompt the user before triggering a fresh scan when one already exists."""
         target = f"*{domain}*" if domain else f"`{repo_name or 'this repository'}`"
@@ -446,13 +471,14 @@ JSON:"""
                             },
                             "style": "primary",
                             "value": json.dumps(
-                                {
-                                    "domain": domain,
-                                    "slack_user_id": user_id,
-                                    "channel_id": channel_id,
-                                    "thread_ts": thread_ts,
-                                    "rescan": True,
-                                }
+                                self._content_factory_identity_payload(
+                                    requested_by_slack_user_id=requested_by_slack_user_id or user_id,
+                                    effective_slack_user_id=effective_slack_user_id or user_id,
+                                    domain=domain,
+                                    channel_id=channel_id,
+                                    thread_ts=thread_ts,
+                                    rescan=True,
+                                )
                             ),
                             "action_id": "prerequisite_scan",
                         },
@@ -463,7 +489,13 @@ JSON:"""
                                 "text": "Keep Existing Scan",
                                 "emoji": True,
                             },
-                            "value": json.dumps({"domain": domain}),
+                            "value": json.dumps(
+                                self._content_factory_identity_payload(
+                                    requested_by_slack_user_id=requested_by_slack_user_id or user_id,
+                                    effective_slack_user_id=effective_slack_user_id or user_id,
+                                    domain=domain,
+                                )
+                            ),
                             "action_id": "prerequisite_cancel",
                         },
                     ],
@@ -552,11 +584,76 @@ JSON:"""
             response["blocks"] = blocks
         return response
 
+    @staticmethod
+    def _resolve_content_factory_identity_context(
+        params: dict,
+        requester_slack_user_id: str,
+    ) -> tuple[str, str, bool]:
+        requested_by_slack_user_id = str(
+            params.get("requested_by_slack_user_id") or requester_slack_user_id or ""
+        ).strip()
+        effective_slack_user_id = str(
+            params.get("effective_slack_user_id") or requested_by_slack_user_id or ""
+        ).strip()
+        is_delegated = bool(
+            requested_by_slack_user_id
+            and effective_slack_user_id
+            and requested_by_slack_user_id != effective_slack_user_id
+        )
+        return requested_by_slack_user_id, effective_slack_user_id, is_delegated
+
+    @staticmethod
+    def _content_factory_identity_payload(
+        *,
+        requested_by_slack_user_id: Optional[str],
+        effective_slack_user_id: Optional[str],
+        **extra: Any,
+    ) -> dict[str, Any]:
+        payload = dict(extra)
+        if (
+            requested_by_slack_user_id
+            and effective_slack_user_id
+            and requested_by_slack_user_id != effective_slack_user_id
+        ):
+            payload["requested_by_slack_user_id"] = requested_by_slack_user_id
+            payload["effective_slack_user_id"] = effective_slack_user_id
+        return payload
+
+    @staticmethod
+    def _delegated_backend_kwargs(
+        requested_by_slack_user_id: Optional[str],
+        effective_slack_user_id: Optional[str],
+    ) -> dict[str, str]:
+        if (
+            requested_by_slack_user_id
+            and effective_slack_user_id
+            and requested_by_slack_user_id != effective_slack_user_id
+        ):
+            return {
+                "requested_by_slack_user_id": requested_by_slack_user_id,
+            }
+        return {}
+
+    @staticmethod
+    def _delegated_content_factory_auth_required_message(
+        *,
+        effective_slack_user_id: Optional[str],
+        domain: Optional[str],
+    ) -> str:
+        target = f"<@{effective_slack_user_id}>" if effective_slack_user_id else "that user"
+        domain_label = normalize_content_factory_domain(domain) or domain or "this domain"
+        return (
+            f"GitHub auth for {target} isn't available for {domain_label}. "
+            "Ask them to reconnect GitHub, then retry the delegated run."
+        )
+
     async def _request_github_reconnect(
         self,
         api_client,
         *,
         user_id: str,
+        requested_by_slack_user_id: Optional[str] = None,
+        effective_slack_user_id: Optional[str] = None,
         domain: Optional[str],
         github_repo: Optional[str],
         trigger: str,
@@ -572,6 +669,22 @@ JSON:"""
         resume_value: Optional[dict] = None,
     ) -> Optional[Any]:
         from ..clients.mlai_backend import MLAIBackendUnavailableError
+
+        delegated_effective_slack_user_id = str(
+            effective_slack_user_id or user_id or ""
+        ).strip()
+        delegated_requested_by_slack_user_id = str(
+            requested_by_slack_user_id or user_id or ""
+        ).strip()
+        if (
+            delegated_requested_by_slack_user_id
+            and delegated_effective_slack_user_id
+            and delegated_requested_by_slack_user_id != delegated_effective_slack_user_id
+        ):
+            return self._delegated_content_factory_auth_required_message(
+                effective_slack_user_id=delegated_effective_slack_user_id,
+                domain=domain,
+            )
 
         try:
             reconnect = await api_client.reconnect_content_factory_github(
@@ -1389,6 +1502,14 @@ Keep the response concise but informative."""
         params["client_request_id"] = client_request_id
         domain = normalize_content_factory_domain(params.get("domain"))
         action = str(params.get("action") or "").strip().lower()
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+            is_delegated,
+        ) = self._resolve_content_factory_identity_context(params, user_id)
+
+        if is_delegated:
+            return
 
         backend_intent: dict[str, Any] = {
             "type": "roo_content_factory",
@@ -1414,6 +1535,7 @@ Keep the response concise but informative."""
                     "slack_root_message_ts": thread_ts,
                     "request_source": CONTENT_FACTORY_REQUEST_SOURCE,
                     "client_request_id": client_request_id,
+                    "requested_by_slack_user_id": requested_by_slack_user_id,
                 },
                 "resume_context": {
                     "text": text,
@@ -1427,8 +1549,9 @@ Keep the response concise but informative."""
             from .. import main as main_module
 
             main_module._remember_pending_intent(
-                user_id,
+                requested_by_slack_user_id,
                 domain,
+                effective_slack_user_id=effective_slack_user_id,
                 intent_data={
                     "action": "write",
                     "topic": params.get("topic"),
@@ -1440,6 +1563,8 @@ Keep the response concise but informative."""
                     "request_source": CONTENT_FACTORY_REQUEST_SOURCE,
                     "text": text,
                     "params": params,
+                    "requested_by_slack_user_id": requested_by_slack_user_id,
+                    "effective_slack_user_id": effective_slack_user_id,
                 },
                 channel_id=channel_id,
                 thread_ts=thread_ts,
@@ -1448,7 +1573,7 @@ Keep the response concise but informative."""
             )
 
         try:
-            await api_client.save_pending_intent(user_id, backend_intent)
+            await api_client.save_pending_intent(requested_by_slack_user_id, backend_intent)
         except MLAIBackendUnavailableError as exc:
             print(
                 "⚠️ Failed to persist content-factory pending intent to mlai-backend: "
@@ -1551,6 +1676,8 @@ Keep the response concise but informative."""
         job_id: str,
         topic: Optional[str],
         workflow: str,
+        requested_by_slack_user_id: Optional[str] = None,
+        effective_slack_user_id: Optional[str] = None,
     ) -> dict:
         is_discovery = workflow == "auto_discovery" or not topic
         summary_text = (
@@ -1576,6 +1703,8 @@ Keep the response concise but informative."""
                 "content_factory_watchdog_mode": workflow,
                 "content_factory_domain": domain,
                 "content_factory_workflow": workflow,
+                "requested_by_slack_user_id": requested_by_slack_user_id,
+                "effective_slack_user_id": effective_slack_user_id,
             },
         }
 
@@ -1584,6 +1713,8 @@ Keep the response concise but informative."""
         *,
         domain: Optional[str],
         job_id: str,
+        requested_by_slack_user_id: Optional[str] = None,
+        effective_slack_user_id: Optional[str] = None,
     ) -> dict:
         display_domain = normalize_content_factory_domain(domain) or domain or "this domain"
         return {
@@ -1606,6 +1737,8 @@ Keep the response concise but informative."""
                 "content_factory_watchdog_mode": "publish_pr",
                 "content_factory_domain": display_domain,
                 "content_factory_workflow": "publish_pr",
+                "requested_by_slack_user_id": requested_by_slack_user_id,
+                "effective_slack_user_id": effective_slack_user_id,
             },
         }
 
@@ -1620,6 +1753,11 @@ Keep the response concise but informative."""
         thread_ts: Optional[str],
     ) -> tuple[dict, Optional[Any]]:
         from ..clients.mlai_backend import MLAIBackendUnavailableError
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+            _is_delegated,
+        ) = self._resolve_content_factory_identity_context(params, user_id)
 
         requested_action = detect_content_action(text)
         if requested_action != "publish_pr":
@@ -1636,12 +1774,17 @@ Keep the response concise but informative."""
             )
 
         try:
+            delegated_backend_kwargs = self._delegated_backend_kwargs(
+                requested_by_slack_user_id,
+                effective_slack_user_id,
+            )
             resolution = await api_client.resolve_content_thread(
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id,
                 slack_channel_id=channel_id,
                 slack_thread_ts=thread_ts,
                 requested_action="publish_pr",
                 domain=params.get("domain"),
+                **delegated_backend_kwargs,
             )
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 404:
@@ -1677,6 +1820,8 @@ Keep the response concise but informative."""
             return params, self._build_publish_pr_start_response(
                 domain=resolved_domain,
                 job_id=publish_job_id,
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
             )
 
         return params, (
@@ -1703,7 +1848,8 @@ Keep the response concise but informative."""
         *,
         job_id: str,
         domain: Optional[str],
-        slack_user_id: str,
+        requested_by_slack_user_id: str,
+        effective_slack_user_id: str,
         channel_id: Optional[str],
         thread_ts: Optional[str],
         text: str,
@@ -1719,7 +1865,9 @@ Keep the response concise but informative."""
 
         reconnect_result = await self._request_github_reconnect(
             api_client,
-            user_id=slack_user_id,
+            user_id=effective_slack_user_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            effective_slack_user_id=effective_slack_user_id,
             domain=domain,
             github_repo=None,
             trigger="preflight",
@@ -1735,7 +1883,14 @@ Keep the response concise but informative."""
             return reconnect_result
 
         try:
-            response = await api_client.publish_article_as_pr(job_id, slack_user_id)
+            response = await api_client.publish_article_as_pr(
+                job_id,
+                effective_slack_user_id,
+                **self._delegated_backend_kwargs(
+                    requested_by_slack_user_id,
+                    effective_slack_user_id,
+                ),
+            )
         except MLAIBackendUnavailableError:
             return self._content_factory_backend_unavailable_message()
         except httpx.HTTPStatusError as exc:
@@ -1746,10 +1901,17 @@ Keep the response concise but informative."""
                 error_data = {}
             if isinstance(error_data, dict):
                 if error_data.get("error_code") == "AUTH_REQUIRED":
+                    if (
+                        requested_by_slack_user_id != effective_slack_user_id
+                    ):
+                        return self._delegated_content_factory_auth_required_message(
+                            effective_slack_user_id=effective_slack_user_id,
+                            domain=domain,
+                        )
                     if not error_data.get("pending_intent_stored"):
                         await self._save_content_factory_pending_intent(
                             api_client,
-                            slack_user_id,
+                            requested_by_slack_user_id,
                             params,
                             text,
                             channel_id,
@@ -1758,7 +1920,7 @@ Keep the response concise but informative."""
                     auth_url = error_data.get("auth_url")
                     if not auth_url:
                         reconnect = await api_client.reconnect_content_factory_github(
-                            slack_user_id=slack_user_id,
+                            slack_user_id=effective_slack_user_id,
                             domain=domain,
                             github_repo=None,
                             trigger="fallback_412",
@@ -1807,6 +1969,8 @@ Keep the response concise but informative."""
         return self._build_publish_pr_start_response(
             domain=resolved_domain,
             job_id=child_job_id,
+            requested_by_slack_user_id=requested_by_slack_user_id,
+            effective_slack_user_id=effective_slack_user_id,
         )
 
     def _resolve_content_factory_repo_name(
@@ -1842,6 +2006,25 @@ Keep the response concise but informative."""
 
         params = dict(params or {})
         params["client_request_id"] = self._get_content_factory_client_request_id(params)
+        (
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+            is_delegated,
+        ) = self._resolve_content_factory_identity_context(params, user_id)
+        params["requested_by_slack_user_id"] = requested_by_slack_user_id
+        params["effective_slack_user_id"] = effective_slack_user_id
+
+        def content_factory_identity_payload(**extra: Any) -> dict[str, Any]:
+            return self._content_factory_identity_payload(
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
+                **extra,
+            )
+
+        delegated_backend_kwargs = self._delegated_backend_kwargs(
+            requested_by_slack_user_id,
+            effective_slack_user_id,
+        )
         
         # Get a MLAIBackendClient for API calls
         settings = get_settings()
@@ -1871,7 +2054,8 @@ Keep the response concise but informative."""
                 api_client,
                 job_id=str(params.get("job_id") or "").strip(),
                 domain=domain,
-                slack_user_id=user_id,
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
                 channel_id=channel_id,
                 thread_ts=thread_ts,
                 text=text,
@@ -1889,7 +2073,10 @@ Keep the response concise but informative."""
         # integration can return a multi-domain selection error before we ever
         # reach the domain-specific flow.
         try:
-            integration = await api_client.get_integration(user_id, domain=domain)
+            integration = await api_client.get_integration(
+                effective_slack_user_id,
+                domain=domain,
+            )
         except MLAIBackendUnavailableError:
             return self._content_factory_backend_unavailable_message()
         
@@ -1898,7 +2085,7 @@ Keep the response concise but informative."""
         if not integration and not params.get("confirmed"):
             await self._save_content_factory_pending_intent(
                 api_client,
-                user_id,
+                requested_by_slack_user_id,
                 params,
                 text,
                 channel_id,
@@ -1975,13 +2162,21 @@ Keep the response concise but informative."""
 
         # Check for Expired Token or Other Errors
         if integration and integration.get("error"):
+            if is_delegated:
+                return self._delegated_content_factory_auth_required_message(
+                    effective_slack_user_id=effective_slack_user_id,
+                    domain=domain,
+                )
             auth_url = integration.get("auth_url")
             error_msg = integration.get("error")
             
             if not auth_url:
                 # Fallback if auth_url missing in error response
                 try:
-                    auth_url_resp = await api_client.get_github_auth_url(user_id, domain=domain)
+                    auth_url_resp = await api_client.get_github_auth_url(
+                        effective_slack_user_id,
+                        domain=domain,
+                    )
                 except MLAIBackendUnavailableError:
                     return self._content_factory_backend_unavailable_message()
                 auth_url = auth_url_resp.get("auth_url")
@@ -2034,7 +2229,10 @@ Keep the response concise but informative."""
         if not integration:
             if is_article_flow:
                 try:
-                    org_config_cached = await api_client.get_content_org_config(user_id, domain=domain)
+                    org_config_cached = await api_client.get_content_org_config(
+                        effective_slack_user_id,
+                        domain=domain,
+                    )
                 except MLAIBackendUnavailableError:
                     return self._content_factory_backend_unavailable_message()
                 if org_config_cached:
@@ -2055,8 +2253,16 @@ Keep the response concise but informative."""
                     }
 
             if not integration:
+                if is_delegated:
+                    return self._delegated_content_factory_auth_required_message(
+                        effective_slack_user_id=effective_slack_user_id,
+                        domain=domain,
+                    )
                 try:
-                    auth_response = await api_client.get_github_auth_url(user_id, domain=domain)
+                    auth_response = await api_client.get_github_auth_url(
+                        effective_slack_user_id,
+                        domain=domain,
+                    )
                 except MLAIBackendUnavailableError:
                     return self._content_factory_backend_unavailable_message()
                 auth_url = auth_response.get("auth_url")
@@ -2092,7 +2298,7 @@ Keep the response concise but informative."""
 
                 await self._save_content_factory_pending_intent(
                     api_client,
-                    user_id,
+                    requested_by_slack_user_id,
                     params,
                     text,
                     channel_id,
@@ -2115,7 +2321,7 @@ Keep the response concise but informative."""
                 # No domains connected — fall back to org config lookup
                 try:
                     org_config_cached = await api_client.get_content_org_config(
-                        slack_user_id=user_id
+                        slack_user_id=effective_slack_user_id
                     )
                 except MLAIBackendUnavailableError:
                     return self._content_factory_backend_unavailable_message()
@@ -2141,7 +2347,10 @@ Keep the response concise but informative."""
         # or "write_article" without forcing a re-scan.
         if domain:
             try:
-                domain_integration = await api_client.get_integration(user_id, domain=domain)
+                domain_integration = await api_client.get_integration(
+                    effective_slack_user_id,
+                    domain=domain,
+                )
             except MLAIBackendUnavailableError:
                 return self._content_factory_backend_unavailable_message()
             if domain_integration:
@@ -2149,7 +2358,10 @@ Keep the response concise but informative."""
                 connected_domains = integration.get("connected_domains", connected_domains)
             elif is_article_flow and org_config_cached is None:
                 try:
-                    org_config_cached = await api_client.get_content_org_config(user_id, domain=domain)
+                    org_config_cached = await api_client.get_content_org_config(
+                        effective_slack_user_id,
+                        domain=domain,
+                    )
                 except MLAIBackendUnavailableError:
                     return self._content_factory_backend_unavailable_message()
 
@@ -2162,7 +2374,9 @@ Keep the response concise but informative."""
         if domain and integration and integration.get("needs_github_auth") and not is_article_flow:
             reconnect_result = await self._request_github_reconnect(
                 api_client,
-                user_id=user_id,
+                user_id=effective_slack_user_id,
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
                 domain=domain,
                 github_repo=repo_name,
                 trigger="manual",
@@ -2181,7 +2395,9 @@ Keep the response concise but informative."""
         if not repo_name and not is_article_flow:
             reconnect_result = await self._request_github_reconnect(
                 api_client,
-                user_id=user_id,
+                user_id=effective_slack_user_id,
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
                 domain=domain,
                 github_repo=None,
                 trigger="manual",
@@ -2203,7 +2419,9 @@ Keep the response concise but informative."""
 
             reconnect_result = await self._request_github_reconnect(
                 api_client,
-                user_id=user_id,
+                user_id=effective_slack_user_id,
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
                 domain=domain,
                 github_repo=repo_name,
                 trigger="preflight",
@@ -2236,19 +2454,22 @@ Keep the response concise but informative."""
                                 "type": "button",
                                 "text": {"type": "plain_text", "text": "Scan Codebase", "emoji": True},
                                 "style": "primary",
-                                "value": json.dumps({
-                                    "domain": domain,
-                                    "slack_user_id": user_id,
-                                    "channel_id": channel_id,
-                                    "thread_ts": thread_ts,
-                                    "original_intent": {"action": "scaffold"}
-                                }),
+                                "value": json.dumps(
+                                    content_factory_identity_payload(
+                                        domain=domain,
+                                        channel_id=channel_id,
+                                        thread_ts=thread_ts,
+                                        original_intent={"action": "scaffold"},
+                                    )
+                                ),
                                 "action_id": "prerequisite_scan"
                             },
                             {
                                 "type": "button",
                                 "text": {"type": "plain_text", "text": "Cancel", "emoji": True},
-                                "value": json.dumps({"domain": domain}),
+                                "value": json.dumps(
+                                    content_factory_identity_payload(domain=domain)
+                                ),
                                 "action_id": "prerequisite_cancel"
                             }
                         ]
@@ -2268,9 +2489,10 @@ Keep the response concise but informative."""
             try:
                 result = await api_client.scaffold_articles(
                     domain=domain,
-                    slack_user_id=user_id,
+                    slack_user_id=effective_slack_user_id,
                     slack_channel_id=channel_id or "",
-                    slack_thread_ts=thread_ts or ""
+                    slack_thread_ts=thread_ts or "",
+                    **delegated_backend_kwargs,
                 )
 
                 status_code = result.get("status_code")
@@ -2306,19 +2528,22 @@ Keep the response concise but informative."""
                                     "type": "button",
                                     "text": {"type": "plain_text", "text": "Scan Codebase", "emoji": True},
                                     "style": "primary",
-                                    "value": json.dumps({
-                                        "domain": domain,
-                                        "slack_user_id": user_id,
-                                        "channel_id": channel_id,
-                                        "thread_ts": thread_ts,
-                                        "original_intent": {"action": "scaffold"}
-                                    }),
+                                    "value": json.dumps(
+                                        content_factory_identity_payload(
+                                            domain=domain,
+                                            channel_id=channel_id,
+                                            thread_ts=thread_ts,
+                                            original_intent={"action": "scaffold"},
+                                        )
+                                    ),
                                     "action_id": "prerequisite_scan"
                                 },
                                 {
                                     "type": "button",
                                     "text": {"type": "plain_text", "text": "Cancel", "emoji": True},
-                                    "value": json.dumps({"domain": domain}),
+                                    "value": json.dumps(
+                                        content_factory_identity_payload(domain=domain)
+                                    ),
                                     "action_id": "prerequisite_cancel"
                                 }
                             ]
@@ -2329,6 +2554,11 @@ Keep the response concise but informative."""
                     return "I need to scan your codebase first."
                 elif status_code == 400:
                     if data.get("needs_github_auth"):
+                        if is_delegated:
+                            return self._delegated_content_factory_auth_required_message(
+                                effective_slack_user_id=effective_slack_user_id,
+                                domain=domain,
+                            )
                         oauth_url = data.get("oauth_url", "")
                         return f"❌ GitHub authentication required for *{domain}*.\n\nPlease reconnect: {oauth_url}"
                     return f"❌ Could not start scaffolding: {data.get('error', 'Unknown error')}"
@@ -2384,6 +2614,8 @@ Keep the response concise but informative."""
                 user_id=user_id,
                 channel_id=channel_id,
                 thread_ts=thread_ts,
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
             )
 
         # Compile Status Report
@@ -2427,7 +2659,9 @@ Keep the response concise but informative."""
         if needs_scan:
             reconnect_result = await self._request_github_reconnect(
                 api_client,
-                user_id=user_id,
+                user_id=effective_slack_user_id,
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
                 domain=domain,
                 github_repo=repo_name,
                 trigger="preflight",
@@ -2443,10 +2677,11 @@ Keep the response concise but informative."""
                 return reconnect_result
 
             scan_result = await api_client.trigger_repo_scan(
-                user_id, 
+                effective_slack_user_id,
                 slack_channel_id=channel_id,
                 slack_thread_ts=thread_ts,
-                domain=domain
+                domain=domain,
+                **delegated_backend_kwargs,
             )
             
             if scan_result.get("status") == "accepted":
@@ -2470,6 +2705,11 @@ Keep the response concise but informative."""
 
                 # If backend says GitHub isn't connected for this domain
                 if scan_result.get("needs_github_auth"):
+                    if is_delegated:
+                        return self._delegated_content_factory_auth_required_message(
+                            effective_slack_user_id=effective_slack_user_id,
+                            domain=domain,
+                        )
                     oauth_url = scan_result.get("oauth_url")
                     domain_name = scan_result.get("domain", domain)
                     if oauth_url:
@@ -2510,7 +2750,10 @@ Keep the response concise but informative."""
                 if any(code in str(error_msg) for code in ["404", "401", "403", "Not Found", "Bad credentials"]):
                     # Fetch Auth URL to allow reconnect
                     try:
-                        auth_response = await api_client.get_github_auth_url(user_id, domain=domain)
+                        auth_response = await api_client.get_github_auth_url(
+                            effective_slack_user_id,
+                            domain=domain,
+                        )
                     except MLAIBackendUnavailableError:
                         return self._content_factory_backend_unavailable_message()
                     auth_url = auth_response.get("auth_url")
@@ -2554,7 +2797,10 @@ Keep the response concise but informative."""
             # Legacy Sync Behavior (if backend returns 200 immediately)
             # Scan succeeded - refresh integration status
             try:
-                integration = await api_client.get_integration(user_id, domain=domain)
+                integration = await api_client.get_integration(
+                    effective_slack_user_id,
+                    domain=domain,
+                )
             except MLAIBackendUnavailableError:
                 return self._content_factory_backend_unavailable_message()
             if not integration or not integration.get("project_scanned"):
@@ -2584,6 +2830,8 @@ Keep the response concise but informative."""
                     params["client_request_id"],
                     requested_delivery_mode,
                     requested_delivery_mode_confirmed,
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
                 ),
             }
 
@@ -2622,13 +2870,12 @@ Keep the response concise but informative."""
                             "text": {"type": "plain_text", "text": "Use Detected Structure", "emoji": True},
                             "style": "primary",
                             "value": json.dumps(
-                                {
-                                    "domain": domain,
-                                    "slack_user_id": user_id,
-                                    "channel_id": channel_id,
-                                    "thread_ts": thread_ts,
-                                    "original_intent": original_intent,
-                                }
+                                content_factory_identity_payload(
+                                    domain=domain,
+                                    channel_id=channel_id,
+                                    thread_ts=thread_ts,
+                                    original_intent=original_intent,
+                                )
                             ),
                             "action_id": "article_system_use_detected",
                         },
@@ -2636,13 +2883,12 @@ Keep the response concise but informative."""
                             "type": "button",
                             "text": {"type": "plain_text", "text": "Rescan Repo", "emoji": True},
                             "value": json.dumps(
-                                {
-                                    "domain": domain,
-                                    "slack_user_id": user_id,
-                                    "channel_id": channel_id,
-                                    "thread_ts": thread_ts,
-                                    "original_intent": original_intent,
-                                }
+                                content_factory_identity_payload(
+                                    domain=domain,
+                                    channel_id=channel_id,
+                                    thread_ts=thread_ts,
+                                    original_intent=original_intent,
+                                )
                             ),
                             "action_id": "article_system_rescan",
                         },
@@ -2650,13 +2896,12 @@ Keep the response concise but informative."""
                             "type": "button",
                             "text": {"type": "plain_text", "text": "Set Up Articles Directory", "emoji": True},
                             "value": json.dumps(
-                                {
-                                    "domain": domain,
-                                    "slack_user_id": user_id,
-                                    "channel_id": channel_id,
-                                    "thread_ts": thread_ts,
-                                    "original_intent": original_intent,
-                                }
+                                content_factory_identity_payload(
+                                    domain=domain,
+                                    channel_id=channel_id,
+                                    thread_ts=thread_ts,
+                                    original_intent=original_intent,
+                                )
                             ),
                             "action_id": "article_system_scaffold",
                         },
@@ -2675,7 +2920,11 @@ Keep the response concise but informative."""
                 history_str = "\n".join([f"{msg.get('user')}: {msg.get('text')}" for msg in thread_history[:-1]])
                 full_context = f"Context from Thread:\n{history_str}\n\nCurrent Request: {text}"
 
-            access_error = await self._validate_content_factory_paid_access(api_client, user_id, domain)
+            access_error = await self._validate_content_factory_paid_access(
+                api_client,
+                requested_by_slack_user_id,
+                domain,
+            )
             if access_error:
                 return access_error
 
@@ -2688,7 +2937,9 @@ Keep the response concise but informative."""
             if effective_article_delivery_mode == "publish_code":
                 reconnect_result = await self._request_github_reconnect(
                     api_client,
-                    user_id=user_id,
+                    user_id=effective_slack_user_id,
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
                     domain=domain,
                     github_repo=repo_name,
                     trigger="preflight",
@@ -2704,13 +2955,13 @@ Keep the response concise but informative."""
                     return reconnect_result
 
             from ..slack_client import get_user_info
-            slack_info = get_user_info(user_id)
+            slack_info = get_user_info(requested_by_slack_user_id)
             real_name = str(slack_info.get("real_name") or "").strip()
             name_parts = real_name.split(" ", 1) if real_name else []
             
             # Note: topic can be None (triggers Auto-Write / Research Mode)
             response = await api_client.trigger_article_generation(
-                slack_user_id=user_id,
+                slack_user_id=effective_slack_user_id,
                 domain=domain,
                 topic=topic,
                 target_keyword=target_keyword,
@@ -2725,6 +2976,7 @@ Keep the response concise but informative."""
                 user_first_name=name_parts[0] if name_parts else None,
                 user_last_name=name_parts[1] if len(name_parts) > 1 else None,
                 user_avatar_url=str(slack_info.get("image_192") or "").strip() or None,
+                **delegated_backend_kwargs,
             )
             
             job_id = response.get("job_id")
@@ -2737,6 +2989,8 @@ Keep the response concise but informative."""
                     job_id=job_id,
                     topic=topic,
                     recommended_delivery_mode=response.get("recommended_delivery_mode"),
+                    requested_by_slack_user_id=requested_by_slack_user_id,
+                    effective_slack_user_id=effective_slack_user_id,
                 )
 
             workflow = str(
@@ -2749,6 +3003,8 @@ Keep the response concise but informative."""
                 job_id=job_id,
                 topic=topic,
                 workflow=workflow,
+                requested_by_slack_user_id=requested_by_slack_user_id,
+                effective_slack_user_id=effective_slack_user_id,
             )
             
         except MLAIBackendUnavailableError:
@@ -2762,10 +3018,15 @@ Keep the response concise but informative."""
                     error_data = {}
                 error_code = error_data.get("error_code", "")
                 if error_code == "AUTH_REQUIRED":
+                    if is_delegated:
+                        return self._delegated_content_factory_auth_required_message(
+                            effective_slack_user_id=effective_slack_user_id,
+                            domain=domain,
+                        )
                     if not error_data.get("pending_intent_stored"):
                         await self._save_content_factory_pending_intent(
                             api_client,
-                            user_id,
+                            requested_by_slack_user_id,
                             params,
                             text,
                             channel_id,
@@ -2774,7 +3035,7 @@ Keep the response concise but informative."""
                     auth_url = error_data.get("auth_url")
                     if not auth_url:
                         reconnect = await api_client.reconnect_content_factory_github(
-                            slack_user_id=user_id,
+                            slack_user_id=effective_slack_user_id,
                             domain=domain,
                             github_repo=repo_name,
                             trigger="fallback_412",
@@ -2800,10 +3061,18 @@ Keep the response concise but informative."""
                         }
                     return message
                 if error_code == "PUBLISH_TARGET_ACTION_REQUIRED":
+                    if is_delegated:
+                        return self._delegated_content_factory_auth_required_message(
+                            effective_slack_user_id=effective_slack_user_id,
+                            domain=domain,
+                        )
                     auth_url = None
                     if domain:
                         try:
-                            auth_response = await api_client.get_github_auth_url(user_id, domain=domain)
+                            auth_response = await api_client.get_github_auth_url(
+                                effective_slack_user_id,
+                                domain=domain,
+                            )
                         except MLAIBackendUnavailableError:
                             return self._content_factory_backend_unavailable_message()
                         auth_url = auth_response.get("auth_url")
@@ -2884,37 +3153,40 @@ Keep the response concise but informative."""
                                         "type": "button",
                                         "text": {"type": "plain_text", "text": "Use Detected Structure", "emoji": True},
                                         "style": "primary",
-                                        "value": json.dumps({
-                                            "domain": domain,
-                                            "slack_user_id": user_id,
-                                            "channel_id": channel_id,
-                                            "thread_ts": thread_ts,
-                                            "original_intent": original_intent,
-                                        }),
+                                        "value": json.dumps(
+                                            content_factory_identity_payload(
+                                                domain=domain,
+                                                channel_id=channel_id,
+                                                thread_ts=thread_ts,
+                                                original_intent=original_intent,
+                                            )
+                                        ),
                                         "action_id": "article_system_use_detected",
                                     },
                                     {
                                         "type": "button",
                                         "text": {"type": "plain_text", "text": "Rescan Repo", "emoji": True},
-                                        "value": json.dumps({
-                                            "domain": domain,
-                                            "slack_user_id": user_id,
-                                            "channel_id": channel_id,
-                                            "thread_ts": thread_ts,
-                                            "original_intent": original_intent,
-                                        }),
+                                        "value": json.dumps(
+                                            content_factory_identity_payload(
+                                                domain=domain,
+                                                channel_id=channel_id,
+                                                thread_ts=thread_ts,
+                                                original_intent=original_intent,
+                                            )
+                                        ),
                                         "action_id": "article_system_rescan",
                                     },
                                     {
                                         "type": "button",
                                         "text": {"type": "plain_text", "text": "Set Up Articles Directory", "emoji": True},
-                                        "value": json.dumps({
-                                            "domain": domain,
-                                            "slack_user_id": user_id,
-                                            "channel_id": channel_id,
-                                            "thread_ts": thread_ts,
-                                            "original_intent": original_intent,
-                                        }),
+                                        "value": json.dumps(
+                                            content_factory_identity_payload(
+                                                domain=domain,
+                                                channel_id=channel_id,
+                                                thread_ts=thread_ts,
+                                                original_intent=original_intent,
+                                            )
+                                        ),
                                         "action_id": "article_system_scaffold",
                                     },
                                 ],
@@ -2949,19 +3221,22 @@ Keep the response concise but informative."""
                                     "type": "button",
                                     "text": {"type": "plain_text", "text": "Set Up Articles Directory", "emoji": True},
                                     "style": "primary",
-                                    "value": json.dumps({
-                                        "domain": domain,
-                                        "slack_user_id": user_id,
-                                        "channel_id": channel_id,
-                                        "thread_ts": thread_ts,
-                                        "original_intent": original_intent,
-                                    }),
+                                    "value": json.dumps(
+                                        content_factory_identity_payload(
+                                            domain=domain,
+                                            channel_id=channel_id,
+                                            thread_ts=thread_ts,
+                                            original_intent=original_intent,
+                                        )
+                                    ),
                                     "action_id": "prerequisite_scaffold",
                                 },
                                 {
                                     "type": "button",
                                     "text": {"type": "plain_text", "text": "Cancel", "emoji": True},
-                                    "value": json.dumps({"domain": domain}),
+                                    "value": json.dumps(
+                                        content_factory_identity_payload(domain=domain)
+                                    ),
                                     "action_id": "prerequisite_cancel",
                                 },
                             ],
@@ -2994,19 +3269,22 @@ Keep the response concise but informative."""
                                     "type": "button",
                                     "text": {"type": "plain_text", "text": "Scan Codebase", "emoji": True},
                                     "style": "primary",
-                                    "value": json.dumps({
-                                        "domain": domain,
-                                        "slack_user_id": user_id,
-                                        "channel_id": channel_id,
-                                        "thread_ts": thread_ts,
-                                        "original_intent": original_intent
-                                    }),
+                                    "value": json.dumps(
+                                        content_factory_identity_payload(
+                                            domain=domain,
+                                            channel_id=channel_id,
+                                            thread_ts=thread_ts,
+                                            original_intent=original_intent,
+                                        )
+                                    ),
                                     "action_id": "prerequisite_scan"
                                 },
                                 {
                                     "type": "button",
                                     "text": {"type": "plain_text", "text": "Cancel", "emoji": True},
-                                    "value": json.dumps({"domain": domain}),
+                                    "value": json.dumps(
+                                        content_factory_identity_payload(domain=domain)
+                                    ),
                                     "action_id": "prerequisite_cancel"
                                 }
                             ]
@@ -3038,19 +3316,22 @@ Keep the response concise but informative."""
                                     "type": "button",
                                     "text": {"type": "plain_text", "text": "Set Up Articles Directory", "emoji": True},
                                     "style": "primary",
-                                    "value": json.dumps({
-                                        "domain": domain,
-                                        "slack_user_id": user_id,
-                                        "channel_id": channel_id,
-                                        "thread_ts": thread_ts,
-                                        "original_intent": original_intent
-                                    }),
+                                    "value": json.dumps(
+                                        content_factory_identity_payload(
+                                            domain=domain,
+                                            channel_id=channel_id,
+                                            thread_ts=thread_ts,
+                                            original_intent=original_intent,
+                                        )
+                                    ),
                                     "action_id": "prerequisite_scaffold"
                                 },
                                 {
                                     "type": "button",
                                     "text": {"type": "plain_text", "text": "Cancel", "emoji": True},
-                                    "value": json.dumps({"domain": domain}),
+                                    "value": json.dumps(
+                                        content_factory_identity_payload(domain=domain)
+                                    ),
                                     "action_id": "prerequisite_cancel"
                                 }
                             ]
@@ -3068,6 +3349,11 @@ Keep the response concise but informative."""
                     error_data = {}
                 # Structured error: GitHub not connected for this domain
                 if error_data.get("needs_github_auth"):
+                    if is_delegated:
+                        return self._delegated_content_factory_auth_required_message(
+                            effective_slack_user_id=effective_slack_user_id,
+                            domain=domain,
+                        )
                     oauth_url = error_data.get("oauth_url")
                     domain_name = error_data.get("domain", domain)
                     if oauth_url and channel_id:

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -328,6 +328,123 @@ def test_handle_mention_normalizes_slack_link_and_passes_scan_params(monkeypatch
     }
 
 
+def test_handle_mention_parses_delegated_scan_and_passes_identity_overrides(monkeypatch):
+    agent = _make_agent()
+    captured = {}
+
+    class FakeExecutor:
+        async def execute(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                message="ok",
+                data=kwargs.get("param_overrides"),
+                blocks=None,
+                suppress_post=False,
+            )
+
+    agent.skill_executor = FakeExecutor()
+
+    async def fail_chat(*args, **kwargs):
+        raise AssertionError("LLM router should not be needed for delegated scans")
+
+    monkeypatch.setattr("roo.agent.chat", fail_chat)
+    monkeypatch.setattr("roo.agent.get_thread_messages", lambda channel, thread_ts: [])
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "U090FV0GTT4")
+
+    result = asyncio.run(
+        agent.handle_mention(
+            text="<@U090FV0GTT4> scan the repo for the domain woofya.com.au as <@U0AQV5X9G0J>",
+            user_id="U05QPB483K9",
+            channel_id="C123",
+            thread_ts="123.456",
+        )
+    )
+
+    assert result["skill_used"] == "content-factory"
+    assert captured["text"] == "scan the repo for the domain woofya.com.au"
+    assert captured["param_overrides"] == {
+        "action": "scan",
+        "domain": "woofya.com.au",
+        "requested_by_slack_user_id": "U05QPB483K9",
+        "effective_slack_user_id": "U0AQV5X9G0J",
+    }
+
+
+def test_handle_mention_rejects_unauthorized_delegation(monkeypatch):
+    agent = _make_agent()
+
+    async def fail_chat(*args, **kwargs):
+        raise AssertionError("LLM router should not be needed for delegation denials")
+
+    monkeypatch.setattr("roo.agent.chat", fail_chat)
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "U090FV0GTT4")
+
+    result = asyncio.run(
+        agent.handle_mention(
+            text="<@U090FV0GTT4> scan mlai.au as <@U0AQV5X9G0J>",
+            user_id="U123OTHER",
+            channel_id="C123",
+            thread_ts="123.456",
+        )
+    )
+
+    assert result == {
+        "message": "Only <@U05QPB483K9> can run Content Factory as another user.",
+        "skill_used": "content-factory",
+        "data": None,
+    }
+
+
+def test_handle_mention_keeps_delegated_target_sticky_within_thread(monkeypatch):
+    agent = _make_agent()
+    agent.remember_thread_context(
+        "content-factory",
+        "C123",
+        "123.456",
+        domain="studynash.co",
+        workflow="scan",
+        requested_by_slack_user_id="U05QPB483K9",
+        effective_slack_user_id="U0AQV5X9G0J",
+    )
+    captured = {}
+
+    class FakeExecutor:
+        async def execute(self, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(
+                message="ok",
+                data=kwargs.get("param_overrides"),
+                blocks=None,
+                suppress_post=False,
+            )
+
+    agent.skill_executor = FakeExecutor()
+
+    async def fail_chat(*args, **kwargs):
+        raise AssertionError("LLM router should not be needed for sticky delegated follow-up")
+
+    monkeypatch.setattr("roo.agent.chat", fail_chat)
+    monkeypatch.setattr("roo.agent.get_thread_messages", lambda channel, thread_ts: [])
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "U090FV0GTT4")
+
+    result = asyncio.run(
+        agent.handle_mention(
+            text="<@U090FV0GTT4> publish this article as a PR",
+            user_id="U05QPB483K9",
+            channel_id="C123",
+            thread_ts="123.456",
+        )
+    )
+
+    assert result["skill_used"] == "content-factory"
+    assert captured["param_overrides"] == {
+        "action": "publish_pr",
+        "domain": "studynash.co",
+        "requested_by_slack_user_id": "U05QPB483K9",
+        "effective_slack_user_id": "U0AQV5X9G0J",
+    }
+
+
 def test_handle_mention_passes_publish_pr_job_from_thread_context(monkeypatch):
     agent = _make_agent()
     agent.remember_thread_context(

--- a/roo-standalone/roo/tests/test_content_factory_article_flow.py
+++ b/roo-standalone/roo/tests/test_content_factory_article_flow.py
@@ -147,6 +147,7 @@ class FakeContentFactoryClient:
         user_first_name=None,
         user_last_name=None,
         user_avatar_url=None,
+        requested_by_slack_user_id=None,
     ):
         self.trigger_calls.append(
             {
@@ -166,6 +167,7 @@ class FakeContentFactoryClient:
                 "user_first_name": user_first_name,
                 "user_last_name": user_last_name,
                 "user_avatar_url": user_avatar_url,
+                "requested_by_slack_user_id": requested_by_slack_user_id,
             }
         )
         return FakeContentFactoryClient.trigger_article_generation_result or {
@@ -233,10 +235,11 @@ class FakeContentFactoryClient:
             "pr_url": "https://github.test/pr/123",
         }
 
-    async def publish_article_as_pr(self, job_id, slack_user_id):
-        FakeContentFactoryClient.publish_article_as_pr_calls.append(
-            {"job_id": job_id, "slack_user_id": slack_user_id}
-        )
+    async def publish_article_as_pr(self, job_id, slack_user_id, requested_by_slack_user_id=None):
+        payload = {"job_id": job_id, "slack_user_id": slack_user_id}
+        if requested_by_slack_user_id is not None:
+            payload["requested_by_slack_user_id"] = requested_by_slack_user_id
+        FakeContentFactoryClient.publish_article_as_pr_calls.append(payload)
         return {
             "job_id": "publish-job-456",
             "status": "queued",
@@ -251,6 +254,7 @@ class FakeContentFactoryClient:
         requested_action,
         domain=None,
         job_id=None,
+        requested_by_slack_user_id=None,
     ):
         call = {
             "slack_user_id": slack_user_id,
@@ -261,6 +265,8 @@ class FakeContentFactoryClient:
         }
         if job_id is not None:
             call["job_id"] = job_id
+        if requested_by_slack_user_id is not None:
+            call["requested_by_slack_user_id"] = requested_by_slack_user_id
         FakeContentFactoryClient.resolve_content_thread_calls.append(call)
         if isinstance(FakeContentFactoryClient.resolve_content_thread_result, Exception):
             raise FakeContentFactoryClient.resolve_content_thread_result
@@ -281,15 +287,17 @@ class FakeContentFactoryClient:
         slack_channel_id=None,
         slack_thread_ts=None,
         domain=None,
+        requested_by_slack_user_id=None,
     ):
-        self.repo_scan_calls.append(
-            {
-                "slack_user_id": slack_user_id,
-                "slack_channel_id": slack_channel_id,
-                "slack_thread_ts": slack_thread_ts,
-                "domain": domain,
-            }
-        )
+        payload = {
+            "slack_user_id": slack_user_id,
+            "slack_channel_id": slack_channel_id,
+            "slack_thread_ts": slack_thread_ts,
+            "domain": domain,
+        }
+        if requested_by_slack_user_id is not None:
+            payload["requested_by_slack_user_id"] = requested_by_slack_user_id
+        self.repo_scan_calls.append(payload)
         return {"status": "accepted", "message": "Scan queued successfully."}
 
 
@@ -578,6 +586,84 @@ async def test_requested_domain_bypasses_generic_multi_domain_error(monkeypatch)
     assert trigger_call["topic"] == "dog grooming tips"
     assert posted_messages
     assert "Status Report" in posted_messages[0]["args"][1]
+
+
+@pytest.mark.asyncio
+async def test_delegated_article_request_uses_effective_user_for_backend_and_requester_for_billing(monkeypatch):
+    executor = SkillExecutor()
+    _patch_content_factory(monkeypatch)
+    monkeypatch.setattr(
+        executor_module,
+        "post_message",
+        lambda *args, **kwargs: {"ts": "111.222"},
+    )
+
+    result = await executor._execute_content_factory(
+        skill=None,
+        text="write an article for woofya.com.au",
+        params={
+            "domain": "woofya.com.au",
+            "topic": "dog grooming tips",
+            "requested_by_slack_user_id": "U05QPB483K9",
+            "effective_slack_user_id": "U0AQV5X9G0J",
+        },
+        user_id="U05QPB483K9",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert isinstance(result, dict)
+    assert FakeContentFactoryClient.integration_requests[0] == {
+        "user_id": "U0AQV5X9G0J",
+        "domain": "woofya.com.au",
+        "include_repo_freshness": False,
+    }
+    trigger_call = FakeContentFactoryClient.last_instance.trigger_calls[0]
+    assert trigger_call["slack_user_id"] == "U0AQV5X9G0J"
+    assert trigger_call["requested_by_slack_user_id"] == "U05QPB483K9"
+    assert trigger_call["user_email"] == "sam@example.com"
+    assert FakeContentFactoryClient.last_instance.balance_checks == ["U05QPB483K9"]
+    assert FakeContentFactoryClient.last_instance.user_registration_calls == [
+        {
+            "slack_id": "U05QPB483K9",
+            "email": "sam@example.com",
+            "first_name": "Sam",
+            "last_name": "Donegan",
+            "avatar_url": "https://avatar.test/sam.png",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delegated_scan_auth_blocker_returns_error_without_reconnect(monkeypatch):
+    executor = SkillExecutor()
+    _patch_content_factory(monkeypatch)
+    FakeContentFactoryClient.domain_integrations["mlai.au"] = {
+        **FakeContentFactoryClient.domain_integrations["mlai.au"],
+        "needs_github_auth": True,
+        "recommended_next_action": "scan",
+    }
+
+    result = await executor._execute_content_factory(
+        skill=None,
+        text="scan mlai.au",
+        params={
+            "domain": "mlai.au",
+            "action": "scan",
+            "requested_by_slack_user_id": "U05QPB483K9",
+            "effective_slack_user_id": "U0AQV5X9G0J",
+        },
+        user_id="U05QPB483K9",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert result == (
+        "GitHub auth for <@U0AQV5X9G0J> isn't available for mlai.au. "
+        "Ask them to reconnect GitHub, then retry the delegated run."
+    )
+    assert FakeContentFactoryClient.reconnect_calls == []
+    assert FakeContentFactoryClient.last_instance.repo_scan_calls == []
 
 
 @pytest.mark.asyncio
@@ -938,7 +1024,6 @@ async def test_explicit_content_factory_scan_with_existing_scan_prompts_for_conf
     assert buttons[0]["text"]["text"] == "Scan Again"
     assert json.loads(buttons[0]["value"]) == {
         "domain": "mlai.au",
-        "slack_user_id": "U05QPB483K9",
         "channel_id": "C123",
         "thread_ts": "111.222",
         "rescan": True,
@@ -2529,7 +2614,7 @@ def test_prerequisite_scan_action_stores_pending_intent_after_accepted(monkeypat
     response = asyncio.run(main_module.slack_actions(FakeRequest()))
 
     assert response.status_code == 200
-    pending = main_module._pending_intents["U05QPB483K9:mlai.au"]
+    pending = main_module._pending_intents["U05QPB483K9:U05QPB483K9:mlai.au"]
     assert pending["action"] == "write"
     assert pending["topic"] == "AI for clinic workflows"
     assert pending["wait_for"] == "scan_complete"
@@ -3027,6 +3112,73 @@ def test_confirm_topic_action_uses_roo_request_source_and_mentions_no_extra_char
     ]
     assert scheduled_job_ids == ["job-123"]
     assert "No additional Roo points will be charged" in body["text"]
+
+
+def test_confirm_topic_action_routes_delegated_confirmation_to_effective_user(monkeypatch):
+    confirm_calls = []
+
+    class FakeConfirmClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def confirm_article_topic(self, **kwargs):
+            confirm_calls.append(kwargs)
+            return {"job_id": "job-123", "status": "confirmed"}
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+        ),
+    )
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeConfirmClient)
+    monkeypatch.setattr(main_module, "_remember_content_thread_context", lambda *args, **kwargs: None)
+
+    payload = {
+        "user": {"id": "U05QPB483K9"},
+        "channel": {"id": "C123"},
+        "message": {
+            "ts": "111.222",
+            "thread_ts": "111.222",
+            "text": "Choose a topic",
+        },
+        "actions": [
+            {
+                "action_id": "confirm_topic",
+                "value": json.dumps(
+                    {
+                        "action": "confirm_topic",
+                        "keyword": "ai agents",
+                        "job_id": "job-123",
+                        "domain": "mlai.au",
+                        "requested_by_slack_user_id": "U05QPB483K9",
+                        "effective_slack_user_id": "U0AQV5X9G0J",
+                    }
+                ),
+            }
+        ],
+    }
+
+    class FakeRequest:
+        async def form(self):
+            return {"payload": json.dumps(payload)}
+
+    response = asyncio.run(main_module.slack_actions(FakeRequest()))
+
+    assert response.status_code == 200
+    assert confirm_calls == [
+        {
+            "job_id": "job-123",
+            "slack_user_id": "U0AQV5X9G0J",
+            "domain": "mlai.au",
+            "confirmed_keyword": "ai agents",
+            "request_source": "roo_slackbot",
+            "requested_by_slack_user_id": "U05QPB483K9",
+        }
+    ]
 
 
 def test_confirm_topic_btn_action_queues_generation_and_updates_message(monkeypatch):

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -137,6 +137,38 @@ async def test_trigger_repo_scan_sends_request_source(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_trigger_repo_scan_includes_requested_by_when_provided(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured["json"] = kwargs["json"]
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(
+            202,
+            request=request,
+            json={"status": "scan_initiated", "message": "Scan queued successfully."},
+        )
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    await client.trigger_repo_scan(
+        "U0AQV5X9G0J",
+        slack_channel_id="C123",
+        slack_thread_ts="111.222",
+        domain="studynash.co",
+        requested_by_slack_user_id="U05QPB483K9",
+    )
+
+    assert captured["json"]["slack_user_id"] == "U0AQV5X9G0J"
+    assert captured["json"]["requested_by_slack_user_id"] == "U05QPB483K9"
+
+
+@pytest.mark.asyncio
 async def test_confirm_article_topic_raises_backend_unavailable_on_503(monkeypatch):
     async def fake_request(method, endpoint, **kwargs):
         request = httpx.Request(method, f"https://backend.test{endpoint}")
@@ -163,3 +195,30 @@ async def test_confirm_article_topic_raises_backend_unavailable_on_503(monkeypat
             slack_user_id="U123",
             confirmed_keyword="ai agents",
         )
+
+
+@pytest.mark.asyncio
+async def test_confirm_article_topic_includes_requested_by_when_provided(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured["json"] = kwargs["json"]
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(200, request=request, json={"status": "confirmed"})
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    await client.confirm_article_topic(
+        job_id="job-123",
+        slack_user_id="U0AQV5X9G0J",
+        confirmed_keyword="ai agents",
+        requested_by_slack_user_id="U05QPB483K9",
+    )
+
+    assert captured["json"]["slack_user_id"] == "U0AQV5X9G0J"
+    assert captured["json"]["requested_by_slack_user_id"] == "U05QPB483K9"


### PR DESCRIPTION
## Summary

- add delegated `as <@user>` support for content-factory scan, write, and discovery flows
- carry separate requester and effective Slack identities through thread context, callbacks, pending intents, and button payloads
- keep billing and Slack ownership on the requester while using the effective user for repo/auth-sensitive backend calls

## Why

Roo was still treating the requesting Slack user as the auth user during delegated content-factory actions. That broke cases like `@Roo scan studynash.co as @Dev`, especially across repeat-scan confirmations and follow-up actions.

## Validation

- `pytest -q roo-standalone/roo/tests/test_agent_routing.py roo-standalone/roo/tests/test_mlai_backend_client.py roo-standalone/roo/tests/test_content_factory_article_flow.py -q`
- `python3 -m py_compile roo-standalone/roo/main.py roo-standalone/roo/skills/executor.py roo-standalone/roo/agent.py roo-standalone/roo/content_intent.py roo-standalone/roo/clients/mlai_backend.py`

## Notes

- Content Factory support for `requested_by_slack_user_id` and delegated callback routing is already present on `content-factory` `main`; this PR wires Roo to use it end-to-end.
