### PR TITLE
[codex] Handle registry-driven SEO publish targets in Roo

### DIFF
--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -174,6 +174,193 @@ def _content_factory_identity_payload(
     return payload
 
 
+def _is_registry_driven_publish_target(target: Any) -> bool:
+    if not isinstance(target, dict):
+        return False
+    strategy = target.get("registration_strategy")
+    if not isinstance(strategy, dict):
+        strategy = {}
+    return (
+        str(target.get("kind") or "").strip() == "registry_driven_seo"
+        or str(target.get("delivery_adapter") or "").strip() == "registry_entry"
+        or str(strategy.get("type") or "").strip() == "registry_entry_patch"
+    )
+
+
+def _registry_target_readiness(target: Any) -> dict[str, bool]:
+    if not _is_registry_driven_publish_target(target):
+        return {
+            "structure_ready": False,
+            "mapping_ready": False,
+            "routing_ready": False,
+            "safety_ready": False,
+        }
+    strategy = target.get("registration_strategy") if isinstance(target, dict) else {}
+    if not isinstance(strategy, dict):
+        strategy = {}
+    readiness = target.get("readiness") if isinstance(target, dict) else {}
+    if not isinstance(readiness, dict):
+        readiness = strategy.get("readiness") if isinstance(strategy.get("readiness"), dict) else {}
+    status = str(
+        (target or {}).get("registry_status")
+        or (target or {}).get("status")
+        or readiness.get("status")
+        or ""
+    ).strip()
+    all_ready = status == "publish_ready" or bool(readiness.get("publish_ready"))
+    return {
+        key: bool(readiness.get(key) or all_ready)
+        for key in ("structure_ready", "mapping_ready", "routing_ready", "safety_ready")
+    }
+
+
+def _registry_target_publish_ready(target: Any) -> bool:
+    if not _is_registry_driven_publish_target(target):
+        return False
+    return all(_registry_target_readiness(target).values())
+
+
+def _registry_target_from_article_system(article_system: Any) -> Optional[dict]:
+    if not isinstance(article_system, dict):
+        return None
+    if str(article_system.get("system_type") or "").strip() != "registry_driven_seo":
+        return None
+    registry = article_system.get("registry") if isinstance(article_system.get("registry"), dict) else {}
+    mutation_target = article_system.get("publish_mutation_target")
+    mutation_target_path = (
+        mutation_target.get("registry_path")
+        or mutation_target.get("path")
+        or mutation_target.get("file")
+        if isinstance(mutation_target, dict)
+        else mutation_target
+    )
+    content_source = article_system.get("content_source")
+    content_source_path = (
+        content_source.get("path")
+        or content_source.get("registry_path")
+        or content_source.get("file")
+        if isinstance(content_source, dict)
+        else content_source
+    )
+    registry_path = (
+        registry.get("path")
+        or mutation_target_path
+        or content_source_path
+        or article_system.get("directory_path")
+        or article_system.get("directory_name")
+    )
+    return {
+        "kind": "registry_driven_seo",
+        "delivery_adapter": "registry_entry",
+        "readiness": article_system.get("readiness") if isinstance(article_system.get("readiness"), dict) else {},
+        "diagnostics": article_system.get("diagnostics") if isinstance(article_system.get("diagnostics"), dict) else {},
+        "observability": article_system.get("observability") if isinstance(article_system.get("observability"), dict) else {},
+        "registration_strategy": {
+            "type": "registry_entry_patch",
+            "registry_path": registry_path,
+            "route_template": article_system.get("route_template") or "",
+        },
+    }
+
+
+def _best_registry_driven_target(*sources: Any) -> Optional[dict]:
+    targets: list[dict] = []
+    for source in sources:
+        if not source:
+            continue
+        if isinstance(source, list):
+            candidates = source
+        elif isinstance(source, dict):
+            candidates = source.get("publish_targets") or source.get("targets") or []
+            if _is_registry_driven_publish_target(source):
+                candidates = [source, *list(candidates or [])]
+            else:
+                direct_target = _registry_target_from_article_system(source)
+                nested_target = _registry_target_from_article_system(source.get("article_system"))
+                synthesized = [target for target in (direct_target, nested_target) if target]
+                if synthesized:
+                    candidates = [*list(candidates or []), *synthesized]
+        else:
+            candidates = []
+        for candidate in candidates:
+            if isinstance(candidate, dict) and _is_registry_driven_publish_target(candidate):
+                targets.append(candidate)
+    if not targets:
+        return None
+    return next((target for target in targets if _registry_target_publish_ready(target)), None) or targets[0]
+
+
+def _registry_target_path(target: Optional[dict], article_system: Optional[dict] = None) -> str:
+    target = target or {}
+    article_system = article_system or {}
+    strategy = target.get("registration_strategy") if isinstance(target.get("registration_strategy"), dict) else {}
+    registry = article_system.get("registry") if isinstance(article_system.get("registry"), dict) else {}
+    return str(
+        strategy.get("registry_path")
+        or target.get("registry_path")
+        or target.get("content_source")
+        or registry.get("path")
+        or article_system.get("directory_path")
+        or article_system.get("directory_name")
+        or "the detected registry"
+    ).strip()
+
+
+def _registry_target_issues(target: Optional[dict], article_system: Optional[dict] = None) -> list[str]:
+    issues: list[str] = []
+    target = target or {}
+    article_system = article_system or {}
+    strategy = target.get("registration_strategy") if isinstance(target.get("registration_strategy"), dict) else {}
+    for key, ready in _registry_target_readiness(target).items():
+        if not ready:
+            issues.append(f"{key.replace('_', ' ')} is not proven")
+    for source in (
+        target.get("diagnostics"),
+        strategy.get("diagnostics"),
+        article_system.get("diagnostics"),
+        target.get("observability"),
+        article_system.get("observability"),
+    ):
+        if not isinstance(source, dict):
+            continue
+        for key in ("issues", "blocking_issues", "fallback_reasons"):
+            raw_items = source.get(key)
+            if isinstance(raw_items, str):
+                raw_items = [raw_items]
+            for item in raw_items or []:
+                text = str(item or "").strip()
+                if text and text not in issues:
+                    issues.append(text)
+        fallback_reason = str(source.get("fallback_reason") or "").strip()
+        if fallback_reason and fallback_reason not in issues:
+            issues.append(fallback_reason)
+    return issues
+
+
+def _registry_target_summary(
+    *,
+    domain: Optional[str],
+    target: Optional[dict],
+    article_system: Optional[dict] = None,
+) -> str:
+    registry_path = _registry_target_path(target, article_system)
+    if _registry_target_publish_ready(target):
+        return (
+            f"I found a registry-driven SEO system at `{registry_path}`. "
+            "Roo can publish new SEO pages by adding typed registry entries through the existing page structure."
+        )
+    issues = _registry_target_issues(target, article_system)
+    issue_text = ""
+    if issues:
+        issue_text = "\n\nBlockers:\n" + "\n".join(f"- {item}" for item in issues[:6])
+    return (
+        f"I found a registry-driven SEO system for *{domain or 'this domain'}* at `{registry_path}`, "
+        f"but it is not safe to patch automatically yet."
+        f"{issue_text}\n\n"
+        "Use content-only delivery for now, or add/confirm a `.content-factory/target.yml` hook after the registry target is proven."
+    )
+
+
 def _is_delegated_content_factory_request(
     requested_by_slack_user_id: Optional[str],
     effective_slack_user_id: Optional[str],
@@ -2048,6 +2235,18 @@ async def content_factory_callback(request: Request):
             scaffold_status = str(payload.get("scaffold_status") or "").strip()
             scaffold_queued = bool(payload.get("scaffold_queued"))
             scaffold_job_id = str(payload.get("scaffold_job_id") or "").strip()
+            article_system = payload.get("article_system") if isinstance(payload.get("article_system"), dict) else {}
+            registry_target = _best_registry_driven_target(payload.get("publish_targets"), payload, article_system)
+            registry_target_ready = _registry_target_publish_ready(registry_target)
+            registry_summary = (
+                _registry_target_summary(
+                    domain=domain,
+                    target=registry_target,
+                    article_system=article_system,
+                )
+                if registry_target
+                else ""
+            )
             approval_required = (
                 requested_action == "scaffold_publish_route"
                 and scaffold_status == "approval_required"
@@ -2143,6 +2342,11 @@ async def content_factory_callback(request: Request):
                         }
                     ]
                 else:
+                    detail_text = (
+                        registry_summary
+                        if registry_summary
+                        else "Scan completed successfully. If you need an articles directory scaffold, run a fresh scan so Roo can request approval-first scaffolding."
+                    )
                     blocks = [
                         {
                             "type": "section",
@@ -2155,17 +2359,22 @@ async def content_factory_callback(request: Request):
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
-                                "text": "Scan completed successfully. If you need an articles directory scaffold, run a fresh scan so Roo can request approval-first scaffolding."
+                                "text": detail_text
                             }
                         }
                     ]
             else:
