### PR TITLE
[codex] Add Roo coworking report command

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -1002,6 +1002,24 @@ class MLAIBackendClient:
         response.raise_for_status()
         return response.json()
 
+    async def get_coworking_report(self, slack_user_id: str, start_date: str, end_date: str) -> dict:
+        """Get active coworking booking report for an inclusive date range."""
+        response = await self._request(
+            "GET",
+            f"{self._points_base}/coworking/report/",
+            params={
+                "slack_user_id": self._clean_slack_id(slack_user_id),
+                "start_date": start_date,
+                "end_date": end_date,
+            },
+            timeout=15.0,
+            transport_retries=1,
+            retry_backoff_seconds=0.25,
+            circuit_breaker=True,
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def book_coworking(self, slack_user_id: str, booking_date: str, slack_channel_id: Optional[str] = None) -> dict:
         """Book a coworking day."""
         try:

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -9,7 +9,9 @@ Follows Anthropic's Agent Skills pattern for execution.
 import json
 import re
 import asyncio
+import calendar
 from dataclasses import dataclass
+from datetime import date, timedelta
 from typing import Any, Optional, List
 from difflib import SequenceMatcher
 from uuid import uuid4
@@ -3921,6 +3923,16 @@ Keep the response concise but informative."""
         if explicit_points_request:
             return "request_points"
 
+        if action in [
+            "coworking_report",
+            "report_coworking",
+            "coworking_summary",
+            "coworking_overview",
+        ]:
+            return "coworking_report"
+        if action in ["report", "summary", "overview"] and "coworking" in text_lower:
+            return "coworking_report"
+
         if action == "book":
             action = "book_coworking"
         elif action in ["create", "task", "create_task"]:
@@ -3942,6 +3954,11 @@ Keep the response concise but informative."""
             return "claim_task"
         if "submit" in text_lower:
             return "submit_task"
+        if "coworking" in text_lower and any(
+            w in text_lower
+            for w in ["report", "summary", "overview", "how many users", "attendance"]
+        ):
+            return "coworking_report"
         if any(w in text_lower for w in ["coworking check", "check coworking", "availability"]):
             return "check_coworking"
         if any(w in text_lower for w in ["coworking book", "book coworking", "book me"]):
@@ -4000,6 +4017,13 @@ Keep the response concise but informative."""
         return (
             f"Sorry mate, only <@{POINTS_SUPER_ADMIN_SLACK_ID}> can manage "
             "Points Admin access and weekly allowances. 🔒"
+        )
+
+    def _coworking_report_super_admin_denial(self) -> str:
+        """Fixed denial response for coworking booking reports."""
+        return (
+            f"Sorry mate, only <@{POINTS_SUPER_ADMIN_SLACK_ID}> can generate "
+            "coworking reports. 🔒"
         )
 
     def _is_points_admin_promotion_command(self, text: str) -> bool:
@@ -4179,6 +4203,118 @@ Keep the response concise but informative."""
                 param_targets.append(cleaned_target)
 
         return bool(param_targets) and all(param_target == user_id for param_target in param_targets)
+
+    def _shift_months(self, value: date, months: int) -> date:
+        """Move a date by calendar months, clamping to the target month's end."""
+        target_month_index = value.month - 1 + months
+        target_year = value.year + target_month_index // 12
+        target_month = target_month_index % 12 + 1
+        target_day = min(value.day, calendar.monthrange(target_year, target_month)[1])
+        return date(target_year, target_month, target_day)
+
+    def _resolve_coworking_report_range(self, text: str, params: dict) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Resolve coworking report start/end dates from presets, params, or text."""
+        text_lower = text.lower()
+        months = None
+        if re.search(r"\blast\s+3\s+months?\b", text_lower):
+            months = 3
+        elif re.search(r"\blast\s+6\s+months?\b", text_lower):
+            months = 6
+        elif re.search(r"\b(?:last|past)\s+(?:1\s+)?years?\b", text_lower) or re.search(
+            r"\blast\s+12\s+months?\b",
+            text_lower,
+        ):
+            months = 12
+
+        if months:
+            from ..utils import get_current_date
+
+            today = get_current_date()
+            start = self._shift_months(today, -months) + timedelta(days=1)
+            return start.isoformat(), today.isoformat(), None
+
+        start_date = params.get("start_date") or params.get("from_date")
+        end_date = params.get("end_date") or params.get("to_date")
+        iso_dates = re.findall(r"\b\d{4}-\d{2}-\d{2}\b", text)
+        if len(iso_dates) >= 2:
+            start_date, end_date = iso_dates[0], iso_dates[1]
+
+        if not start_date or not end_date:
+            return (
+                None,
+                None,
+                "Give me a start date and end date, like `coworking report from 2026-01-01 to 2026-03-31`, "
+                "or ask for `coworking report last 3 months`.",
+            )
+
+        try:
+            start = date.fromisoformat(str(start_date))
+            end = date.fromisoformat(str(end_date))
+        except ValueError:
+            return None, None, "Use ISO dates for coworking reports, like `2026-01-01`."
+
+        range_days = (end - start).days + 1
+        if range_days <= 0:
+            return None, None, "The coworking report end date must be on or after the start date."
+        if range_days > 366:
+            return None, None, "Coworking reports are limited to 366 days. Try a shorter date range."
+
+        return start.isoformat(), end.isoformat(), None
+
+    def _format_coworking_report(self, report: dict) -> str:
+        """Format a coworking booking report for Slack."""
+        report_range = report.get("range", {})
+        totals = report.get("totals", {})
+        daily = report.get("daily", [])
+        weekly = report.get("weekly", [])
+        monthly = report.get("monthly", [])
+
+        busiest_days = totals.get("busiest_days") or []
+        if busiest_days:
+            busiest = ", ".join(
+                f"{day.get('date')} ({day.get('booked_users', 0)})"
+                for day in busiest_days[:5]
+            )
+            if len(busiest_days) > 5:
+                busiest += f", +{len(busiest_days) - 5} more"
+        else:
+            busiest = "None"
+
+        monthly_lines = ["Month      User-days Active"]
+        for row in monthly:
+            monthly_lines.append(
+                f"{row.get('month', ''):<10} {int(row.get('booked_user_days', 0)):>9} {int(row.get('active_days', 0)):>6}"
+            )
+
+        weekly_lines = ["Week start User-days Active"]
+        for row in weekly:
+            weekly_lines.append(
+                f"{row.get('week_start', ''):<10} {int(row.get('booked_user_days', 0)):>9} {int(row.get('active_days', 0)):>6}"
+            )
+
+        daily_lines = ["Date       Users"]
+        for row in daily:
+            daily_lines.append(f"{row.get('date', ''):<10} {int(row.get('booked_users', 0)):>5}")
+
+        return "\n".join([
+            "🏢 *Coworking report*",
+            f"Range: {report_range.get('start_date')} to {report_range.get('end_date')}",
+            "Source: Active coworking bookings",
+            "",
+            "*Summary*",
+            f"Booked user-days: {totals.get('booked_user_days', 0)}",
+            f"Unique users: {totals.get('unique_users', 0)}",
+            f"Active days: {totals.get('active_days', 0)} of {totals.get('range_days', 0)}",
+            f"Average per day: {totals.get('average_per_day', 0)}",
+            f"Busiest day: {busiest}",
+            "",
+            "*Monthly*",
+            "```\n" + "\n".join(monthly_lines) + "\n```",
+            "*Weekly*",
+            "```\n" + "\n".join(weekly_lines) + "\n```",
+            "*Daily*",
+            "```\n" + "\n".join(daily_lines) + "\n```",
+        ])
 
     async def _handle_points_action(
         self,
@@ -4401,6 +4537,17 @@ Keep the response concise but informative."""
             
             return f"Submitted! 📬 Task #{task_id} is now pending approval.\n\nA Points Admin will review your work soon. Legend! 🦘"
         
+        elif action == "coworking_report":
+            if not self._is_points_super_admin(user_id):
+                return self._coworking_report_super_admin_denial()
+
+            start_date, end_date, error = self._resolve_coworking_report_range(text, params)
+            if error:
+                return error
+
+            report = await client.get_coworking_report(user_id, start_date, end_date)
+            return self._format_coworking_report(report)
+
         elif action == "check_coworking":
             check_date = params.get("date")
             days = params.get("days", 7)
@@ -4425,8 +4572,7 @@ Keep the response concise but informative."""
             booking_date = params.get("date")
             
             # Normalize date aliases
-            if booking_date:
-                from datetime import timedelta
+            if str(booking_date or "").lower() in {"today", "tomorrow"}:
                 from roo.utils import get_current_date
                 today = get_current_date()
 
@@ -4510,8 +4656,7 @@ Keep the response concise but informative."""
             booking_id = params.get("booking_id")
             
             # Normalize date aliases
-            if booking_date:
-                from datetime import timedelta
+            if str(booking_date or "").lower() in {"today", "tomorrow"}:
                 from roo.utils import get_current_date
                 today = get_current_date()
 

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -85,6 +85,19 @@ def test_request_points_phrase_routes_to_points():
     assert skill.name == "mlai-points"
 
 
+def test_coworking_report_wording_routes_to_points():
+    agent = _make_agent()
+
+    for text in [
+        "coworking report last 3 months",
+        "coworking summary last 6 months",
+        "coworking overview from 2026-01-01 to 2026-03-31",
+    ]:
+        skill = agent._select_skill_from_triggers(text)
+        assert skill is not None
+        assert skill.name == "mlai-points"
+
+
 def test_promote_points_admin_phrase_routes_to_points():
     agent = _make_agent()
 

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -137,6 +137,36 @@ async def test_trigger_repo_scan_sends_request_source(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_coworking_report_uses_canonical_endpoint(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["params"] = kwargs["params"]
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(200, request=request, json={"totals": {"booked_user_days": 3}})
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.get_coworking_report("<@U123>", "2026-01-01", "2026-01-31")
+
+    assert result == {"totals": {"booked_user_days": 3}}
+    assert captured["method"] == "GET"
+    assert captured["endpoint"] == "/api/v1/points/coworking/report/"
+    assert captured["params"] == {
+        "slack_user_id": "U123",
+        "start_date": "2026-01-01",
+        "end_date": "2026-01-31",
+    }
+
+
+@pytest.mark.asyncio
 async def test_trigger_repo_scan_includes_requested_by_when_provided(monkeypatch):
     captured = {}
 

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 import sys
+from datetime import date
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -1776,6 +1777,118 @@ async def test_book_coworking_still_succeeds_when_balance_refresh_times_out(tmp_
 
     assert "Booked you in for **2026-04-09**" in result
     assert "Balance remaining" not in result
+
+
+class FakeCoworkingReportClient:
+    def __init__(self):
+        self.calls = []
+
+    async def get_coworking_report(self, slack_user_id, start_date, end_date):
+        self.calls.append((slack_user_id, start_date, end_date))
+        return {
+            "range": {
+                "start_date": start_date,
+                "end_date": end_date,
+                "source": "active_coworking_bookings",
+            },
+            "totals": {
+                "booked_user_days": 3,
+                "unique_users": 2,
+                "active_days": 2,
+                "range_days": 31,
+                "average_per_day": 0.1,
+                "busiest_days": [{"date": start_date, "booked_users": 2}],
+            },
+            "monthly": [
+                {"month": start_date[:7], "booked_user_days": 3, "active_days": 2},
+            ],
+            "weekly": [
+                {"week_start": start_date, "booked_user_days": 3, "active_days": 2},
+            ],
+            "daily": [
+                {"date": start_date, "booked_users": 2},
+                {"date": end_date, "booked_users": 1},
+            ],
+        }
+
+
+@pytest.mark.asyncio
+async def test_coworking_report_exact_range_formats_slack_report():
+    client = FakeCoworkingReportClient()
+    executor = SkillExecutor()
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="coworking_report",
+        params={},
+        text="coworking report from 2026-01-01 to 2026-01-31",
+        user_id=executor_module.POINTS_SUPER_ADMIN_SLACK_ID,
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert client.calls == [
+        (executor_module.POINTS_SUPER_ADMIN_SLACK_ID, "2026-01-01", "2026-01-31")
+    ]
+    assert "Source: Active coworking bookings" in result
+    assert "Booked user-days: 3" in result
+    assert "Unique users: 2" in result
+    assert "*Monthly*" in result
+    assert "*Weekly*" in result
+    assert "*Daily*" in result
+    assert "2026-01" in result
+    assert "2026-01-01" in result
+    assert "```" in result
+
+
+@pytest.mark.asyncio
+async def test_coworking_report_denies_non_super_admin_without_backend_call():
+    client = FakeCoworkingReportClient()
+    executor = SkillExecutor()
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="coworking_report",
+        params={"start_date": "2026-01-01", "end_date": "2026-01-31"},
+        text="coworking report 2026-01-01 2026-01-31",
+        user_id="UOTHER",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "only <@U05QPB483K9> can generate coworking reports" in result
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_coworking_report_last_three_months_uses_current_date(monkeypatch):
+    client = FakeCoworkingReportClient()
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 4, 28))
+
+    await executor._handle_points_action(
+        client=client,
+        action="coworking_report",
+        params={},
+        text="coworking report last 3 months",
+        user_id=executor_module.POINTS_SUPER_ADMIN_SLACK_ID,
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert client.calls == [
+        (executor_module.POINTS_SUPER_ADMIN_SLACK_ID, "2026-01-29", "2026-04-28")
+    ]
+
+
+def test_resolve_points_action_detects_coworking_report_wording():
+    executor = SkillExecutor()
+
+    assert executor._resolve_points_action({}, "coworking summary last 6 months") == "coworking_report"
+    assert executor._resolve_points_action({"action": "report"}, "coworking report last year") == "coworking_report"
 
 
 @pytest.mark.asyncio

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -36,6 +36,7 @@ This skill enables Roo to interact with the MLAI Points System via API, allowing
 - Promote one tagged user to Points Admin
 - Revoke one tagged user's Points Admin access
 - Change one tagged Points Admin's weekly allowance
+- Generate coworking usage reports for date ranges and standard lookback windows
 
 ### Admin Weekly Allowance
 
@@ -53,9 +54,11 @@ Example responses:
 
 ## Parameters
 
-- **action**: The action to perform (required) - e.g., "balance", "request_points", "book_coworking", "claim_task", "submit_task", "award_points", "create_task"
+- **action**: The action to perform (required) - e.g., "balance", "request_points", "book_coworking", "coworking_report", "claim_task", "submit_task", "award_points", "create_task"
 - **task_id**: Task ID number for task-related actions
 - **date**: Date for coworking bookings (YYYY-MM-DD format)
+- **start_date**: Start date for coworking reports (YYYY-MM-DD format)
+- **end_date**: End date for coworking reports (YYYY-MM-DD format)
 - **points**: The number of points to award (integer, positive only)
 - **reason**: A short description of why the points are being awarded or requested
 - **target_user**: A single Slack User ID (e.g., U012ABC) or mention (e.g., <@U012ABC>) of the person receiving points. For single-user awards.
@@ -81,6 +84,10 @@ Parse user messages to identify the action and parameters:
 | `task claim <id>` | claim_task | "I'll claim task 42" |
 | `task submit <id> <text>` | submit_task | "Task 42 done, fixed the typo" |
 | `coworking check <date>` | check_coworking | "Is there space on Dec 20?" |
+| `coworking report from <start> to <end>` | coworking_report | "Coworking report from 2026-01-01 to 2026-03-31" |
+| `coworking report <start> <end>` | coworking_report | "Coworking report 2026-01-01 2026-03-31" |
+| `coworking report last 3/6 months` | coworking_report | "Coworking report last 3 months" |
+| `coworking report last year` | coworking_report | "Coworking report last year" |
 | `coworking book <date/today>` | book_coworking | "Book me in for today", "@Roo coworking book today" |
 | `coworking cancel <date>` | cancel_coworking | "Cancel my booking for Friday", "@Roo coworking cancel" |
 | `rewards`, `points rewards` | list_rewards | "What rewards are available?", "@Roo points rewards" |
@@ -117,6 +124,13 @@ For admin-only actions (create, approve, award):
 
 For super admin actions (promote admin, revoke admin, change allowance):
 - Roo must fail fast unless the requester Slack ID is `U05QPB483K9`
+- The backend must still validate the requester for defense in depth
+
+For coworking report actions:
+- Roo must fail fast unless the requester Slack ID is `U05QPB483K9`
+- Count only active bookings (`status=booked`), not cancelled bookings
+- Support exact inclusive date ranges and presets: last 3 months, last 6 months, last year
+- Format the response as a concise Slack report with summary, monthly, weekly, and daily counts
 - The backend must still validate the requester for defense in depth
 
 ### Step 3: Execute via API


### PR DESCRIPTION
## Summary
- add Roo client support for the coworking report endpoint
- route coworking report, summary, and overview requests through mlai-points
- enforce super-admin-only access and format Slack-friendly daily, weekly, and monthly tables

## Tests
- pytest roo/tests/test_mlai_backend_client.py roo/tests/test_points_requests.py roo/tests/test_agent_routing.py