### PR TITLE
[codex] Add coworking same-day booking and admin check-in

### DIFF
--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -355,6 +355,8 @@ class RooAgent:
             r'\bpoints?\b',
             r'\bbalance\b',
             r'\bcoworking\b',
+            r'\bbook\s+me\s+in\b',
+            r'\bcheck\b.*<@[a-z0-9]+>.*\bin\b',
             r'\brewards?\b',
             r'\bclaim\s+task\b',
             r'\bcreate\s+(?:a\s+)?task\b',

--- a/roo-standalone/roo/coworking_booking_intents.py
+++ b/roo-standalone/roo/coworking_booking_intents.py
@@ -82,6 +82,7 @@ class CoworkingBookingIntentStore:
                         id INTEGER PRIMARY KEY AUTOINCREMENT,
                         idempotency_key TEXT NOT NULL UNIQUE,
                         slack_user_id TEXT NOT NULL,
+                        requested_by_slack_id TEXT,
                         booking_date TEXT NOT NULL,
                         channel_id TEXT,
                         thread_ts TEXT,
@@ -100,6 +101,15 @@ class CoworkingBookingIntentStore:
                     )
                     """
                 )
+                columns = {
+                    row["name"]
+                    for row in conn.execute("PRAGMA table_info(coworking_booking_intents)").fetchall()
+                }
+                if "requested_by_slack_id" not in columns:
+                    conn.execute(
+                        "ALTER TABLE coworking_booking_intents "
+                        "ADD COLUMN requested_by_slack_id TEXT"
+                    )
                 conn.execute(
                     """
                     CREATE INDEX IF NOT EXISTS idx_coworking_intents_due
@@ -124,6 +134,7 @@ class CoworkingBookingIntentStore:
         self,
         *,
         slack_user_id: str,
+        requested_by_slack_id: Optional[str] = None,
         booking_date: str,
         channel_id: Optional[str],
         thread_ts: Optional[str],
@@ -132,6 +143,8 @@ class CoworkingBookingIntentStore:
         self._ensure_schema()
         current_time = _now()
         idempotency_key = build_coworking_intent_key(slack_user_id, booking_date)