+                no_component_text = (
+                    f"✅ *Scan complete for {domain}*\n\n{registry_summary}"
+                    if registry_summary
+                    else f"✅ *Scan complete for {domain}*\n\nNo new components were detected."
+                )
                 blocks = [
                     {
                         "type": "section",
                         "text": {
                             "type": "mrkdwn",
-                            "text": f"✅ *Scan complete for {domain}*\n\nNo new components were detected."
+                            "text": no_component_text
                         }
                     }
                 ]
@@ -2257,7 +2466,7 @@ async def content_factory_callback(request: Request):
                                     thread_ts=intent_thread,
                                     text=f"📁 Scan complete! The articles directory setup is already queued for *{domain}*."
                                 )
-                    elif scaffold_status == "not_needed":
+                    elif scaffold_status == "not_needed" or registry_target_ready:
                         consumed = _get_pending_intent(
                             pending_requested_by_slack_user_id,
                             domain,
@@ -2279,7 +2488,27 @@ async def content_factory_callback(request: Request):
                             post_message(
                                 channel=intent_channel,
                                 thread_ts=intent_thread,
-                                text=f"✅ Scan complete! Your repo already has the publish route Roo needs for *{domain}*."
+                                text=(
+                                    f"Scan complete. Your repo already has the publish route Roo needs for *{domain}*."
+                                    if not registry_target_ready
+                                    else f"Scan complete. Roo found a publish-ready registry-driven SEO system for *{domain}*."
+                                )
+                            )
+                    elif registry_target:
+                        _get_pending_intent(
+                            pending_requested_by_slack_user_id,
+                            domain,
+                            effective_slack_user_id=pending_effective_slack_user_id,
+                            job_id=job_id,
+                            wait_for="scan_complete",
+                            consume=True,
+                        )
+                        print(f"Registry-driven target for {domain} is not publish-ready; not auto-triggering scaffold")
+                        if intent_channel:
+                            post_message(
+                                channel=intent_channel,
+                                thread_ts=intent_thread,
+                                text=registry_summary,
                             )
                     else:
                         _get_pending_intent(

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -2004,6 +2004,216 @@ Keep the response concise but informative."""
             )
 
         return integration.get("github_repo"), domain_info
+
+    @staticmethod
+    def _is_registry_driven_publish_target(target: Any) -> bool:
+        if not isinstance(target, dict):
+            return False
+        strategy = target.get("registration_strategy")
+        if not isinstance(strategy, dict):
+            strategy = {}
+        return (
+            str(target.get("kind") or "").strip() == "registry_driven_seo"
+            or str(target.get("delivery_adapter") or "").strip() == "registry_entry"
+            or str(strategy.get("type") or "").strip() == "registry_entry_patch"
+        )
+
+    @classmethod
+    def _registry_target_readiness(cls, target: Any) -> dict[str, bool]:
+        if not cls._is_registry_driven_publish_target(target):
+            return {
+                "structure_ready": False,
+                "mapping_ready": False,
+                "routing_ready": False,
+                "safety_ready": False,
+            }
+        strategy = target.get("registration_strategy") if isinstance(target, dict) else {}
+        if not isinstance(strategy, dict):
+            strategy = {}
+        readiness = target.get("readiness") if isinstance(target, dict) else {}
+        if not isinstance(readiness, dict):
+            readiness = strategy.get("readiness") if isinstance(strategy.get("readiness"), dict) else {}
+        status = str(
+            (target or {}).get("registry_status")
+            or (target or {}).get("status")
+            or readiness.get("status")
+            or ""
+        ).strip()
+        all_ready = status == "publish_ready" or bool(readiness.get("publish_ready"))
+        return {
+            key: bool(readiness.get(key) or all_ready)
+            for key in ("structure_ready", "mapping_ready", "routing_ready", "safety_ready")
+        }
+
+    @classmethod
+    def _registry_target_publish_ready(cls, target: Any) -> bool:
+        if not cls._is_registry_driven_publish_target(target):
+            return False
+        readiness = cls._registry_target_readiness(target)
+        return all(readiness.values())
+
+    @staticmethod
+    def _registry_target_from_article_system(article_system: Any) -> Optional[dict]:
+        if not isinstance(article_system, dict):
+            return None
+        if str(article_system.get("system_type") or "").strip() != "registry_driven_seo":
+            return None
+        registry = article_system.get("registry") if isinstance(article_system.get("registry"), dict) else {}
+        mutation_target = article_system.get("publish_mutation_target")
+        mutation_target_path = (
+            mutation_target.get("registry_path")
+            or mutation_target.get("path")
+            or mutation_target.get("file")
+            if isinstance(mutation_target, dict)
+            else mutation_target
+        )
+        content_source = article_system.get("content_source")
+        content_source_path = (
+            content_source.get("path")
+            or content_source.get("registry_path")
+            or content_source.get("file")
+            if isinstance(content_source, dict)
+            else content_source
+        )
+        registry_path = (
+            registry.get("path")
+            or mutation_target_path
+            or content_source_path
+            or article_system.get("directory_path")
+            or article_system.get("directory_name")
+        )
+        return {
+            "kind": "registry_driven_seo",
+            "delivery_adapter": "registry_entry",
+            "readiness": article_system.get("readiness") if isinstance(article_system.get("readiness"), dict) else {},
+            "diagnostics": article_system.get("diagnostics") if isinstance(article_system.get("diagnostics"), dict) else {},
+            "observability": article_system.get("observability") if isinstance(article_system.get("observability"), dict) else {},
+            "registration_strategy": {
+                "type": "registry_entry_patch",
+                "registry_path": registry_path,
+                "route_template": article_system.get("route_template") or "",
+            },
+        }
+
+    @classmethod
+    def _best_registry_driven_target(cls, *sources: Any) -> Optional[dict]:
+        targets: list[dict] = []
+        for source in sources:
+            if not source:
+                continue
+            if isinstance(source, list):
+                candidates = source
+            elif isinstance(source, dict):
+                candidates = source.get("publish_targets") or source.get("targets") or []
+                if cls._is_registry_driven_publish_target(source):
+                    candidates = [source, *list(candidates or [])]
+                else:
+                    direct_target = cls._registry_target_from_article_system(source)
+                    nested_target = cls._registry_target_from_article_system(source.get("article_system"))
+                    synthesized = [target for target in (direct_target, nested_target) if target]
+                    if synthesized:
+                        candidates = [*list(candidates or []), *synthesized]
+            else:
+                candidates = []
+            for candidate in candidates:
+                if isinstance(candidate, dict) and cls._is_registry_driven_publish_target(candidate):
+                    targets.append(candidate)
+        if not targets:
+            return None
+        return next((target for target in targets if cls._registry_target_publish_ready(target)), None) or targets[0]
+
+    @staticmethod
+    def _registry_target_path(target: Optional[dict], article_system: Optional[dict] = None) -> str:
+        target = target or {}
+        article_system = article_system or {}
+        strategy = target.get("registration_strategy") if isinstance(target.get("registration_strategy"), dict) else {}
+        registry = article_system.get("registry") if isinstance(article_system.get("registry"), dict) else {}
+        return str(
+            strategy.get("registry_path")
+            or target.get("registry_path")
+            or target.get("content_source")
+            or registry.get("path")
+            or article_system.get("directory_path")
+            or article_system.get("directory_name")
+            or "the detected registry"
+        ).strip()
+
+    @classmethod
+    def _registry_target_issues(cls, target: Optional[dict], article_system: Optional[dict] = None) -> list[str]:
+        issues: list[str] = []
+        target = target or {}
+        article_system = article_system or {}
+        strategy = target.get("registration_strategy") if isinstance(target.get("registration_strategy"), dict) else {}
+        readiness = cls._registry_target_readiness(target)
+        for key, ready in readiness.items():
+            if not ready:
+                issues.append(f"{key.replace('_', ' ')} is not proven")
+
+        diagnostic_sources = [
+            target.get("diagnostics"),
+            strategy.get("diagnostics"),
+            article_system.get("diagnostics"),
+            target.get("observability"),
+            article_system.get("observability"),
+        ]
+        for source in diagnostic_sources:
+            if not isinstance(source, dict):
+                continue
+            for key in ("issues", "blocking_issues", "fallback_reasons"):
+                raw_items = source.get(key)
+                if isinstance(raw_items, str):
+                    raw_items = [raw_items]
+                for item in raw_items or []:
+                    text = str(item or "").strip()
+                    if text and text not in issues:
+                        issues.append(text)
+            fallback_reason = str(source.get("fallback_reason") or "").strip()
+            if fallback_reason and fallback_reason not in issues:
+                issues.append(fallback_reason)
+        return issues
+
+    @classmethod
+    def _registry_target_diagnostic_message(
+        cls,
+        *,
+        domain: str,
+        target: Optional[dict],
+        article_system: Optional[dict] = None,
+    ) -> str:
+        registry_path = cls._registry_target_path(target, article_system)
+        issues = cls._registry_target_issues(target, article_system)
+        issue_text = ""
+        if issues:
+            issue_text = "\n\nBlockers:\n" + "\n".join(f"- {item}" for item in issues[:6])
+        return (
+            f"I found a registry-driven SEO system for *{domain}* at `{registry_path}`, "
+            f"but it is not safe to patch automatically yet."
+            f"{issue_text}\n\n"
+            "Roo stopped before changing the repository. Use content-only delivery for now, "
+            "or add/confirm a `.content-factory/target.yml` hook after the registry target is proven."
+        )
+
+    @classmethod
+    def _registry_target_diagnostic_blocks(
+        cls,
+        *,
+        domain: str,
+        target: Optional[dict],
+        article_system: Optional[dict] = None,
+    ) -> list[dict]:
+        return [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": cls._registry_target_diagnostic_message(
+                        domain=domain,
+                        target=target,
+                        article_system=article_system,
+                    ),
+                },
+            }
+        ]
     
     async def _execute_content_factory(
         self,
@@ -2856,6 +3066,29 @@ Keep the response concise but informative."""
         article_system = (integration or {}).get("article_system") or {}
         if not article_system and domain_info:
             article_system = domain_info.get("article_system") or {}
+        registry_target = self._best_registry_driven_target(integration, domain_info, article_system)
+        registry_target_ready = self._registry_target_publish_ready(registry_target)
+
+        if (
+            topic
+            and registry_target
+            and not registry_target_ready
+            and recommended_next_action in {"scaffold", "confirm_article_system"}
+        ):
+            message = self._registry_target_diagnostic_message(
+                domain=domain,
+                target=registry_target,
+                article_system=article_system,
+            )
+            blocks = self._registry_target_diagnostic_blocks(
+                domain=domain,
+                target=registry_target,
+                article_system=article_system,
+            )
+            if channel_id:
+                post_message(channel_id, f"Registry target needs confirmation for {domain}", thread_ts=thread_ts, blocks=blocks)
+                return self._already_posted_response(message, blocks=blocks)
+            return message
 
         if topic and recommended_next_action == "confirm_article_system":
             original_intent = {
@@ -3084,6 +3317,33 @@ Keep the response concise but informative."""
                             effective_slack_user_id=effective_slack_user_id,
                             domain=domain,
                         )
+                    error_article_system = error_data.get("article_system") or article_system or {}
+                    error_registry_target = self._best_registry_driven_target(
+                        error_data,
+                        integration,
+                        domain_info,
+                        error_article_system,
+                    )
+                    if error_registry_target and not self._registry_target_publish_ready(error_registry_target):
+                        message = self._registry_target_diagnostic_message(
+                            domain=domain,
+                            target=error_registry_target,
+                            article_system=error_article_system,
+                        )
+                        blocks = self._registry_target_diagnostic_blocks(
+                            domain=domain,
+                            target=error_registry_target,
+                            article_system=error_article_system,
+                        )
+                        if channel_id:
+                            post_message(
+                                channel_id,
+                                f"Registry target needs confirmation for {domain}",
+                                thread_ts=thread_ts,
+                                blocks=blocks,
+                            )
+                            return self._already_posted_response(message, blocks=blocks)
+                        return message
                     auth_url = None
                     if domain:
                         try:
@@ -3144,6 +3404,32 @@ Keep the response concise but informative."""
                         or article_system.get("directory_name")
                         or "the detected article directory"
                     )
+                    error_registry_target = self._best_registry_driven_target(
+                        error_data,
+                        integration,
+                        domain_info,
+                        article_system,
+                    )
+                    if error_registry_target and not self._registry_target_publish_ready(error_registry_target):
+                        message = self._registry_target_diagnostic_message(
+                            domain=domain,
+                            target=error_registry_target,
+                            article_system=article_system,
+                        )
+                        blocks = self._registry_target_diagnostic_blocks(
+                            domain=domain,
+                            target=error_registry_target,
+                            article_system=article_system,
+                        )
+                        if channel_id:
+                            post_message(
+                                channel_id,
+                                f"Registry target needs confirmation for {domain}",
+                                thread_ts=thread_ts,
+                                blocks=blocks,
+                            )
+                            return self._already_posted_response(message, blocks=blocks)
+                        return message
                     original_intent = {
                         "action": "write",
                         "client_request_id": params["client_request_id"],

--- a/roo-standalone/roo/tests/test_content_factory_article_flow.py
+++ b/roo-standalone/roo/tests/test_content_factory_article_flow.py
@@ -589,6 +589,130 @@ async def test_requested_domain_bypasses_generic_multi_domain_error(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_publish_ready_registry_target_writes_without_scaffold_prompt(monkeypatch):
+    executor = SkillExecutor()
+    posted_messages = []
+    _patch_content_factory(monkeypatch)
+    FakeContentFactoryClient.domain_integrations["skedy.io"] = {
+        "github_repo": "mesieou/skedy-ai",
+        "domain_github_repo": "mesieou/skedy-ai",
+        "project_scanned": True,
+        "scan_completed": True,
+        "content_research_ready": True,
+        "last_scanned_at": "2026-04-23T00:00:00Z",
+        "last_article": None,
+        "recommended_next_action": "research_article",
+        "registry_driven_seo_ready": True,
+        "article_system": {},
+        "publish_targets": [
+            {
+                "target_id": "registry_driven_seo_shared_lib_seo_public_pages_ts",
+                "kind": "registry_driven_seo",
+                "delivery_adapter": "registry_entry",
+                "registry_status": "publish_ready",
+                "readiness": {
+                    "structure_ready": True,
+                    "mapping_ready": True,
+                    "routing_ready": True,
+                    "safety_ready": True,
+                },
+                "registration_strategy": {
+                    "type": "registry_entry_patch",
+                    "registry_path": "shared/lib/seo/public-pages.ts",
+                },
+            }
+        ],
+        "connected_domains": [
+            {
+                "domain": "skedy.io",
+                "github_repo": "mesieou/skedy-ai",
+                "scanned": True,
+            }
+        ],
+        "selected_domain": "skedy.io",
+    }
+    monkeypatch.setattr(
+        executor_module,
+        "post_message",
+        lambda *args, **kwargs: posted_messages.append({"args": args, "kwargs": kwargs}) or {"ts": "111.222"},
+    )
+
+    result = await executor._execute_content_factory(
+        skill=None,
+        text="write an article for skedy.io about best ai receptionist for tradies australia",
+        params={"domain": "skedy.io", "topic": "best ai receptionist for tradies australia"},
+        user_id="U05QPB483K9",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert result["data"]["content_factory_progress_job_id"] == "job-123"
+    assert FakeContentFactoryClient.last_instance.trigger_calls
+    assert FakeContentFactoryClient.last_instance.trigger_calls[0]["domain"] == "skedy.io"
+    assert "Set Up Articles Directory" not in json.dumps(posted_messages)
+
+
+@pytest.mark.asyncio
+async def test_unsafe_registry_target_shows_diagnostic_instead_of_scaffold_prompt(monkeypatch):
+    executor = SkillExecutor()
+    posted_messages = []
+    _patch_content_factory(monkeypatch)
+    FakeContentFactoryClient.domain_integrations["skedy.io"] = {
+        "github_repo": "mesieou/skedy-ai",
+        "domain_github_repo": "mesieou/skedy-ai",
+        "project_scanned": True,
+        "scan_completed": True,
+        "content_research_ready": True,
+        "last_scanned_at": "2026-04-23T00:00:00Z",
+        "last_article": None,
+        "recommended_next_action": "scaffold",
+        "registry_driven_seo_ready": False,
+        "article_system": {
+            "state": "missing",
+            "system_type": "registry_driven_seo",
+            "directory_path": "shared/lib/seo/public-pages.ts",
+            "readiness": {
+                "structure_ready": True,
+                "mapping_ready": False,
+                "routing_ready": True,
+                "safety_ready": False,
+            },
+            "diagnostics": {
+                "issues": ["route field is ambiguous"],
+            },
+        },
+        "connected_domains": [
+            {
+                "domain": "skedy.io",
+                "github_repo": "mesieou/skedy-ai",
+                "scanned": True,
+            }
+        ],
+        "selected_domain": "skedy.io",
+    }
+    monkeypatch.setattr(
+        executor_module,
+        "post_message",
+        lambda *args, **kwargs: posted_messages.append({"args": args, "kwargs": kwargs}) or {"ts": "111.222"},
+    )
+
+    result = await executor._execute_content_factory(
+        skill=None,
+        text="write an article for skedy.io about best ai receptionist for tradies australia",
+        params={"domain": "skedy.io", "topic": "best ai receptionist for tradies australia"},
+        user_id="U05QPB483K9",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert result["suppress_post"] is True
+    assert "registry-driven SEO system" in result["message"]
+    assert "route field is ambiguous" in result["message"]
+    assert "Set Up Articles Directory" not in json.dumps(posted_messages)
+    assert FakeContentFactoryClient.last_instance.trigger_calls == []
+
+
+@pytest.mark.asyncio
 async def test_delegated_article_request_uses_effective_user_for_backend_and_requester_for_billing(monkeypatch):
     executor = SkillExecutor()
     _patch_content_factory(monkeypatch)
@@ -2854,6 +2978,97 @@ def test_scan_complete_auto_write_resumes_when_scaffold_not_needed(monkeypatch):
     assert scheduled_job_ids == ["article-job-123"]
     assert main_module._pending_intents == {}
     assert posted_messages
+
+
+def test_scan_complete_auto_write_resumes_for_publish_ready_registry_target(monkeypatch):
+    posted_messages = []
+    trigger_calls = []
+
+    main_module._remember_pending_intent(
+        "U05QPB483K9",
+        "skedy.io",
+        intent_data={
+            "action": "write",
+            "topic": "best ai receptionist for tradies australia",
+            "target_keyword": "best ai receptionist for tradies australia",
+        },
+        channel_id="C123",
+        thread_ts="111.222",
+        wait_for="scan_complete",
+    )
+
+    class FakeAutoContinueClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def trigger_article_generation(self, **kwargs):
+            trigger_calls.append(kwargs)
+            return {"job_id": "article-job-registry-123"}
+
+    def capture_task(coro):
+        try:
+            coro.send(None)
+        except StopIteration:
+            pass
+        return SimpleNamespace(cancel=lambda: None)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+        ),
+    )
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeAutoContinueClient)
+    monkeypatch.setattr(
+        main_module,
+        "post_message",
+        lambda *args, **kwargs: (
+            posted_messages.append((args, kwargs)) or {"ts": "live-status-001"}
+        ),
+    )
+    monkeypatch.setattr(
+        slack_client_module,
+        "get_user_info",
+        lambda user_id: {
+            "id": user_id,
+            "email": "sam@example.com",
+            "real_name": "Sam Donegan",
+            "image_192": "https://avatar.test/sam.png",
+        },
+    )
+    monkeypatch.setattr(main_module, "_watch_content_factory_quiet_run", lambda job_id: None)
+    monkeypatch.setattr(asyncio, "create_task", capture_task)
+
+    payload = {
+        "event_type": "scan_complete",
+        "slack_user_id": "U05QPB483K9",
+        "job_id": "scan-job-registry-123",
+        "domain": "skedy.io",
+        "channel_id": "C123",
+        "thread_ts": "111.222",
+        "components_count": 0,
+        "article_system": {
+            "system_type": "registry_driven_seo",
+            "directory_path": "shared/lib/seo/public-pages.ts",
+            "readiness": {
+                "publish_ready": True,
+            },
+        },
+    }
+
+    class FakeRequest:
+        async def json(self):
+            return payload
+
+    response = asyncio.run(main_module.content_factory_callback(FakeRequest()))
+
+    assert response == {"status": "ok"}
+    assert len(trigger_calls) == 1
+    assert trigger_calls[0]["domain"] == "skedy.io"
+    assert "registry-driven SEO system" in posted_messages[0][1]["blocks"][0]["text"]["text"]
 
 
 def test_scan_complete_does_not_auto_scaffold_without_approval_metadata(monkeypatch):


### PR DESCRIPTION
## Summary

Updates Roo so registry-driven SEO systems returned by Content Factory are handled as first-class publish targets instead of being treated like missing article scaffolds.

## Changes

- Detects registry-driven SEO targets from either explicit `publish_targets` or `article_system` metadata.
- Allows publish-ready registry targets to continue article generation without prompting for scaffold setup.
- Shows actionable diagnostics and stops before repository mutation when registry patchability is not proven.
- Makes scan-complete callbacks resume pending writes for publish-ready registry targets.
- Adds focused tests for ready targets, unsafe diagnostics, and scan-complete auto-resume.

## Validation

- `PYTHONPYCACHEPREFIX=/tmp/roo-pycache python3 -m py_compile roo/skills/executor.py roo/main.py roo/tests/test_content_factory_article_flow.py`
- `git diff --check`

The targeted pytest command was not run locally because `pytest` is not installed on PATH in this shell.