### PR TITLE
Add Luma attendee CSV export for Points Admin roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ Copy `.env.example` to `.env` and configure:
 - `DATABASE_URL` - PostgreSQL connection
 - `SLACK_BOT_TOKEN` - Slack bot token
 - `OPENAI_API_KEY` - For LLM and embeddings
+- `LUMA_API_KEY` - Luma calendar API key for attendee CSV exports
+- `LUMA_BASE_URL` - Optional Luma API base URL, defaults to `https://public-api.luma.com`

--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -362,6 +362,19 @@ class RooAgent:
         )
         return any(re.search(pattern, text) for pattern in patterns)
 
+    def _looks_like_luma_request(self, text: str) -> bool:
+        patterns = (
+            r'\bluma\b',
+            r'\battendees?\b',
+            r'\bguest\s+lists?\b',
+            r'\bguests?\b.*\bcsv\b',
+            r'\bcsv\b.*\bguests?\b',
+            r'\bcsv\b.*\bmlai\s+events?\b',
+            r'\bmlai\s+events?\b.*\bcsv\b',
+            r'\bpast\s+csv\s+documents?\b',
+        )
+        return any(re.search(pattern, text) for pattern in patterns)
+
     def _looks_like_content_follow_up(self, text: str) -> bool:
         patterns = (
             r'\bwrite\b',
@@ -396,6 +409,10 @@ class RooAgent:
 
         text_lower = text.lower().strip()
         content_skill = self._get_skill_by_name("content-factory")
+        luma_skill = self._get_skill_by_name("luma-events")
+
+        if luma_skill and self._looks_like_luma_request(text_lower):
+            return luma_skill
 
         if content_skill and self._looks_like_content_request(text_lower):
             return content_skill
@@ -684,6 +701,7 @@ Routing rules:
 - Prefer content-factory for domain-backed repo scans, article/blog writing, SEO research, content planning, scaffolding blog/article pages, and requests like "scan the domain mlai.au" or "scan the repo for the domain mlai.au".
 - Prefer github-integration for GitHub auth, reconnecting GitHub, or account/integration management.
 - Prefer mlai-points for points, rewards, coworking, and task management.
+- Prefer luma-events for Luma attendee exports, guest lists, CSV documents, and recent/past MLAI event attendee CSVs.
 
 Examples:
 - "please research the best article for me to write" -> content-factory
@@ -692,6 +710,7 @@ Examples:
 - "reconnect github for woofya.com.au" -> github-integration
 - "write me an article about how to build an ai agent harness for long-running specific tasks" -> content-factory
 - "create a task called fix docs worth 5 points" -> mlai-points
+- "give me CSVs for the past 3 MLAI events" -> luma-events
 
 Respond with ONLY the skill name (e.g., "connect_users" or "none"):"""
 

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -32,6 +32,8 @@ class Settings(BaseSettings):
     MLAI_API_KEY: Optional[str] = None
     ROO_API_KEY: Optional[str] = None
     INTERNAL_API_KEY: Optional[str] = None
+    LUMA_API_KEY: Optional[str] = None
+    LUMA_BASE_URL: str = "https://public-api.luma.com"
 
     # GitHub OAuth
     GITHUB_CLIENT_ID: Optional[str] = None

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -49,6 +49,7 @@ from ..coworking_booking_intents import (
 POINTS_SUPER_ADMIN_SLACK_ID = "U05QPB483K9"
 FULL_POINTS_ADMIN_ROLES = {"admin", "committee", "portfolio_lead"}
 COWORKING_REPORT_ROLES = {*FULL_POINTS_ADMIN_ROLES, "partner"}
+LUMA_EXPORT_ROLES = {"admin", "committee", "partner"}
 
 
 @dataclass
@@ -120,6 +121,8 @@ class SkillExecutor:
                 result = await self._execute_tone_of_voice(skill, text, params, user_id)
             elif skill.name == "medhack":
                 result = await self._execute_medhack(skill, text, params, user_id, channel_id, thread_ts, thread_history)
+            elif skill.name == "luma-events":
+                result = await self._execute_luma_events(skill, text, params, user_id, channel_id, thread_ts)
             else:
                 # Generic LLM-based execution
                 result = await self._execute_with_llm(skill, text, params, user_id, thread_history)
@@ -1478,6 +1481,145 @@ Keep the response concise but informative."""
         # Note: Vector search is disabled until API endpoint is implemented
         # For now, fall back to LLM-based execution
         return await self._execute_with_llm(skill, text, params, user_id)
+
+    async def _execute_luma_events(
+        self,
+        skill: Skill,
+        text: str,
+        params: dict,
+        user_id: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+    ) -> Any:
+        """Execute the Luma Events skill by exporting attendee CSVs."""
+        settings = get_settings()
+        if not getattr(settings, "MLAI_BACKEND_URL", None):
+            return (
+                "Luma attendee exports need the Points Admin lookup to be configured. "
+                "Ask the team to set `MLAI_BACKEND_URL`."
+            )
+
+        from roo.clients.mlai_backend import MLAIBackendClient, MLAIBackendUnavailableError
+
+        backend_client = MLAIBackendClient(
+            base_url=settings.MLAI_BACKEND_URL,
+            api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY,
+            internal_api_key=(
+                settings.INTERNAL_API_KEY
+                or settings.ROO_API_KEY
+                or settings.MLAI_API_KEY
+            ),
+        )
+        try:
+            admin_details = await backend_client.get_admin_details(user_id)
+        except MLAIBackendUnavailableError:
+            return (
+                "I couldn't verify your Points Admin role because the MLAI backend is "
+                "temporarily unavailable. Try again in a tick."
+            )
+
+        if not self._can_export_luma_attendees_details(admin_details):
+            return (
+                "Sorry mate, you'll need to be a Points Admin with the `admin`, "
+                "`committee`, or `partner` role to export Luma attendee data. 🔒"
+            )
+
+        api_key = str(getattr(settings, "LUMA_API_KEY", "") or "").strip()
+        if not api_key:
+            return "Luma isn't configured yet. Ask the team to set `LUMA_API_KEY`."
+
+        if not channel_id:
+            return "I need a Slack channel or DM to upload the Luma CSV files."
+
+        ClientClass = skill.get_client_class("LumaEventsClient")
+        if ClientClass is None:
+            return "Sorry mate, the Luma Events skill isn't properly configured. Missing implementation."
+
+        event_count = self._resolve_luma_event_count(params, text)
+        approval_status = str(params.get("approval_status") or "approved").strip() or "approved"
+        base_url = getattr(settings, "LUMA_BASE_URL", "https://public-api.luma.com")
+        client = ClientClass(api_key=api_key, base_url=base_url)
+
+        try:
+            events = await client.get_recent_ended_events(count=event_count)
+            if not events:
+                return "I couldn't find any ended Luma events on the configured MLAI calendar."
+
+            from ..slack_client import upload_file
+
+            exported = []
+            for event in events:
+                guests = await client.list_guests(
+                    event_id=event["id"],
+                    approval_status=approval_status,
+                )
+                csv_content = client.build_attendee_csv(event, guests)
+                filename = client.build_csv_filename(event)
+                title = f"{event.get('name') or 'Luma event'} attendees"
+                upload_file(
+                    channel=channel_id,
+                    content=csv_content,
+                    filename=filename,
+                    title=title,
+                    thread_ts=thread_ts,
+                )
+                exported.append(
+                    {
+                        "event_id": event.get("id"),
+                        "event_name": event.get("name"),
+                        "filename": filename,
+                        "guest_count": len(guests),
+                    }
+                )
+
+            lines = [
+                f"Uploaded {len(exported)} Luma attendee CSV file{'s' if len(exported) != 1 else ''}:"
+            ]
+            for item in exported:
+                lines.append(
+                    f"• `{item['filename']}` — {item['guest_count']} approved guest"
+                    f"{'s' if item['guest_count'] != 1 else ''}"
+                )
+
+            return {
+                "message": "\n".join(lines),
+                "data": {
+                    "action": "export_attendees",
+                    "approval_status": approval_status,
+                    "events": exported,
+                },
+            }
+        except httpx.HTTPStatusError as e:
+            status = e.response.status_code
+            if status in (401, 403):
+                return "Luma rejected the configured API key. Check that `LUMA_API_KEY` belongs to the MLAI calendar and has access."
+            if status == 429:
+                return "Luma rate-limited the export. Try again in a minute."
+            detail = self._extract_http_error_detail(e)
+            return detail or f"Luma returned HTTP {status}. Try again in a tick."
+        except (httpx.TimeoutException, httpx.TransportError):
+            return "I'm having trouble reaching Luma right now. Try again in a tick."
+
+    def _can_export_luma_attendees_details(self, admin_details: Optional[dict]) -> bool:
+        return self._points_admin_role(admin_details) in LUMA_EXPORT_ROLES
+
+    def _resolve_luma_event_count(self, params: dict, text: str) -> int:
+        raw_count = params.get("event_count") or params.get("limit")
+        if raw_count is None:
+            text_lower = text.lower()
+            if re.search(r"\blatest\s+(?:mlai\s+)?event\b", text_lower):
+                raw_count = 1
+            else:
+                count_match = re.search(
+                    r"\b(?:past|last|recent|latest)\s+(\d{1,2})\s+(?:mlai\s+)?events?\b",
+                    text_lower,
+                )
+                raw_count = count_match.group(1) if count_match else 3
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            count = 3
+        return max(1, min(count, 10))
 
     async def _save_content_factory_pending_intent(
         self,

--- a/roo-standalone/roo/slack_client.py
+++ b/roo-standalone/roo/slack_client.py
@@ -87,6 +87,44 @@ def post_message(
         raise
 
 
+def upload_file(
+    channel: str,
+    content: str,
+    filename: str,
+    title: Optional[str] = None,
+    thread_ts: Optional[str] = None,
+    initial_comment: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Upload an in-memory text file to Slack.
+
+    Requires the Slack bot token to have the files:write scope.
+    """
+    client = get_slack_client()
+
+    try:
+        response = client.files_upload_v2(
+            channel=channel,
+            content=content,
+            filename=filename,
+            title=title or filename,
+            thread_ts=thread_ts,
+            initial_comment=initial_comment,
+        )
+
+        if response.get("ok"):
+            suffix = f" (thread: {thread_ts})" if thread_ts else ""
+            print(f"✅ File uploaded to {channel}{suffix}: {filename}")
+        else:
+            print(f"❌ Failed to upload file: {response}")
+
+        return response
+
+    except Exception as e:
+        print(f"❌ Slack file upload error: {e}")
+        raise
+
+
 def get_thread_messages(channel: str, thread_ts: str) -> list[dict]:
     """
     Retrieve all messages in a Slack thread for context.

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -50,6 +50,18 @@ def _make_agent() -> RooAgent:
             "github-integration",
             ["connect github", "github integration", "reconnect github", "github auth"],
         ),
+        _make_skill(
+            "luma-events",
+            [
+                "luma",
+                "attendees",
+                "guest list",
+                "csv",
+                "csv documents",
+                "past csv documents",
+                "mlai events",
+            ],
+        ),
     ]
     agent.skill_executor = SimpleNamespace()
     agent._thread_skill_context = {}
@@ -83,6 +95,17 @@ def test_request_points_phrase_routes_to_points():
 
     assert skill is not None
     assert skill.name == "mlai-points"
+
+
+def test_luma_attendee_csv_phrase_routes_to_luma_events():
+    agent = _make_agent()
+
+    skill = agent._select_skill_from_triggers(
+        "can you give me past csv documents for the past 3 MLAI events"
+    )
+
+    assert skill is not None
+    assert skill.name == "luma-events"
 
 
 def test_coworking_report_wording_routes_to_points():

--- a/roo-standalone/roo/tests/test_luma_events.py
+++ b/roo-standalone/roo/tests/test_luma_events.py
@@ -1,0 +1,472 @@
+import asyncio
+import csv
+import importlib
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("frontmatter", SimpleNamespace(load=lambda *args, **kwargs: None))
+sys.modules.pop("roo.skills.executor", None)
+
+executor_module = importlib.import_module("roo.skills.executor")
+backend_module = importlib.import_module("roo.clients.mlai_backend")
+slack_client_module = importlib.import_module("roo.slack_client")
+SkillExecutor = executor_module.SkillExecutor
+
+
+def _load_luma_client_module():
+    client_path = Path(__file__).resolve().parents[2] / "skills" / "luma_events" / "client.py"
+    spec = importlib.util.spec_from_file_location("luma_events_client_for_tests", client_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+luma_client_module = _load_luma_client_module()
+LumaEventsClient = luma_client_module.LumaEventsClient
+
+
+class FakeAdminLookupClient:
+    roles = {}
+    unavailable = False
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    async def get_admin_details(self, slack_user_id):
+        if self.unavailable:
+            raise backend_module.MLAIBackendUnavailableError("backend unavailable")
+        role = self.roles.get(slack_user_id)
+        if not role:
+            return None
+        return {"slack_user_id": slack_user_id, "role": role}
+
+
+@pytest.mark.asyncio
+async def test_luma_client_paginates_events_and_guests():
+    requests = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append((request.url.path, dict(request.url.params)))
+        params = dict(request.url.params)
+        if request.url.path == "/v1/calendar/list-events":
+            if params.get("pagination_cursor") == "page-2":
+                return httpx.Response(
+                    200,
+                    json={
+                        "entries": [
+                            {
+                                "id": "evt-2",
+                                "name": "MLAI April",
+                                "start_at": "2026-04-20T08:00:00Z",
+                                "end_at": "2026-04-20T10:00:00Z",
+                            }
+                        ],
+                        "has_more": False,
+                    },
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [
+                        {
+                            "id": "evt-current",
+                            "name": "Current Event",
+                            "start_at": "2026-05-04T00:00:00Z",
+                            "end_at": "2026-05-05T00:00:00Z",
+                        },
+                        {
+                            "id": "evt-1",
+                            "name": "MLAI May",
+                            "start_at": "2026-05-03T08:00:00Z",
+                            "end_at": "2026-05-03T10:00:00Z",
+                        },
+                    ],
+                    "has_more": True,
+                    "next_cursor": "page-2",
+                },
+            )
+
+        if request.url.path == "/v1/event/get-guests":
+            if params.get("pagination_cursor") == "guests-2":
+                return httpx.Response(
+                    200,
+                    json={
+                        "entries": [{"id": "gst-2", "user_email": "b@example.com"}],
+                        "has_more": False,
+                    },
+                )
+            return httpx.Response(
+                200,
+                json={
+                    "entries": [{"id": "gst-1", "user_email": "a@example.com"}],
+                    "has_more": True,
+                    "next_cursor": "guests-2",
+                },
+            )
+
+        return httpx.Response(404)
+
+    client = LumaEventsClient(
+        api_key="test-key",
+        base_url="https://luma.test",
+        transport=httpx.MockTransport(handler),
+    )
+
+    events = await client.get_recent_ended_events(
+        count=2,
+        now=datetime.fromisoformat("2026-05-04T12:00:00+10:00"),
+    )
+    guests = await client.list_guests("evt-1")
+
+    assert [event["id"] for event in events] == ["evt-1", "evt-2"]
+    assert [guest["id"] for guest in guests] == ["gst-1", "gst-2"]
+    assert any(
+        path == "/v1/calendar/list-events" and params.get("pagination_cursor") == "page-2"
+        for path, params in requests
+    )
+    assert any(
+        path == "/v1/event/get-guests"
+        and params.get("approval_status") == "approved"
+        and params.get("pagination_cursor") == "guests-2"
+        for path, params in requests
+    )
+
+
+def test_luma_csv_flattens_guest_tickets_and_registration_answers():
+    client = LumaEventsClient(api_key="test-key")
+    event = {
+        "id": "evt-1",
+        "name": "MLAI Demo Night",
+        "url": "https://luma.com/mlai-demo",
+        "start_at": "2026-04-28T08:00:00Z",
+        "end_at": "2026-04-28T10:00:00Z",
+    }
+    guests = [
+        {
+            "id": "gst-1",
+            "user_id": "usr-1",
+            "user_email": "sam@example.com",
+            "user_name": "Sam Donegan",
+            "user_first_name": "Sam",
+            "user_last_name": "Donegan",
+            "phone_number": "+61000000000",
+            "approval_status": "approved",
+            "registered_at": "2026-04-01T00:00:00Z",
+            "utm_source": "newsletter",
+            "event_tickets": [
+                {
+                    "id": "tkt-1",
+                    "name": "General Admission",
+                    "checked_in_at": "2026-04-28T08:10:00Z",
+                },
+                {"id": "tkt-2", "name": "Workshop", "checked_in_at": None},
+            ],
+            "registration_answers": [
+                {"label": "Company", "question_type": "company", "answer_company": "MLAI", "answer_job_title": "Founder"},
+                {"label": "Interests", "question_type": "multi-select", "answer": ["AI", "Health"]},
+            ],
+        },
+        {
+            "id": "gst-2",
+            "user_email": "missing-name@example.com",
+            "approval_status": "approved",
+            "event_tickets": [],
+            "registration_answers": [{"label": "Interests", "answer": "Robotics"}],
+        },
+    ]
+
+    rows = list(csv.DictReader(client.build_attendee_csv(event, guests).splitlines()))
+
+    assert rows[0]["event_id"] == "evt-1"
+    assert rows[0]["name"] == "Sam Donegan"
+    assert rows[0]["ticket_count"] == "2"
+    assert rows[0]["ticket_names"] == "General Admission; Workshop"
+    assert rows[0]["checked_in_at"] == "2026-04-28T08:10:00Z"
+    assert rows[0]["question: Company"] == "MLAI - Founder"
+    assert rows[0]["question: Interests"] == "AI; Health"
+    assert rows[1]["name"] == ""
+    assert rows[1]["question: Interests"] == "Robotics"
+    assert client.build_csv_filename(event) == "luma-mlai-2026-04-28-mlai-demo-night.csv"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("role", ["admin", "committee", "partner"])
+async def test_luma_executor_allows_luma_export_roles(monkeypatch, role):
+    uploaded = []
+
+    class FakeLumaClient:
+        def __init__(self, api_key, base_url):
+            self.api_key = api_key
+            self.base_url = base_url
+
+        async def get_recent_ended_events(self, count):
+            return [{"id": "evt-1", "name": "One"}]
+
+        async def list_guests(self, event_id, approval_status):
+            return [{"id": "gst-1"}]
+
+        def build_attendee_csv(self, event, guests):
+            return "event_id,guest_id\nevt-1,gst-1\n"
+
+        def build_csv_filename(self, event):
+            return "evt-1.csv"
+
+    executor = SkillExecutor()
+    FakeAdminLookupClient.roles = {"UADMIN": role}
+    FakeAdminLookupClient.unavailable = False
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+            INTERNAL_API_KEY="internal-key",
+            LUMA_API_KEY="test-key",
+            LUMA_BASE_URL="https://luma.test",
+        ),
+    )
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeAdminLookupClient)
+    monkeypatch.setattr(
+        slack_client_module,
+        "upload_file",
+        lambda **kwargs: uploaded.append(kwargs) or {"ok": True},
+    )
+
+    result = await executor._execute_luma_events(
+        skill=SimpleNamespace(get_client_class=lambda name: FakeLumaClient),
+        text="luma attendees",
+        params={},
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert result["data"]["action"] == "export_attendees"
+    assert uploaded[0]["filename"] == "evt-1.csv"
+
+
+@pytest.mark.asyncio
+async def test_luma_executor_denies_missing_points_admin_record(monkeypatch):
+    executor = SkillExecutor()
+    FakeAdminLookupClient.roles = {}
+    FakeAdminLookupClient.unavailable = False
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+            INTERNAL_API_KEY="internal-key",
+            LUMA_API_KEY="test-key",
+            LUMA_BASE_URL="https://luma.test",
+        ),
+    )
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeAdminLookupClient)
+
+    result = await executor._execute_luma_events(
+        skill=SimpleNamespace(get_client_class=lambda name: None),
+        text="luma attendees",
+        params={},
+        user_id="UOTHER",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert "admin`, `committee`, or `partner` role" in result
+
+
+@pytest.mark.asyncio
+async def test_luma_executor_denies_portfolio_lead(monkeypatch):
+    executor = SkillExecutor()
+    FakeAdminLookupClient.roles = {"UPORTFOLIO": "portfolio_lead"}
+    FakeAdminLookupClient.unavailable = False
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+            INTERNAL_API_KEY="internal-key",
+            LUMA_API_KEY="test-key",
+            LUMA_BASE_URL="https://luma.test",
+        ),
+    )
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeAdminLookupClient)
+
+    result = await executor._execute_luma_events(
+        skill=SimpleNamespace(get_client_class=lambda name: None),
+        text="luma attendees",
+        params={},
+        user_id="UPORTFOLIO",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert "admin`, `committee`, or `partner` role" in result
+
+
+@pytest.mark.asyncio
+async def test_luma_executor_reports_missing_backend_url(monkeypatch):
+    executor = SkillExecutor()
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+            INTERNAL_API_KEY="internal-key",
+            LUMA_API_KEY="test-key",
+            LUMA_BASE_URL="https://luma.test",
+        ),
+    )
+
+    result = await executor._execute_luma_events(
+        skill=SimpleNamespace(get_client_class=lambda name: None),
+        text="luma attendees",
+        params={},
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert "MLAI_BACKEND_URL" in result
+
+
+@pytest.mark.asyncio
+async def test_luma_executor_reports_unavailable_admin_lookup(monkeypatch):
+    executor = SkillExecutor()
+    FakeAdminLookupClient.roles = {"UADMIN": "admin"}
+    FakeAdminLookupClient.unavailable = True
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+            INTERNAL_API_KEY="internal-key",
+            LUMA_API_KEY="test-key",
+            LUMA_BASE_URL="https://luma.test",
+        ),
+    )
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeAdminLookupClient)
+
+    result = await executor._execute_luma_events(
+        skill=SimpleNamespace(get_client_class=lambda name: None),
+        text="luma attendees",
+        params={},
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert "couldn't verify your Points Admin role" in result
+
+
+@pytest.mark.asyncio
+async def test_luma_executor_reports_missing_api_key(monkeypatch):
+    executor = SkillExecutor()
+    FakeAdminLookupClient.roles = {"UADMIN": "admin"}
+    FakeAdminLookupClient.unavailable = False
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+            INTERNAL_API_KEY="internal-key",
+            LUMA_API_KEY="",
+            LUMA_BASE_URL="https://luma.test",
+        ),
+    )
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeAdminLookupClient)
+
+    result = await executor._execute_luma_events(
+        skill=SimpleNamespace(get_client_class=lambda name: None),
+        text="luma attendees",
+        params={},
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert "LUMA_API_KEY" in result
+
+
+@pytest.mark.asyncio
+async def test_luma_executor_uploads_csvs(monkeypatch):
+    uploaded = []
+
+    class FakeLumaClient:
+        def __init__(self, api_key, base_url):
+            self.api_key = api_key
+            self.base_url = base_url
+
+        async def get_recent_ended_events(self, count):
+            assert count == 2
+            return [
+                {"id": "evt-1", "name": "One"},
+                {"id": "evt-2", "name": "Two"},
+            ]
+
+        async def list_guests(self, event_id, approval_status):
+            assert approval_status == "approved"
+            return [{"id": f"gst-{event_id}"}]
+
+        def build_attendee_csv(self, event, guests):
+            return f"event_id,guest_id\n{event['id']},{guests[0]['id']}\n"
+
+        def build_csv_filename(self, event):
+            return f"{event['id']}.csv"
+
+    executor = SkillExecutor()
+    FakeAdminLookupClient.roles = {"UADMIN": "admin"}
+    FakeAdminLookupClient.unavailable = False
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+            INTERNAL_API_KEY="internal-key",
+            LUMA_API_KEY="test-key",
+            LUMA_BASE_URL="https://luma.test",
+        ),
+    )
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeAdminLookupClient)
+    monkeypatch.setattr(
+        slack_client_module,
+        "upload_file",
+        lambda **kwargs: uploaded.append(kwargs) or {"ok": True},
+    )
+
+    result = await executor._execute_luma_events(
+        skill=SimpleNamespace(get_client_class=lambda name: FakeLumaClient),
+        text="give me CSVs for the past 2 MLAI events",
+        params={},
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+    )
+
+    assert result["data"]["action"] == "export_attendees"
+    assert len(uploaded) == 2
+    assert uploaded[0]["channel"] == "C123"
+    assert uploaded[0]["filename"] == "evt-1.csv"
+    assert uploaded[0]["thread_ts"] == "111.222"
+    assert "Uploaded 2 Luma attendee CSV files" in result["message"]

