### PR TITLE
[codex] Allow partners to request coworking reports

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -13,6 +13,7 @@ import httpx
 from ..config import get_settings
 
 CONTENT_FACTORY_REQUEST_SOURCE = "roo_slackbot"
+FULL_POINTS_ADMIN_ROLES = {"admin", "committee", "portfolio_lead"}
 
 
 class MLAIBackendUnavailableError(RuntimeError):
@@ -1592,13 +1593,16 @@ class MLAIBackendClient:
             return []
 
     async def is_admin(self, slack_user_id: str) -> bool:
-        """Check if a user is a Points Admin (with caching)."""
+        """Check if a user is a full Points Admin (with caching)."""
         if slack_user_id in self._admin_cache:
             return self._admin_cache[slack_user_id]
         
         try:
             details = await self.get_admin_details(slack_user_id)
-            is_admin = details is not None
+            is_admin = (
+                isinstance(details, dict)
+                and str(details.get("role") or "").strip().lower() in FULL_POINTS_ADMIN_ROLES
+            )
             self._admin_cache[slack_user_id] = is_admin
             return is_admin
         except Exception:
@@ -2221,14 +2225,14 @@ class MLAIBackendClient:
     ) -> dict:
         """System award points (bypasses client-side admin checks)."""
         payload = {
-            "admin_slack_id": admin_slack_id,
+            "created_by_slack_id": admin_slack_id,
             "target_slack_id": self._clean_slack_id(target_slack_id),
             "points": points,
             "reason": reason,
         }
         response = await self._request(
             "POST",
-            f"{self._points_base}/admin/award/",
+            f"{self._points_base}/system/award/",
             json=payload,
             timeout=15.0,
             circuit_breaker=True,

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -47,6 +47,8 @@ from ..coworking_booking_intents import (
 
 
 POINTS_SUPER_ADMIN_SLACK_ID = "U05QPB483K9"
+FULL_POINTS_ADMIN_ROLES = {"admin", "committee", "portfolio_lead"}
+COWORKING_REPORT_ROLES = {*FULL_POINTS_ADMIN_ROLES, "partner"}
 
 
 @dataclass
@@ -4208,6 +4210,25 @@ Keep the response concise but informative."""
             "Sorry mate, you'll need to be a Points Admin to generate coworking reports. 🔒"
         )
 
+    def _points_admin_role(self, admin_details: Optional[dict]) -> str:
+        if not isinstance(admin_details, dict):
+            return ""
+        return str(admin_details.get("role") or "").strip().lower()
+
+    def _is_full_points_admin_details(self, admin_details: Optional[dict]) -> bool:
+        return self._points_admin_role(admin_details) in FULL_POINTS_ADMIN_ROLES
+
+    def _can_generate_coworking_report_details(self, admin_details: Optional[dict]) -> bool:
+        return self._points_admin_role(admin_details) in COWORKING_REPORT_ROLES
+
+    def _full_points_admin_denial(self, admin_details: Optional[dict], action_label: str) -> str:
+        if self._points_admin_role(admin_details) == "partner":
+            return (
+                f"Sorry mate, partner admins can only generate coworking reports. "
+                f"You need a full Points Admin role to {action_label}. 🔒"
+            )
+        return f"Sorry mate, you'll need to be a full Points Admin to {action_label}. 🔒"
+
     def _is_points_admin_promotion_command(self, text: str) -> bool:
         """Detect commands that promote a tagged user to Points Admin."""
         return bool(
@@ -4784,7 +4805,8 @@ Keep the response concise but informative."""
             return f"Submitted! 📬 Task {display_id} is now pending approval.\n\nA reviewer will take a look soon. Legend! 🦘"
         
         elif action == "coworking_report":
-            if not await client.get_admin_details(user_id):
+            admin_details = await client.get_admin_details(user_id)
+            if not self._can_generate_coworking_report_details(admin_details):
                 return self._coworking_report_points_admin_denial()
 
             start_date, end_date, error = self._resolve_coworking_report_range(text, params)
@@ -5095,16 +5117,15 @@ Keep the response concise but informative."""
             title = params.get("task_title") or params.get("title") or params.get("submission_text")
             points = params.get("points")
             description = params.get("description", "")
+            admin_details = await client.get_admin_details(user_id)
+
+            if not self._is_full_points_admin_details(admin_details):
+                return self._full_points_admin_denial(admin_details, "create tasks")
             
             # Default portfolio logic: Param > Admin's Portfolio > "events"
             portfolio = params.get("portfolio")
-            if not portfolio:
-                try:
-                    admin_details = await client.get_admin_details(user_id)
-                    if admin_details:
-                        portfolio = admin_details.get("portfolio")
-                except Exception as e:
-                    print(f"⚠️ Failed to lookup admin portfolio: {e}")
+            if not portfolio and admin_details:
+                portfolio = admin_details.get("portfolio")
             
             if not portfolio:
                 portfolio = "events" # Fallback if lookup fails
@@ -5155,6 +5176,10 @@ Keep the response concise but informative."""
             if not task_id:
                 return "Which task do you want to edit? Give me the task ID or code."
 
+            admin_details = await client.get_admin_details(user_id)
+            if not self._is_full_points_admin_details(admin_details):
+                return self._full_points_admin_denial(admin_details, "edit tasks")
+
             current_task = await client.get_task(task_id)
             updates = self._extract_task_edit_updates(params, text)
             if not updates:
@@ -5179,6 +5204,10 @@ Keep the response concise but informative."""
             task_id = self._extract_task_identifier(text, params.get("task_id"))
             if not task_id:
                 return "Which task do you want to cancel? Give me the task ID or code."
+
+            admin_details = await client.get_admin_details(user_id)
+            if not self._is_full_points_admin_details(admin_details):
+                return self._full_points_admin_denial(admin_details, "cancel tasks")
 
             reason = params.get("reason", "")
             result = await client.cancel_task(task_id, user_id, reason=reason)
@@ -5205,6 +5234,10 @@ Keep the response concise but informative."""
             if not task_id:
                 return "Which task are you approving? Give me the task ID or code (e.g., \"task approve 42\" or \"task approve ROO-0042\")"
 
+            admin_details = await client.get_admin_details(user_id)
+            if not self._is_full_points_admin_details(admin_details):
+                return self._full_points_admin_denial(admin_details, "approve tasks")
+
             result = await client.approve_task(task_id, user_id)
             points_awarded = result.get("points_awarded", 0)
             task = result.get("task", {})
@@ -5218,6 +5251,10 @@ Keep the response concise but informative."""
             
             if not task_id:
                 return "Which task are you rejecting? Give me the task ID or code."
+
+            admin_details = await client.get_admin_details(user_id)
+            if not self._is_full_points_admin_details(admin_details):
+                return self._full_points_admin_denial(admin_details, "reject tasks")
             
             result = await client.reject_task(task_id, user_id, reason)
             task = result.get("task", {})
@@ -5262,6 +5299,10 @@ Keep the response concise but informative."""
                     thread_ts=thread_ts,
                     skill=skill,
                 )
+
+            admin_details = await client.get_admin_details(user_id)
+            if not self._is_full_points_admin_details(admin_details):
+                return self._full_points_admin_denial(admin_details, "award points")
 
             # Early allowance check for award actions (before LLM/rate card lookup)
             if action in ["award_points", "award"]:

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -193,6 +193,22 @@ async def test_get_coworking_report_503_raises_backend_unavailable(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_is_admin_excludes_report_only_partner(monkeypatch):
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+
+    async def fake_get_admin_details(slack_user_id):
+        return {"slack_user_id": slack_user_id, "role": "partner"}
+
+    monkeypatch.setattr(client, "get_admin_details", fake_get_admin_details)
+
+    assert await client.is_admin("UPARTNER") is False
+
+
+@pytest.mark.asyncio
 async def test_trigger_repo_scan_includes_requested_by_when_provided(monkeypatch):
     captured = {}
 

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -125,6 +125,9 @@ class FakePointsAdminClient:
     def _clean_slack_id(self, user_id):
         return str(user_id).strip("<@>")
 
+    async def get_admin_details(self, slack_user_id):
+        return {"slack_user_id": slack_user_id, "role": "admin"}
+
     async def promote_points_admin(self, requester_slack_id, target_slack_id):
         self.promote_args = (requester_slack_id, target_slack_id)
         return {"target_slack_id": target_slack_id}
@@ -182,6 +185,24 @@ class FakeAwardGuardClient(FakePointsAdminClient):
     async def award_points(self, requester_slack_id, target_slack_id, points, reason):
         self.award_called = True
         return {"points_awarded": points, "new_balance": 999}
+
+
+class FakePartnerRestrictedClient(FakeAwardGuardClient):
+    def __init__(self):
+        super().__init__()
+        self.create_called = False
+        self.approve_called = False
+
+    async def get_admin_details(self, slack_user_id):
+        return {"slack_user_id": slack_user_id, "role": "partner"}
+
+    async def create_task(self, *args, **kwargs):
+        self.create_called = True
+        return {"id": 1}
+
+    async def approve_task(self, *args, **kwargs):
+        self.approve_called = True
+        return {"points_awarded": 5}
 
 
 def test_resolve_points_action_prefers_request_points():
@@ -860,6 +881,86 @@ async def test_award_flow_reroutes_missing_tag_management_phrase_to_clarificatio
     assert client.allowance_lookup_called is False
     assert client.award_called is False
     assert "Tag exactly one user to change their weekly points allowance." == result
+
+
+@pytest.mark.asyncio
+async def test_partner_admin_cannot_award_points(monkeypatch):
+    executor = SkillExecutor()
+    client = FakePartnerRestrictedClient()
+
+    monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UBOT")
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="award_points",
+        params={"points": 5, "reason": "helping out", "target_user": "UTARGET"},
+        text="award <@UTARGET> 5 points for helping out",
+        user_id="UPARTNER",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=None,
+    )
+
+    assert "partner admins can only generate coworking reports" in result
+    assert client.allowance_lookup_called is False
+    assert client.award_called is False
+
+
+@pytest.mark.asyncio
+async def test_partner_admin_cannot_create_or_approve_tasks():
+    executor = SkillExecutor()
+    create_client = FakePartnerRestrictedClient()
+    approve_client = FakePartnerRestrictedClient()
+    edit_client = FakePartnerRestrictedClient()
+    cancel_client = FakePartnerRestrictedClient()
+
+    create_result = await executor._handle_points_action(
+        client=create_client,
+        action="create_task",
+        params={"title": "Partner task", "points": 5, "portfolio": "ops"},
+        text="create task Partner task worth 5 points",
+        user_id="UPARTNER",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=None,
+    )
+    approve_result = await executor._handle_points_action(
+        client=approve_client,
+        action="approve_task",
+        params={"task_id": 42},
+        text="approve task 42",
+        user_id="UPARTNER",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=None,
+    )
+    edit_result = await executor._handle_points_action(
+        client=edit_client,
+        action="edit_task",
+        params={"task_id": 42, "title": "Updated partner task"},
+        text="edit task 42 title to Updated partner task",
+        user_id="UPARTNER",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=None,
+    )
+    cancel_result = await executor._handle_points_action(
+        client=cancel_client,
+        action="cancel_task",
+        params={"task_id": 42},
+        text="cancel task 42",
+        user_id="UPARTNER",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=None,
+    )
+
+    assert "partner admins can only generate coworking reports" in create_result
+    assert "partner admins can only generate coworking reports" in approve_result
+    assert "partner admins can only generate coworking reports" in edit_result
+    assert "partner admins can only generate coworking reports" in cancel_result
+    assert create_client.create_called is False
+    assert approve_client.approve_called is False
 
 
 class FakeApprovalClient:
@@ -1710,6 +1811,40 @@ async def test_backend_client_award_first_channel_post_uses_canonical_endpoint(m
 
 
 @pytest.mark.asyncio
+async def test_backend_client_system_award_points_uses_system_endpoint(monkeypatch):
+    recorder = RecordingAsyncClient(json_data={"points_awarded": 12, "new_balance": 17})
+    monkeypatch.setattr(backend_module.httpx, "AsyncClient", lambda: recorder)
+
+    client = backend_module.MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="api-key",
+        internal_api_key="internal-key",
+    )
+
+    result = await client.system_award_points(
+        admin_slack_id="UROOBOT",
+        target_slack_id="<@UTARGET>",
+        points=12,
+        reason="System award",
+    )
+
+    assert result == {"points_awarded": 12, "new_balance": 17}
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0]["method"] == "POST"
+    assert recorder.calls[0]["url"] == "https://backend.test/api/v1/points/system/award/"
+    assert recorder.calls[0]["json"] == {
+        "created_by_slack_id": "UROOBOT",
+        "target_slack_id": "UTARGET",
+        "points": 12,
+        "reason": "System award",
+    }
+    assert recorder.calls[0]["params"] is None
+    assert recorder.calls[0]["headers"]["Content-Type"] == "application/json"
+    assert recorder.calls[0]["headers"]["X-API-Key"] == "internal-key"
+    assert recorder.calls[0]["timeout"] == 15.0
+
+
+@pytest.mark.asyncio
 async def test_execute_mlai_points_returns_backend_unavailable_message(monkeypatch):
     executor = SkillExecutor()
     skill = SimpleNamespace(name="mlai-points")
