### PR TITLE
[codex] Handle coworking report backend failures

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -1017,7 +1017,7 @@ class MLAIBackendClient:
             retry_backoff_seconds=0.25,
             circuit_breaker=True,
         )
-        response.raise_for_status()
+        self._raise_for_status_or_backend_unavailable(response)
         return response.json()
 
     async def book_coworking(self, slack_user_id: str, booking_date: str, slack_channel_id: Optional[str] = None) -> dict:

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -3838,6 +3838,7 @@ Keep the response concise but informative."""
         if ClientClass is None:
             return "Sorry mate, the Points skill isn't properly configured. Missing implementation."
         
+        action = None
         try:
             settings = get_settings()
             if not settings.MLAI_BACKEND_URL:
@@ -3898,6 +3899,8 @@ Keep the response concise but informative."""
                     return f"🛑 {error_detail}"
                 except Exception:
                     return f"Ran into a snag with that request (400 Bad Request)."
+            elif e.response.status_code >= 500:
+                return self._points_backend_unavailable_message(action)
             else:
                 error_detail = self._extract_http_error_detail(e)
                 return f"Ran into a snag: {error_detail or str(e)}"
@@ -3956,7 +3959,15 @@ Keep the response concise but informative."""
             return "submit_task"
         if "coworking" in text_lower and any(
             w in text_lower
-            for w in ["report", "summary", "overview", "how many users", "attendance"]
+            for w in [
+                "report",
+                "summary",
+                "overview",
+                "how many users",
+                "how many people",
+                "used the coworking",
+                "attendance",
+            ]
         ):
             return "coworking_report"
         if any(w in text_lower for w in ["coworking check", "check coworking", "availability"]):
@@ -4148,10 +4159,18 @@ Keep the response concise but informative."""
 
     def _extract_http_error_detail(self, exc: httpx.HTTPStatusError) -> str:
         """Extract a compact error string from a backend HTTP error."""
+        if exc.response.status_code >= 500:
+            return "MLAI backend is temporarily unavailable. Please try again in a moment."
+
         try:
             payload = exc.response.json()
         except ValueError:
-            return exc.response.text.strip()
+            body = exc.response.text.strip()
+            body_lower = body.lower()
+            content_type = exc.response.headers.get("content-type", "").lower()
+            if "<!doctype html" in body_lower or "<html" in body_lower or "html" in content_type:
+                return "MLAI backend returned an unexpected error response. Please try again in a moment."
+            return body
         except Exception:
             return ""
 