--- a/roo-standalone/skills/luma_events/SKILL.md
+++ b/roo-standalone/skills/luma_events/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: luma-events
+description: Export Luma event attendee and guest lists as CSV files for recent MLAI events
+trigger_keywords:
+  - luma
+  - attendees
+  - attendee
+  - guest list
+  - guests
+  - export guests
+  - csv
+  - csv documents
+  - past csv documents
+  - mlai events
+  - recent events
+---
+
+# Luma Events Skill
+
+This skill lets Roo export approved Luma guests for recent MLAI calendar events as CSV files in Slack.
+
+## Capabilities
+
+- Find the latest ended events from the MLAI Luma calendar.
+- Export approved guests for one or more events.
+- Upload one CSV per event to the Slack thread where the request was made.
+
+## Parameters
+
+- **action**: The action to perform. Use `export_attendees` for attendee, guest list, or CSV export requests.
+- **event_count**: Number of recent ended events to export. Defaults to 3. Use 1 for "latest event".
+- **approval_status**: Luma guest approval status to export. Defaults to `approved`.
+
+## Workflow
+
+1. Verify the requester is allowed to export attendee data.
+2. Use the configured Luma calendar API key.
+3. Fetch recent ended events from Luma.
+4. Fetch approved guests for each selected event.
+5. Build one CSV per event with guest identity, ticket, check-in, source, and registration-answer columns.
+6. Upload the CSV files to Slack.
+
+## Security
+
+- Never print or reveal the Luma API key.
+- Never store attendee CSVs permanently.
+- Only allow Points Admin users with the `admin`, `committee`, or `partner` role.