@@ -1780,16 +1915,21 @@ async def test_book_coworking_still_succeeds_when_balance_refresh_times_out(tmp_
 
 
 class FakeCoworkingReportClient:
-    def __init__(self, admin_slack_ids=None):
+    def __init__(self, admin_slack_ids=None, admin_roles=None):
         self.calls = []
         self.admin_checks = []
-        self.admin_slack_ids = set(admin_slack_ids or [executor_module.POINTS_SUPER_ADMIN_SLACK_ID])
+        self.admin_roles = {
+            slack_id: "admin"
+            for slack_id in (admin_slack_ids or [executor_module.POINTS_SUPER_ADMIN_SLACK_ID])
+        }
+        self.admin_roles.update(admin_roles or {})
 
     async def get_admin_details(self, slack_user_id):
         self.admin_checks.append(slack_user_id)
-        if slack_user_id not in self.admin_slack_ids:
+        role = self.admin_roles.get(slack_user_id)
+        if not role:
             return None
-        return {"slack_user_id": slack_user_id, "role": "admin"}
+        return {"slack_user_id": slack_user_id, "role": role}
 
     async def get_coworking_report(self, slack_user_id, start_date, end_date):
         self.calls.append((slack_user_id, start_date, end_date))
@@ -1868,6 +2008,27 @@ async def test_coworking_report_allows_points_admin():
 
     assert client.admin_checks == ["UPOINTSADMIN"]
     assert client.calls == [("UPOINTSADMIN", "2026-01-01", "2026-01-31")]
+    assert "Source: Active coworking bookings" in result
+
+
+@pytest.mark.asyncio
+async def test_coworking_report_allows_partner_admin():
+    client = FakeCoworkingReportClient(admin_roles={"UPARTNER": "partner"})
+    executor = SkillExecutor()
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="coworking_report",
+        params={"start_date": "2026-01-01", "end_date": "2026-01-31"},
+        text="coworking report 2026-01-01 2026-01-31",
+        user_id="UPARTNER",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert client.admin_checks == ["UPARTNER"]
+    assert client.calls == [("UPARTNER", "2026-01-01", "2026-01-31")]
     assert "Source: Active coworking bookings" in result
 
 

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -27,7 +27,7 @@ This skill enables Roo to interact with the MLAI Points System via API, allowing
 - Book and cancel coworking days
 - View rewards catalog and request redemptions
 
-### Admin Actions (requires PointsAdmin role)
+### Full Admin Actions (requires `admin`, `committee`, or `portfolio_lead` role)
 - Create new tasks with point values
 - Edit supported task fields
 - Cancel/archive tasks while preserving history
@@ -41,11 +41,13 @@ This skill enables Roo to interact with the MLAI Points System via API, allowing
 - `unclaim` is only allowed before any submission exists
 - Approval awards points once, on final acceptance
 
+### Partner Actions (report-only)
+- Generate coworking usage reports for date ranges and standard lookback windows
+
 ### Super Admin Actions (restricted to Slack user `U05QPB483K9`)
 - Promote one tagged user to Points Admin
 - Revoke one tagged user's Points Admin access
 - Change one tagged Points Admin's weekly allowance
-- Generate coworking usage reports for date ranges and standard lookback windows
 
 ### Admin Weekly Allowance
 
@@ -153,8 +155,9 @@ Parse the user's message to determine which action they want:
 - For super admin actions, require exactly one tagged Slack user, never fall through into `award_points`, and require a positive numeric allowance when changing allowance
 
 ### Step 2: Permission Check
-For admin-only actions (create, edit, cancel, approve, reject, award):
+For full admin-only actions (create, edit, cancel, approve, reject, award):
 - The API will validate the requester's Slack ID
+- Partner admins are not full admins and must be denied for point-mutating actions
 - If 403 returned, respond with friendly denial
 
 For super admin actions (promote admin, revoke admin, change allowance):
@@ -162,7 +165,7 @@ For super admin actions (promote admin, revoke admin, change allowance):
 - The backend must still validate the requester for defense in depth
 
 For coworking report actions:
-- Roo must fail fast unless the requester is a Points Admin
+- Roo must fail fast unless the requester is a full Points Admin or report-only partner
 - Count only active bookings (`status=booked`), not cancelled bookings
 - Support exact inclusive date ranges and presets: this week, last week, last 3 months, last 6 months, last year
 - Format the response as a concise Slack report with summary, monthly, weekly, and daily counts


### PR DESCRIPTION
## Summary
- Treat Roo partners as report-only points admins for coworking reports.
- Keep point-awarding and task admin flows restricted to full points admin roles.
- Route Roo-owned system awards to the backend system-award endpoint.
- Update mlai-points skill docs and tests for partner behavior.

## Validation
- `pytest roo/tests/test_mlai_backend_client.py roo/tests/test_points_requests.py roo/tests/test_agent_routing.py`