### PR TITLE
[codex] Allow points admins to request coworking reports

### DIFF
--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -4030,11 +4030,10 @@ Keep the response concise but informative."""
             "Points Admin access and weekly allowances. 🔒"
         )
 
-    def _coworking_report_super_admin_denial(self) -> str:
+    def _coworking_report_points_admin_denial(self) -> str:
         """Fixed denial response for coworking booking reports."""
         return (
-            f"Sorry mate, only <@{POINTS_SUPER_ADMIN_SLACK_ID}> can generate "
-            "coworking reports. 🔒"
+            "Sorry mate, you'll need to be a Points Admin to generate coworking reports. 🔒"
         )
 
     def _is_points_admin_promotion_command(self, text: str) -> bool:
@@ -4234,6 +4233,15 @@ Keep the response concise but informative."""
     def _resolve_coworking_report_range(self, text: str, params: dict) -> tuple[Optional[str], Optional[str], Optional[str]]:
         """Resolve coworking report start/end dates from presets, params, or text."""
         text_lower = text.lower()
+        if re.search(r"\blast\s+week\b", text_lower):
+            from ..utils import get_current_date
+
+            today = get_current_date()
+            current_sunday_start = today - timedelta(days=(today.weekday() + 1) % 7)
+            start = current_sunday_start - timedelta(days=7)
+            end = current_sunday_start - timedelta(days=1)
+            return start.isoformat(), end.isoformat(), None
+
         if re.search(r"\bthis\s+week\b", text_lower):
             from ..utils import get_current_date
 