@@ -4215,6 +4234,13 @@ Keep the response concise but informative."""
     def _resolve_coworking_report_range(self, text: str, params: dict) -> tuple[Optional[str], Optional[str], Optional[str]]:
         """Resolve coworking report start/end dates from presets, params, or text."""
         text_lower = text.lower()
+        if re.search(r"\bthis\s+week\b", text_lower):
+            from ..utils import get_current_date
+
+            today = get_current_date()
+            start = today - timedelta(days=today.weekday())
+            return start.isoformat(), today.isoformat(), None
+
         months = None
         if re.search(r"\blast\s+3\s+months?\b", text_lower):
             months = 3

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -92,6 +92,7 @@ def test_coworking_report_wording_routes_to_points():
         "coworking report last 3 months",
         "coworking summary last 6 months",
         "coworking overview from 2026-01-01 to 2026-03-31",
+        "how many people used the coworking space this week",
     ]:
         skill = agent._select_skill_from_triggers(text)
         assert skill is not None

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -167,6 +167,32 @@ async def test_get_coworking_report_uses_canonical_endpoint(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_coworking_report_503_raises_backend_unavailable(monkeypatch):
+    async def fake_request(method, endpoint, **kwargs):
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(
+            503,
+            request=request,
+            json={
+                "status": "error",
+                "message": "Points subsystem is temporarily unavailable",
+                "error_code": "database_connection_interrupted",
+                "retryable": True,
+            },
+        )
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    with pytest.raises(MLAIBackendUnavailableError, match="Points subsystem is temporarily unavailable"):
+        await client.get_coworking_report("U123", "2026-01-01", "2026-01-31")
+
+
+@pytest.mark.asyncio
 async def test_trigger_repo_scan_includes_requested_by_when_provided(monkeypatch):
     captured = {}
 

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -1884,11 +1884,98 @@ async def test_coworking_report_last_three_months_uses_current_date(monkeypatch)
     ]
 
 
+@pytest.mark.asyncio
+async def test_coworking_report_this_week_uses_monday_through_today(monkeypatch):
+    client = FakeCoworkingReportClient()
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 4, 28))
+
+    await executor._handle_points_action(
+        client=client,
+        action="coworking_report",
+        params={},
+        text="how many people used the coworking space this week",
+        user_id=executor_module.POINTS_SUPER_ADMIN_SLACK_ID,
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert client.calls == [
+        (executor_module.POINTS_SUPER_ADMIN_SLACK_ID, "2026-04-27", "2026-04-28")
+    ]
+
+
+def test_extract_http_error_detail_suppresses_html_500_body():
+    executor = SkillExecutor()
+    request = httpx.Request("GET", "https://backend.test/api/v1/points/coworking/report/")
+    response = httpx.Response(
+        500,
+        request=request,
+        text="<!doctype html><html><body><h1>Server Error (500)</h1></body></html>",
+    )
+    exc = httpx.HTTPStatusError("server error", request=request, response=response)
+
+    detail = executor._extract_http_error_detail(exc)
+
+    assert "<!doctype html>" not in detail
+    assert "temporarily unavailable" in detail
+
+
+@pytest.mark.asyncio
+async def test_execute_mlai_points_html_500_uses_backend_unavailable_message(monkeypatch):
+    executor = SkillExecutor()
+    skill = SimpleNamespace(name="mlai-points")
+
+    async def fake_handle_points_action(**kwargs):
+        request = httpx.Request(
+            "GET",
+            "https://backend.test/api/v1/points/coworking/report/",
+        )
+        response = httpx.Response(
+            500,
+            request=request,
+            text="<!doctype html><html><body><h1>Server Error (500)</h1></body></html>",
+        )
+        raise httpx.HTTPStatusError("server error", request=request, response=response)
+
+    monkeypatch.setattr(executor, "_handle_points_action", fake_handle_points_action)
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+            INTERNAL_API_KEY="internal-key",
+        ),
+    )
+
+    result = await executor._execute_mlai_points(
+        skill=skill,
+        text="how many people used the coworking space this week",
+        params={},
+        user_id=executor_module.POINTS_SUPER_ADMIN_SLACK_ID,
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert "<!doctype html>" not in result
+    assert "couldn't reach the MLAI points backend" in result
+
+
 def test_resolve_points_action_detects_coworking_report_wording():
     executor = SkillExecutor()
 
     assert executor._resolve_points_action({}, "coworking summary last 6 months") == "coworking_report"
     assert executor._resolve_points_action({"action": "report"}, "coworking report last year") == "coworking_report"
+    assert (
+        executor._resolve_points_action(
+            {},
+            "how many people used the coworking space this week",
+        )
+        == "coworking_report"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Convert coworking report backend JSON 503s into the existing MLAI backend unavailable path.
- Suppress raw HTML/5xx backend bodies in Slack-facing error messages.
- Add deterministic `this week` parsing as Monday through today using the configured Roo date helper.
- Route natural wording like “how many people used the coworking space this week” to the coworking report action.

## Root Cause
Roo was calling the coworking report endpoint with raw `raise_for_status()`, then surfacing backend error bodies directly for non-special HTTP failures. That allowed backend HTML 500 pages to be posted into Slack.

## Validation
- `pytest roo/tests/test_mlai_backend_client.py roo/tests/test_points_requests.py roo/tests/test_agent_routing.py`