+        cleaned_slack_user_id = str(slack_user_id).strip()
+        cleaned_requested_by = str(requested_by_slack_id or cleaned_slack_user_id).strip()
         with self._lock:
             with self._connect() as conn:
                 conn.execute(
@@ -139,6 +152,7 @@ class CoworkingBookingIntentStore:
                     INSERT INTO coworking_booking_intents (
                         idempotency_key,
                         slack_user_id,
+                        requested_by_slack_id,
                         booking_date,
                         channel_id,
                         thread_ts,
@@ -148,8 +162,9 @@ class CoworkingBookingIntentStore:
                         created_at,
                         updated_at
                     )
-                    VALUES (?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)
                     ON CONFLICT(idempotency_key) DO UPDATE SET
+                        requested_by_slack_id = excluded.requested_by_slack_id,
                         channel_id = excluded.channel_id,
                         thread_ts = excluded.thread_ts,
                         request_text = excluded.request_text,
@@ -182,7 +197,8 @@ class CoworkingBookingIntentStore:
                     """,
                     (
                         idempotency_key,
-                        str(slack_user_id).strip(),
+                        cleaned_slack_user_id,
+                        cleaned_requested_by,
                         str(booking_date).strip(),
                         channel_id,
                         thread_ts,
@@ -452,6 +468,40 @@ def _safe_post_thread_message(*, channel_id: Optional[str], thread_ts: Optional[
     post_message(channel=channel_id, thread_ts=thread_ts, text=text)
 
 
+def _coworking_retry_confirmed_message(
+    *,
+    slack_user_id: str,
+    requested_by_slack_id: str,
+    booking_date: str,
+) -> str:
+    if requested_by_slack_id and requested_by_slack_id != slack_user_id:
+        return (
+            "I retried the queued coworking check-in for "
+            f"<@{slack_user_id}> and confirmed {booking_date}. They're booked."
+        )
+    return (
+        "I retried your queued coworking booking and confirmed "
+        f"{booking_date}. You're booked."
+    )
+
+
+def _coworking_retry_blocked_message(
+    *,
+    slack_user_id: str,
+    requested_by_slack_id: str,
+    error: str,
+) -> str:
+    if requested_by_slack_id and requested_by_slack_id != slack_user_id:
+        return (
+            "I retried the coworking check-in for "
+            f"<@{slack_user_id}>, but I still can't process it. Reason: {error}"
+        )
+    return (
+        "I retried your coworking booking request, but I still can't process it. "
+        f"Reason: {error}"
+    )
+
+
 async def process_coworking_booking_intent(
     intent: dict[str, Any],
     *,
@@ -464,6 +514,7 @@ async def process_coworking_booking_intent(
     intent_id = int(intent["id"])
     booking_date = str(intent["booking_date"])
     slack_user_id = str(intent["slack_user_id"])
+    requested_by_slack_id = str(intent.get("requested_by_slack_id") or slack_user_id)
     channel_id = intent.get("channel_id")
     thread_ts = intent.get("thread_ts")
 
@@ -476,9 +527,10 @@ async def process_coworking_booking_intent(
                 _safe_post_thread_message(
                     channel_id=channel_id,
                     thread_ts=thread_ts,
-                    text=(
-                        "I retried your queued coworking booking and confirmed "
-                        f"{booking_date}. You're booked."
+                    text=_coworking_retry_confirmed_message(
+                        slack_user_id=slack_user_id,
+                        requested_by_slack_id=requested_by_slack_id,
+                        booking_date=booking_date,
                     ),
                 )
             return {"status": "confirmed", "already_booked": True, "intent_id": intent_id}
@@ -489,9 +541,10 @@ async def process_coworking_booking_intent(
             _safe_post_thread_message(
                 channel_id=channel_id,
                 thread_ts=thread_ts,
-                text=(
-                    "I retried your queued coworking booking and confirmed "
-                    f"{booking_date}. You're booked."
+                text=_coworking_retry_confirmed_message(
+                    slack_user_id=slack_user_id,
+                    requested_by_slack_id=requested_by_slack_id,
+                    booking_date=booking_date,
                 ),
             )
         return {"status": "confirmed", "backend_result": backend_result, "intent_id": intent_id}
@@ -513,9 +566,10 @@ async def process_coworking_booking_intent(
             _safe_post_thread_message(
                 channel_id=channel_id,
                 thread_ts=thread_ts,
-                text=(
-                    "I retried your coworking booking request, but I still can't process it. "
-                    f"Reason: {error}"
+                text=_coworking_retry_blocked_message(
+                    slack_user_id=slack_user_id,
+                    requested_by_slack_id=requested_by_slack_id,
+                    error=error,
                 ),
             )
         return {"status": "blocked", "error": error, "intent_id": intent_id}

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -4206,6 +4206,15 @@ Keep the response concise but informative."""
             return "coworking_report"
         if action in ["report", "summary", "overview"] and "coworking" in text_lower:
             return "coworking_report"
+        if self._is_coworking_admin_checkin_request(text):
+            return "admin_checkin_coworking"
+        if action in [
+            "admin_checkin_coworking",
+            "coworking_checkin",
+            "checkin_coworking",
+            "check_in_coworking",
+        ]:
+            return "admin_checkin_coworking"
 
         if action == "book":
             action = "book_coworking"
@@ -4305,6 +4314,16 @@ Keep the response concise but informative."""
         for typo, replacement in replacements.items():
             text_lower = text_lower.replace(typo, replacement)
         return text_lower
+
+    def _is_coworking_admin_checkin_request(self, text: str) -> bool:
+        """Detect admin coworking check-in commands like `check <@U123> in today`."""
+        return bool(
+            re.search(
+                r"\bcheck\b.*<@[A-Z0-9]+>.*\bin\b",
+                str(text or ""),
+                re.IGNORECASE,
+            )
+        )
 
     def _extract_task_identifier(self, text: str, explicit_task_id=None) -> Optional[str]:
         """Extract either a numeric task id or a ROO task code from text."""
@@ -5335,6 +5354,232 @@ Keep the response concise but informative."""
         context = self._build_coworking_analysis_context("coworking report", report, None, None)
         return self._format_coworking_analysis_fallback(context)
 
+    def _resolve_coworking_booking_date(
+        self,
+        params: dict,
+        text: str,
+        *,
+        default_to_today: bool,
+    ) -> Optional[str]:
+        """Resolve coworking booking/check-in date from params, text, or today's default."""
+        raw_date = str(params.get("date") or "").strip().strip(".,")
+
+        if not raw_date:
+            match = re.search(r"(\d{4}-\d{2}-\d{2})", str(text or ""))
+            if match:
+                raw_date = match.group(1)
+
+        text_lower = self._normalize_points_routing_text(text)
+        if not raw_date:
+            if re.search(r"\btomorrow\b", text_lower):
+                raw_date = "tomorrow"
+            elif re.search(r"\btoday\b", text_lower):
+                raw_date = "today"
+
+        if raw_date.lower() not in {"today", "tomorrow"} and (raw_date or not default_to_today):
+            return raw_date or None
+
+        from roo.utils import get_current_date
+        today = get_current_date()
+        if raw_date.lower() == "today":
+            return today.isoformat()
+        if raw_date.lower() == "tomorrow":
+            return (today + timedelta(days=1)).isoformat()
+        return today.isoformat()
+
+    def _extract_coworking_checkin_targets(
+        self,
+        text: str,
+        params: dict,
+        *,
+        bot_id: Optional[str],
+    ) -> list[str]:
+        """Extract target Slack IDs for admin coworking check-in."""
+        target_slack_ids: list[str] = []
+
+        for mentioned_user in re.findall(r"<@([A-Z0-9]+)>", str(text or ""), re.IGNORECASE):
+            if not bot_id or mentioned_user != bot_id:
+                target_slack_ids.append(mentioned_user)
+
+        if not target_slack_ids:
+            param_values: list[Any] = []
+            param_values.extend(params.get("target_users", []) or [])
+            param_values.extend(
+                [
+                    params.get("target_user"),
+                    params.get("target_slack_id"),
+                ]
+            )
+            for raw_target in param_values:
+                if raw_target in (None, ""):
+                    continue
+                cleaned = re.sub(r"[<@>]", "", str(raw_target)).strip()
+                if cleaned and (not bot_id or cleaned != bot_id):
+                    target_slack_ids.append(cleaned)
+
+        deduped: list[str] = []
+        for target in target_slack_ids:
+            if target not in deduped:
+                deduped.append(target)
+        return deduped
+
+    def _coworking_booking_already_queued_message(
+        self,
+        *,
+        booking_date: str,
+        target_user_id: str,
+        admin_checkin: bool,
+    ) -> str:
+        if admin_checkin:
+            return (
+                f"I already have a coworking check-in request for <@{target_user_id}> "
+                f"on **{booking_date}** queued or in progress. I'll confirm in this thread "
+                "when it completes."
+            )
+        return (
+            f"I already have your coworking booking request for **{booking_date}** "
+            "queued or in progress. I'll confirm in this thread when it completes."
+        )
+
+    def _coworking_booking_queued_for_retry_message(
+        self,
+        *,
+        booking_date: str,
+        target_user_id: str,
+        admin_checkin: bool,
+    ) -> str:
+        if admin_checkin:
+            return (
+                f"I got the coworking check-in request for <@{target_user_id}> on "
+                f"**{booking_date}**, but MLAI backend didn't confirm it yet. I've queued "
+                "it and will keep retrying automatically. I won't double-book the same day."
+            )
+        return self._coworking_booking_queued_message(booking_date)
+
+    def _format_coworking_booking_success(
+        self,
+        *,
+        booking_date: str,
+        target_user_id: str,
+        cost: int,
+        new_balance: Optional[int],
+        admin_checkin: bool,
+    ) -> str:
+        point_word = "point" if cost == 1 else "points"
+        if admin_checkin:
+            balance_line = f"\nTheir balance: {new_balance} pts" if new_balance is not None else ""
+            return (
+                f"You beauty! 🎉\n\n"
+                f"Checked <@{target_user_id}> in for **{booking_date}** at the coworking space.\n"
+                f"Cost: {cost} {point_word}{balance_line}"
+            )
+
+        balance_line = ""
+        if new_balance is not None:
+            balance_line = f" (Balance remaining: {new_balance} points)"
+
+        return (
+            f"You beauty! 🎉\n\n"
+            f"Booked you in for **{booking_date}** at the coworking space.\n"
+            f"Cost: {cost} {point_word}{balance_line}\n\n"
+            f"See you there, legend!"
+        )
+
+    async def _format_admin_coworking_bad_request(
+        self,
+        *,
+        client,
+        target_user_id: str,
+        exc: httpx.HTTPStatusError,
+    ) -> str:
+        error_detail = self._extract_http_error_detail(exc) or "Bad request"
+        balance_line = ""
+        if "balance" in error_detail.lower() or "insufficient" in error_detail.lower():
+            try:
+                balance_data = await client.get_balance(target_user_id)
+                current_balance = balance_data.get("balance", 0)
+                balance_line = f"\n\nTheir current balance is **{current_balance} points**."
+            except Exception:
+                pass
+        return f"🛑 I couldn't check <@{target_user_id}> in: {error_detail}{balance_line}"
+
+    async def _book_coworking_with_intent(
+        self,
+        *,
+        client,
+        target_user_id: str,
+        requested_by_user_id: str,
+        booking_date: str,
+        text: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+        admin_checkin: bool,
+    ) -> str:
+        try:
+            store = get_coworking_intent_store()
+            intent = store.record_intent(
+                slack_user_id=target_user_id,
+                requested_by_slack_id=requested_by_user_id,
+                booking_date=booking_date,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                request_text=text,
+            )
+            leased_intent = store.reserve_for_processing(
+                int(intent["id"]),
+                owner=f"roo-sync-{uuid4().hex}",
+            )
+        except Exception as exc:
+            print(
+                "🏢 coworking_intent_persist_failed "
+                f"slack_user_id={target_user_id} requested_by={requested_by_user_id} "
+                f"booking_date={booking_date} exc_type={exc.__class__.__name__} exc={exc}"
+            )
+            return (
+                "I couldn't safely queue that coworking booking request just now, "
+                "so I didn't send it to MLAI backend. Please try again in a moment."
+            )
+
+        if not leased_intent:
+            return self._coworking_booking_already_queued_message(
+                booking_date=booking_date,
+                target_user_id=target_user_id,
+                admin_checkin=admin_checkin,
+            )
+
+        try:
+            result = await client.book_coworking(target_user_id, booking_date, channel_id)
+            store.mark_confirmed(int(leased_intent["id"]), backend_result=result)
+        except Exception as exc:
+            error = f"{exc.__class__.__name__}: {exc}"
+            if is_retryable_coworking_exception(exc):
+                store.mark_retryable_failure(int(leased_intent["id"]), error=error)
+                return self._coworking_booking_queued_for_retry_message(
+                    booking_date=booking_date,
+                    target_user_id=target_user_id,
+                    admin_checkin=admin_checkin,
+                )
+            store.mark_blocked(int(leased_intent["id"]), error=error)
+            raise
+
+        cost = result.get("points_cost", 1)
+        from roo.clients.mlai_backend import MLAIBackendUnavailableError
+
+        new_balance = None
+        try:
+            balance_data = await client.get_balance(target_user_id)
+            new_balance = balance_data.get("balance", 0)
+        except MLAIBackendUnavailableError:
+            pass
+
+        return self._format_coworking_booking_success(
+            booking_date=booking_date,
+            target_user_id=target_user_id,
+            cost=cost,
+            new_balance=new_balance,
+            admin_checkin=admin_checkin,
+        )
+
     async def _handle_points_action(
         self,
         client,
@@ -5630,6 +5875,54 @@ Keep the response concise but informative."""
             )
             return await self._format_coworking_analysis_response(context)
 
+        elif action == "admin_checkin_coworking":
+            from ..slack_client import get_bot_user_id
+            try:
+                bot_id = get_bot_user_id()
+            except Exception:
+                bot_id = None
+
+            target_slack_ids = self._extract_coworking_checkin_targets(
+                text,
+                params,
+                bot_id=bot_id,
+            )
+            if not target_slack_ids:
+                return "Who should I check in? Mention exactly one user, like `check @Jasmine in today`."
+            if len(target_slack_ids) != 1:
+                return "Tag exactly one user to check them in for coworking."
+
+            admin_details = await client.get_admin_details(user_id)
+            if not self._is_full_points_admin_details(admin_details):
+                return self._full_points_admin_denial(admin_details, "check people in for coworking")
+
+            target_user_id = target_slack_ids[0]
+            booking_date = self._resolve_coworking_booking_date(
+                params,
+                text,
+                default_to_today=True,
+            )
+
+            try:
+                return await self._book_coworking_with_intent(
+                    client=client,
+                    target_user_id=target_user_id,
+                    requested_by_user_id=user_id,
+                    booking_date=booking_date,
+                    text=text,
+                    channel_id=channel_id,
+                    thread_ts=thread_ts,
+                    admin_checkin=True,
+                )
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 400:
+                    return await self._format_admin_coworking_bad_request(
+                        client=client,
+                        target_user_id=target_user_id,
+                        exc=exc,
+                    )
+                raise
+
         elif action == "check_coworking":
             check_date = params.get("date")
             days = params.get("days", 7)
@@ -5651,86 +5944,20 @@ Keep the response concise but informative."""
             return "\n".join(lines)
         
         elif action == "book_coworking":
-            booking_date = params.get("date")
-            
-            # Normalize date aliases
-            if str(booking_date or "").lower() in {"today", "tomorrow"}:
-                from roo.utils import get_current_date
-                today = get_current_date()
-
-                if booking_date.lower() == "today":
-                    booking_date = today.isoformat()
-                elif booking_date.lower() == "tomorrow":
-                    booking_date = (today + timedelta(days=1)).isoformat()
-            
-            if not booking_date:
-                import re
-                match = re.search(r'(\d{4}-\d{2}-\d{2})', text)
-                if match:
-                    booking_date = match.group(1)
-                else:
-                    return "What date would you like to book? Use format YYYY-MM-DD (e.g., \"book 2025-12-20\")"
-            
-            try:
-                store = get_coworking_intent_store()
-                intent = store.record_intent(
-                    slack_user_id=user_id,
-                    booking_date=booking_date,
-                    channel_id=channel_id,
-                    thread_ts=thread_ts,
-                    request_text=text,
-                )
-                leased_intent = store.reserve_for_processing(
-                    int(intent["id"]),
-                    owner=f"roo-sync-{uuid4().hex}",
-                )
-            except Exception as exc:
-                print(
-                    "🏢 coworking_intent_persist_failed "
-                    f"slack_user_id={user_id} booking_date={booking_date} "
-                    f"exc_type={exc.__class__.__name__} exc={exc}"
-                )
-                return (
-                    "I couldn't safely queue your coworking booking request just now, "
-                    "so I didn't send it to MLAI backend. Please try again in a moment."
-                )
-
-            if not leased_intent:
-                return (
-                    f"I already have your coworking booking request for **{booking_date}** "
-                    "queued or in progress. I'll confirm in this thread when it completes."
-                )
-
-            try:
-                result = await client.book_coworking(user_id, booking_date, channel_id)
-                store.mark_confirmed(int(leased_intent["id"]), backend_result=result)
-            except Exception as exc:
-                error = f"{exc.__class__.__name__}: {exc}"
-                if is_retryable_coworking_exception(exc):
-                    store.mark_retryable_failure(int(leased_intent["id"]), error=error)
-                    return self._coworking_booking_queued_message(booking_date)
-                store.mark_blocked(int(leased_intent["id"]), error=error)
-                raise
-
-            cost = result.get("points_cost", 1)
-            from roo.clients.mlai_backend import MLAIBackendUnavailableError
-
-            new_balance = None
-            try:
-                balance_data = await client.get_balance(user_id)
-                new_balance = balance_data.get("balance", 0)
-            except MLAIBackendUnavailableError:
-                pass
-
-            balance_line = ""
-            if new_balance is not None:
-                balance_line = f" (Balance remaining: {new_balance} points)"
-
-            return (
-                f"You beauty! 🎉\n\n"
-                f"Booked you in for **{booking_date}** at the coworking space.\n"
-                f"Cost: {cost} point{balance_line}\n\n"
-                f"See you there, legend!"
+            booking_date = self._resolve_coworking_booking_date(
+                params,
+                text,
+                default_to_today=True,
+            )
+            return await self._book_coworking_with_intent(
+                client=client,
+                target_user_id=user_id,
+                requested_by_user_id=user_id,
+                booking_date=booking_date,
+                text=text,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                admin_checkin=False,
             )
         
         elif action == "cancel_coworking":

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -97,6 +97,19 @@ def test_request_points_phrase_routes_to_points():
     assert skill.name == "mlai-points"
 
 
+def test_coworking_booking_shortcuts_route_to_points():
+    agent = _make_agent()
+
+    for text in [
+        "book me in",
+        "book me in today",
+        "check <@U123ABC> in today",
+    ]:
+        skill = agent._select_skill_from_triggers(text)
+        assert skill is not None
+        assert skill.name == "mlai-points"
+
+
 def test_luma_attendee_csv_phrase_routes_to_luma_events():
     agent = _make_agent()
 

--- a/roo-standalone/roo/tests/test_coworking_booking_intents.py
+++ b/roo-standalone/roo/tests/test_coworking_booking_intents.py
@@ -95,6 +95,55 @@ async def test_process_intent_confirms_existing_booking_and_notifies(tmp_path, m
 
 
 @pytest.mark.asyncio
+async def test_process_admin_checkin_intent_names_target_user_in_retry_notification(tmp_path, monkeypatch):
+    store = coworking.CoworkingBookingIntentStore(tmp_path / "intents.db")
+    intent = store.record_intent(
+        slack_user_id="UTARGET",
+        requested_by_slack_id="UADMIN",
+        booking_date="2026-04-22",
+        channel_id="C123",
+        thread_ts="111.222",
+        request_text="check <@UTARGET> in today",
+    )
+    leased = store.reserve_for_processing(intent["id"], owner="test-worker")
+    posted = []
+
+    class FakeClient:
+        async def get_my_bookings(self, slack_user_id):
+            assert slack_user_id == "UTARGET"
+            return [{"date": "2026-04-22", "status": "booked"}]
+
+        async def book_coworking(self, *args, **kwargs):
+            raise AssertionError("should not create a duplicate booking")
+
+    monkeypatch.setattr(
+        slack_client_module,
+        "post_message",
+        lambda **kwargs: posted.append(kwargs) or {"ts": "333.444"},
+    )
+
+    result = await coworking.process_coworking_booking_intent(
+        leased,
+        store=store,
+        client=FakeClient(),
+        notify=True,
+    )
+
+    assert result["status"] == "confirmed"
+    assert result["already_booked"] is True
+    assert posted == [
+        {
+            "channel": "C123",
+            "thread_ts": "111.222",
+            "text": (
+                "I retried the queued coworking check-in for <@UTARGET> "
+                "and confirmed 2026-04-22. They're booked."
+            ),
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_process_intent_keeps_retryable_backend_timeout_queued(tmp_path):
     store = coworking.CoworkingBookingIntentStore(tmp_path / "intents.db")
     intent = store.record_intent(

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -1914,6 +1914,222 @@ async def test_book_coworking_still_succeeds_when_balance_refresh_times_out(tmp_
     assert "Balance remaining" not in result
 
 
+@pytest.mark.asyncio
+async def test_book_coworking_defaults_missing_date_to_today(tmp_path, monkeypatch):
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "intents.db")
+
+    class FakeCoworkingClient:
+        def __init__(self):
+            self.book_args = None
+            self.balance_args = None
+
+        async def book_coworking(self, slack_user_id, booking_date, slack_channel_id=None):
+            self.book_args = (slack_user_id, booking_date, slack_channel_id)
+            return {"points_cost": 1}
+
+        async def get_balance(self, slack_user_id):
+            self.balance_args = slack_user_id
+            return {"balance": 9}
+
+    client = FakeCoworkingClient()
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="book_coworking",
+        params={},
+        text="book me in",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    intent = store.get_by_key("coworking:U123:2026-05-04")
+    assert "Booked you in for **2026-05-04**" in result
+    assert client.book_args == ("U123", "2026-05-04", "C123")
+    assert client.balance_args == "U123"
+    assert intent["requested_by_slack_id"] == "U123"
+
+
+class FakeAdminCheckinCoworkingClient:
+    def __init__(
+        self,
+        *,
+        role="admin",
+        book_exception=None,
+        balance=14,
+    ):
+        self.role = role
+        self.book_exception = book_exception
+        self.balance = balance
+        self.admin_checks = []
+        self.book_args = None
+        self.balance_args = None
+
+    async def get_admin_details(self, slack_user_id):
+        self.admin_checks.append(slack_user_id)
+        if not self.role:
+            return None
+        return {"slack_user_id": slack_user_id, "role": self.role}
+
+    async def book_coworking(self, slack_user_id, booking_date, slack_channel_id=None):
+        self.book_args = (slack_user_id, booking_date, slack_channel_id)
+        if self.book_exception:
+            raise self.book_exception
+        return {"points_cost": 1}
+
+    async def get_balance(self, slack_user_id):
+        self.balance_args = slack_user_id
+        return {"balance": self.balance}
+
+
+@pytest.mark.asyncio
+async def test_admin_checkin_books_target_for_today(tmp_path, monkeypatch):
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "intents.db")
+    client = FakeAdminCheckinCoworkingClient(balance=13)
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="admin_checkin_coworking",
+        params={},
+        text="check <@UTARGET> in today",
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    intent = store.get_by_key("coworking:UTARGET:2026-05-04")
+    assert "Checked <@UTARGET> in for **2026-05-04**" in result
+    assert "Their balance: 13 pts" in result
+    assert client.book_args == ("UTARGET", "2026-05-04", "C123")
+    assert client.balance_args == "UTARGET"
+    assert intent["requested_by_slack_id"] == "UADMIN"
+
+
+@pytest.mark.asyncio
+async def test_admin_checkin_honors_explicit_date(tmp_path, monkeypatch):
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "intents.db")
+    client = FakeAdminCheckinCoworkingClient()
+    executor = SkillExecutor()
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="admin_checkin_coworking",
+        params={"date": "2026-06-01"},
+        text="check <@UTARGET> in 2026-06-01",
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "Checked <@UTARGET> in for **2026-06-01**" in result
+    assert client.book_args == ("UTARGET", "2026-06-01", "C123")
+
+
+@pytest.mark.asyncio
+async def test_admin_checkin_denies_partner_without_booking(tmp_path, monkeypatch):
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "intents.db")
+    client = FakeAdminCheckinCoworkingClient(role="partner")
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="admin_checkin_coworking",
+        params={},
+        text="check <@UTARGET> in today",
+        user_id="UPARTNER",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "partner admins can only generate coworking reports" in result
+    assert client.book_args is None
+    assert store.counts_by_status() == {}
+
+
+@pytest.mark.asyncio
+async def test_admin_checkin_requires_exactly_one_target(monkeypatch):
+    executor = SkillExecutor()
+    client = FakeAdminCheckinCoworkingClient()
+    monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+
+    missing_result = await executor._handle_points_action(
+        client=client,
+        action="admin_checkin_coworking",
+        params={},
+        text="check in today",
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+    multiple_result = await executor._handle_points_action(
+        client=client,
+        action="admin_checkin_coworking",
+        params={},
+        text="check <@UONE> and <@UTWO> in today",
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "Mention exactly one user" in missing_result
+    assert "Tag exactly one user" in multiple_result
+    assert client.book_args is None
+
+
+@pytest.mark.asyncio
+async def test_admin_checkin_insufficient_balance_message_names_target(tmp_path, monkeypatch):
+    request = httpx.Request("POST", "https://backend.test/api/v1/points/coworking/book/")
+    response = httpx.Response(
+        400,
+        request=request,
+        json={"detail": "Insufficient balance: need 1 point"},
+    )
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "intents.db")
+    client = FakeAdminCheckinCoworkingClient(
+        book_exception=httpx.HTTPStatusError("bad request", request=request, response=response),
+        balance=0,
+    )
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="admin_checkin_coworking",
+        params={},
+        text="check <@UTARGET> in today",
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    intent = store.get_by_key("coworking:UTARGET:2026-05-04")
+    assert "I couldn't check <@UTARGET> in" in result
+    assert "Their current balance is **0 points**" in result
+    assert "UADMIN" not in result
+    assert intent["status"] == "blocked"
+
+
 def make_coworking_report(start_date: str, end_date: str, counts: list[int], unique_users: int = 2) -> dict:
     start = date.fromisoformat(start_date)
     end = date.fromisoformat(end_date)
@@ -2447,6 +2663,16 @@ def test_resolve_points_action_detects_coworking_report_wording():
             "show coworking trends for the last 3 months and recommendations",
         )
         == "coworking_report"
+    )
+
+
+def test_resolve_points_action_detects_coworking_shortcuts():
+    executor = SkillExecutor()
+
+    assert executor._resolve_points_action({}, "book me in") == "book_coworking"
+    assert (
+        executor._resolve_points_action({}, "check <@UTARGET> in today")
+        == "admin_checkin_coworking"
     )
 
 

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -25,6 +25,7 @@ This skill enables Roo to interact with the MLAI Points System via API, allowing
 - Submit completed work for approval
 - Unclaim a task before any submission exists
 - Book and cancel coworking days
+- Points Admins can check another member in for coworking from Slack
 - View rewards catalog and request redemptions
 
 ### Full Admin Actions (requires `admin`, `committee`, or `portfolio_lead` role)
@@ -65,7 +66,7 @@ Example responses:
 
 ## Parameters
 
-- **action**: The action to perform (required) - e.g., "balance", "request_points", "book_coworking", "coworking_report", "claim_task", "submit_task", "award_points", "create_task"
+- **action**: The action to perform (required) - e.g., "balance", "request_points", "book_coworking", "admin_checkin_coworking", "coworking_report", "claim_task", "submit_task", "award_points", "create_task"
 - **task_id**: Task ID number or task code (for example `42` or `ROO-0042`) for task-related actions
 - **date**: Date for coworking bookings (YYYY-MM-DD format)
 - **start_date**: Start date for coworking reports (YYYY-MM-DD format)
@@ -122,7 +123,8 @@ Parse user messages to identify the action and parameters:
 | `coworking trends/recommendations ...` | coworking_report | "Show coworking trends for the last 3 months and recommendations" |
 | `coworking report last 3/6 months` | coworking_report | "Coworking report last 3 months" |
 | `coworking report last year` | coworking_report | "Coworking report last year" |
-| `coworking book <date/today>` | book_coworking | "Book me in for today", "@Roo coworking book today" |
+| `coworking book <date/today>` | book_coworking | "Book me in", "Book me in for today", "@Roo coworking book" |
+| `check <@USER> in <date/today>` | admin_checkin_coworking | (Admin) "Check <@U123> in", "Check <@U123> in today" |
 | `coworking cancel <date>` | cancel_coworking | "Cancel my booking for Friday", "@Roo coworking cancel" |
 | `rewards`, `points rewards` | list_rewards | "What rewards are available?", "@Roo points rewards" |
 | `reward request <code>` | request_reward | "I want to get the HOTDESK_DAY reward" |
@@ -155,6 +157,8 @@ Parse the user's message to determine which action they want:
 - Accept both numeric task ids and `ROO-xxxx` task codes
 - Treat `request ... points for ...` as `request_points`, not `award_points`
 - For admin actions, verify the Slack mention format
+- Treat coworking booking requests without a date as a booking for today
+- For admin coworking check-ins, require exactly one tagged Slack user and book that user, not the admin
 - For super admin actions, require exactly one tagged Slack user, never fall through into `award_points`, and require a positive numeric allowance when changing allowance
 
 ### Step 2: Permission Check
@@ -162,6 +166,13 @@ For full admin-only actions (create, edit, cancel, approve, reject, award):
 - The API will validate the requester's Slack ID
 - Partner admins are not full admins and must be denied for point-mutating actions
 - If 403 returned, respond with friendly denial
+
+For admin coworking check-ins:
+- Roo must fail fast unless the requester is a full Points Admin
+- Partner admins are report-only and cannot check people in
+- The target user is the single non-Roo Slack mention in the message
+- The booking date defaults to today when omitted
+- The coworking booking must be created for the target user's Slack ID so the target user's points are deducted
 
 For super admin actions (promote admin, revoke admin, change allowance):
 - Roo must fail fast unless the requester Slack ID is `U05QPB483K9`


### PR DESCRIPTION
## Summary
- Default no-date coworking booking requests to today.
- Add admin-only coworking check-in commands that book the mentioned member, not the admin.
- Persist the requester on coworking booking intents so retries can distinguish admin check-ins from self-bookings.

## Validation
- `python3 -m pytest roo/tests/test_agent_routing.py roo/tests/test_coworking_booking_intents.py roo/tests/test_points_requests.py -q` passed: 116 tests.
- `python3 -m pytest roo/tests -q` was also run; 211 tests passed and 5 existing Content Factory Slack action tests failed outside this coworking/points change path.