@@ -4564,8 +4572,8 @@ Keep the response concise but informative."""
             return f"Submitted! 📬 Task #{task_id} is now pending approval.\n\nA Points Admin will review your work soon. Legend! 🦘"
         
         elif action == "coworking_report":
-            if not self._is_points_super_admin(user_id):
-                return self._coworking_report_super_admin_denial()
+            if not await client.get_admin_details(user_id):
+                return self._coworking_report_points_admin_denial()
 
             start_date, end_date, error = self._resolve_coworking_report_range(text, params)
             if error:

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -93,6 +93,7 @@ def test_coworking_report_wording_routes_to_points():
         "coworking summary last 6 months",
         "coworking overview from 2026-01-01 to 2026-03-31",
         "how many people used the coworking space this week",
+        "give me a report for how many people used the coworking space last week",
     ]:
         skill = agent._select_skill_from_triggers(text)
         assert skill is not None

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -1780,8 +1780,16 @@ async def test_book_coworking_still_succeeds_when_balance_refresh_times_out(tmp_
 
 
 class FakeCoworkingReportClient:
-    def __init__(self):
+    def __init__(self, admin_slack_ids=None):
         self.calls = []
+        self.admin_checks = []
+        self.admin_slack_ids = set(admin_slack_ids or [executor_module.POINTS_SUPER_ADMIN_SLACK_ID])
+
+    async def get_admin_details(self, slack_user_id):
+        self.admin_checks.append(slack_user_id)
+        if slack_user_id not in self.admin_slack_ids:
+            return None
+        return {"slack_user_id": slack_user_id, "role": "admin"}
 
     async def get_coworking_report(self, slack_user_id, start_date, end_date):
         self.calls.append((slack_user_id, start_date, end_date))
@@ -1843,7 +1851,28 @@ async def test_coworking_report_exact_range_formats_slack_report():
 
 
 @pytest.mark.asyncio
-async def test_coworking_report_denies_non_super_admin_without_backend_call():
+async def test_coworking_report_allows_points_admin():
+    client = FakeCoworkingReportClient(admin_slack_ids=["UPOINTSADMIN"])
+    executor = SkillExecutor()
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="coworking_report",
+        params={"start_date": "2026-01-01", "end_date": "2026-01-31"},
+        text="coworking report 2026-01-01 2026-01-31",
+        user_id="UPOINTSADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert client.admin_checks == ["UPOINTSADMIN"]
+    assert client.calls == [("UPOINTSADMIN", "2026-01-01", "2026-01-31")]
+    assert "Source: Active coworking bookings" in result
+
+
+@pytest.mark.asyncio
+async def test_coworking_report_denies_non_points_admin_without_report_call():
     client = FakeCoworkingReportClient()
     executor = SkillExecutor()
 
@@ -1858,7 +1887,8 @@ async def test_coworking_report_denies_non_super_admin_without_backend_call():
         skill=SimpleNamespace(name="mlai-points"),
     )
 
-    assert "only <@U05QPB483K9> can generate coworking reports" in result
+    assert "need to be a Points Admin to generate coworking reports" in result
+    assert client.admin_checks == ["UOTHER"]
     assert client.calls == []
 
 
@@ -1903,6 +1933,28 @@ async def test_coworking_report_this_week_uses_monday_through_today(monkeypatch)
 
     assert client.calls == [
         (executor_module.POINTS_SUPER_ADMIN_SLACK_ID, "2026-04-27", "2026-04-28")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_coworking_report_last_week_uses_previous_sunday_through_saturday(monkeypatch):
+    client = FakeCoworkingReportClient()
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 4, 28))
+
+    await executor._handle_points_action(
+        client=client,
+        action="coworking_report",
+        params={},
+        text="give me a report for how many people used the coworking space last week",
+        user_id=executor_module.POINTS_SUPER_ADMIN_SLACK_ID,
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert client.calls == [
+        (executor_module.POINTS_SUPER_ADMIN_SLACK_ID, "2026-04-19", "2026-04-25")
     ]
 
 
@@ -1973,6 +2025,13 @@ def test_resolve_points_action_detects_coworking_report_wording():
         executor._resolve_points_action(
             {},
             "how many people used the coworking space this week",
+        )
+        == "coworking_report"
+    )
+    assert (
+        executor._resolve_points_action(
+            {},
+            "give me a report for how many people used the coworking space last week",
         )
         == "coworking_report"
     )

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -86,6 +86,8 @@ Parse user messages to identify the action and parameters:
 | `coworking check <date>` | check_coworking | "Is there space on Dec 20?" |
 | `coworking report from <start> to <end>` | coworking_report | "Coworking report from 2026-01-01 to 2026-03-31" |
 | `coworking report <start> <end>` | coworking_report | "Coworking report 2026-01-01 2026-03-31" |
+| `coworking report this week` | coworking_report | "How many people used the coworking space this week?" |
+| `coworking report last week` | coworking_report | "How many people used the coworking space last week?" |
 | `coworking report last 3/6 months` | coworking_report | "Coworking report last 3 months" |
 | `coworking report last year` | coworking_report | "Coworking report last year" |
 | `coworking book <date/today>` | book_coworking | "Book me in for today", "@Roo coworking book today" |
@@ -127,9 +129,9 @@ For super admin actions (promote admin, revoke admin, change allowance):
 - The backend must still validate the requester for defense in depth
 
 For coworking report actions:
-- Roo must fail fast unless the requester Slack ID is `U05QPB483K9`
+- Roo must fail fast unless the requester is a Points Admin
 - Count only active bookings (`status=booked`), not cancelled bookings
-- Support exact inclusive date ranges and presets: last 3 months, last 6 months, last year
+- Support exact inclusive date ranges and presets: this week, last week, last 3 months, last 6 months, last year
 - Format the response as a concise Slack report with summary, monthly, weekly, and daily counts
 - The backend must still validate the requester for defense in depth
 


### PR DESCRIPTION
## Summary
- Let any Points Admin request coworking reports through Roo.
- Keep non-admin requesters denied before Roo calls the report endpoint.
- Add support and tests for `last week` as the previous full Sunday-to-Saturday week.
- Update the mlai-points skill docs for Points Admin report access and report presets.

## Impact
Roo can now answer coworking report requests for any active Points Admin while still keeping report access restricted.

## Validation
- `pytest roo/tests/test_points_requests.py roo/tests/test_agent_routing.py`