--- a/roo-standalone/skills/luma_events/client.py
+++ b/roo-standalone/skills/luma_events/client.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional
+from zoneinfo import ZoneInfo
+
+import httpx
+
+
+class LumaEventsClient:
+    """Client and CSV helpers for Luma event attendee exports."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://public-api.luma.com",
+        timeout: float = 30.0,
+        transport: Optional[httpx.AsyncBaseTransport] = None,
+    ):
+        self.api_key = api_key
+        self.base_url = (base_url or "https://public-api.luma.com").rstrip("/")
+        self.timeout = timeout
+        self.transport = transport
+
+    async def get_recent_ended_events(
+        self,
+        count: int = 3,
+        now: Optional[datetime] = None,
+        timezone_name: str = "Australia/Melbourne",
+    ) -> List[Dict[str, Any]]:
+        """Return the latest ended calendar events, newest first."""
+        now_local = now or datetime.now(ZoneInfo(timezone_name))
+        if now_local.tzinfo is None:
+            now_local = now_local.replace(tzinfo=ZoneInfo(timezone_name))
+        now_utc = now_local.astimezone(timezone.utc)
+
+        events: List[Dict[str, Any]] = []
+        cursor = None
+        while len(events) < count:
+            params: Dict[str, Any] = {
+                "before": _isoformat_z(now_utc),
+                "pagination_limit": 100,
+                "sort_column": "start_at",
+                "sort_direction": "desc",
+                "status": "approved",
+            }
+            if cursor:
+                params["pagination_cursor"] = cursor
+
+            page = await self._get("/v1/calendar/list-events", params=params)
+            for event in page.get("entries", []):
+                end_at = _parse_datetime(event.get("end_at"))
+                if end_at and end_at <= now_utc:
+                    events.append(event)
+                    if len(events) >= count:
+                        break
+
+            if len(events) >= count or not page.get("has_more"):
+                break
+            cursor = page.get("next_cursor")
+            if not cursor:
+                break
+
+        return events[:count]
+
+    async def list_guests(
+        self,
+        event_id: str,
+        approval_status: str = "approved",
+    ) -> List[Dict[str, Any]]:
+        """Return all guests for an event and approval status."""
+        params = {
+            "event_id": event_id,
+            "approval_status": approval_status,
+            "pagination_limit": 100,
+            "sort_column": "registered_at",
+            "sort_direction": "asc",
+        }
+        return await self._paginate("/v1/event/get-guests", params=params)
+
+    async def _paginate(self, path: str, params: Dict[str, Any]) -> List[Dict[str, Any]]:
+        entries: List[Dict[str, Any]] = []
+        cursor = None
+        while True:
+            page_params = dict(params)
+            if cursor:
+                page_params["pagination_cursor"] = cursor
+
+            page = await self._get(path, params=page_params)
+            entries.extend(page.get("entries", []))
+
+            if not page.get("has_more"):
+                break
+            cursor = page.get("next_cursor")
+            if not cursor:
+                break
+
+        return entries
+
+    async def _get(self, path: str, params: Dict[str, Any]) -> Dict[str, Any]:
+        headers = {"x-luma-api-key": self.api_key}
+        client_kwargs: Dict[str, Any] = {
+            "base_url": self.base_url,
+            "headers": headers,
+            "timeout": self.timeout,
+        }
+        if self.transport is not None:
+            client_kwargs["transport"] = self.transport
+
+        async with httpx.AsyncClient(**client_kwargs) as client:
+            response = await client.get(path, params=params)
+            response.raise_for_status()
+            return response.json()
+
+    def build_attendee_csv(self, event: Dict[str, Any], guests: Iterable[Dict[str, Any]]) -> str:
+        """Build a CSV string with one row per guest and dynamic registration columns."""
+        rows: List[Dict[str, Any]] = []
+        question_headers: List[str] = []
+        seen_questions = set()
+
+        for guest in guests:
+            row = self._guest_to_row(event, guest)
+            for header in row:
+                if header.startswith("question: ") and header not in seen_questions:
+                    seen_questions.add(header)
+                    question_headers.append(header)
+            rows.append(row)
+
+        headers = [
+            "event_id",
+            "event_name",
+            "event_url",
+            "event_start_at",
+            "event_end_at",
+            "guest_id",
+            "user_id",
+            "name",
+            "first_name",
+            "last_name",
+            "email",
+            "phone_number",
+            "approval_status",
+            "registered_at",
+            "checked_in_at",
+            "ticket_count",
+            "ticket_names",
+            "ticket_ids",
+            "ticket_checked_in_at",
+            "utm_source",
+            "custom_source",
+            "check_in_qr_code",
+        ] + question_headers
+
+        output = io.StringIO()
+        writer = csv.DictWriter(output, fieldnames=headers, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+        return output.getvalue()
+
+    def build_csv_filename(self, event: Dict[str, Any]) -> str:
+        start_at = _parse_datetime(event.get("start_at"))
+        date_label = start_at.date().isoformat() if start_at else "unknown-date"
+        slug = _slugify(str(event.get("name") or "event"))
+        return f"luma-mlai-{date_label}-{slug}.csv"
+
+    def _guest_to_row(self, event: Dict[str, Any], guest: Dict[str, Any]) -> Dict[str, Any]:
+        guest_data = guest.get("guest") if isinstance(guest.get("guest"), dict) else guest
+        tickets = _tickets_for_guest(guest_data)
+        checked_in_values = [
+            str(ticket.get("checked_in_at") or "").strip()
+            for ticket in tickets
+            if str(ticket.get("checked_in_at") or "").strip()
+        ]
+        checked_in_at = "; ".join(checked_in_values) or str(guest_data.get("checked_in_at") or "")
+
+        row: Dict[str, Any] = {
+            "event_id": event.get("id", ""),
+            "event_name": event.get("name", ""),
+            "event_url": event.get("url", ""),
+            "event_start_at": event.get("start_at", ""),
+            "event_end_at": event.get("end_at", ""),
+            "guest_id": guest_data.get("id", ""),
+            "user_id": guest_data.get("user_id", ""),
+            "name": guest_data.get("user_name") or "",
+            "first_name": guest_data.get("user_first_name") or "",
+            "last_name": guest_data.get("user_last_name") or "",
+            "email": guest_data.get("user_email") or "",
+            "phone_number": guest_data.get("phone_number") or "",
+            "approval_status": guest_data.get("approval_status") or "",
+            "registered_at": guest_data.get("registered_at") or "",
+            "checked_in_at": checked_in_at,
+            "ticket_count": len(tickets),
+            "ticket_names": "; ".join(_clean_string(ticket.get("name")) for ticket in tickets if _clean_string(ticket.get("name"))),
+            "ticket_ids": "; ".join(_clean_string(ticket.get("id")) for ticket in tickets if _clean_string(ticket.get("id"))),
+            "ticket_checked_in_at": "; ".join(checked_in_values),
+            "utm_source": guest_data.get("utm_source") or "",
+            "custom_source": guest_data.get("custom_source") or "",
+            "check_in_qr_code": guest_data.get("check_in_qr_code") or "",
+        }
+
+        for answer in guest_data.get("registration_answers") or []:
+            if not isinstance(answer, dict):
+                continue
+            label = _clean_string(answer.get("label")) or _clean_string(answer.get("question_id"))
+            if not label:
+                continue
+            row[f"question: {label}"] = _answer_value(answer)
+
+        return row
+
+
+def _tickets_for_guest(guest: Dict[str, Any]) -> List[Dict[str, Any]]:
+    tickets = guest.get("event_tickets")
+    if isinstance(tickets, list):
+        return [ticket for ticket in tickets if isinstance(ticket, dict)]
+    ticket = guest.get("event_ticket")
+    if isinstance(ticket, dict):
+        return [ticket]
+    return []
+
+
+def _answer_value(answer: Dict[str, Any]) -> str:
+    if answer.get("question_type") == "company":
+        company = _clean_string(answer.get("answer_company") or answer.get("value") or answer.get("answer"))
+        job_title = _clean_string(answer.get("answer_job_title"))
+        return " - ".join(part for part in [company, job_title] if part)
+
+    value = answer.get("answer")
+    if value is None:
+        value = answer.get("value")
+    return _stringify_csv_value(value)
+
+
+def _stringify_csv_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, list):
+        return "; ".join(_stringify_csv_value(item) for item in value)
+    if isinstance(value, dict):
+        return json.dumps(value, sort_keys=True)
+    return str(value)
+
+
+def _parse_datetime(value: Any) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        raw = str(value).strip()
+        if raw.endswith("Z"):
+            raw = raw[:-1] + "+00:00"
+        try:
+            dt = datetime.fromisoformat(raw)
+        except ValueError:
+            return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _isoformat_z(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _clean_string(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    slug = re.sub(r"-+", "-", slug)
+    return (slug or "event")[:80].strip("-") or "event"


### PR DESCRIPTION
## Summary
- Add a Roo Luma attendee CSV skill and deterministic Luma API client.
- Route Luma attendee/guest CSV prompts to a dedicated executor path that uploads one CSV per selected event to Slack.
- Authorize exports via Points Admin role lookup, allowing exactly `admin`, `committee`, and `partner`.
- Remove `LUMA_ALLOWED_SLACK_USER_IDS` in favor of backend role lookup.

## Config notes
- Set `LUMA_API_KEY` from the MLAI Luma calendar developer settings.
- `LUMA_BASE_URL` is optional and defaults to `https://public-api.luma.com`.
- Slack bot needs the `files:write` scope for CSV uploads.
- Points Admin lookup requires `MLAI_BACKEND_URL` and the existing backend auth keys (`ROO_API_KEY`, `MLAI_API_KEY`, or `INTERNAL_API_KEY`).

## Validation
- Passed: `PYTHONPYCACHEPREFIX=/tmp/roo-pycache python3 -m py_compile roo/skills/executor.py roo/config.py roo/slack_client.py roo/agent.py ../skills/luma_events/client.py`
- Passed: `python3 -m pytest roo/tests/test_luma_events.py roo/tests/test_agent_routing.py -q` (`44 passed`)
- Full suite: `python3 -m pytest roo/tests -q` currently fails with 5 pre-existing, unrelated Content Factory topic-confirmation tests:
  - `roo/tests/test_content_factory_article_flow.py::test_confirm_topic_action_uses_roo_request_source_and_mentions_no_extra_charge`
  - `roo/tests/test_content_factory_article_flow.py::test_confirm_topic_btn_action_queues_generation_and_updates_message`
  - `roo/tests/test_content_factory_article_flow.py::test_confirm_topic_btn_action_surfaces_delivery_mode_prompt`
  - `roo/tests/test_content_factory_article_flow.py::test_confirm_topic_action_recovers_via_thread_resolution_after_backend_failure`
  - `roo/tests/test_content_factory_article_flow.py::test_confirm_topic_btn_action_recovers_blocked_run_after_backend_failure`