### PR TITLE
[codex] Add auto link-love rewards

### DIFF
--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -46,6 +46,11 @@ class Settings(BaseSettings):
     ROUTER_MODEL: str = "gpt-5.4"
     COWORKING_INTENTS_DB_PATH: str = "data/coworking_booking_intents.db"
     COWORKING_RETRY_POLL_SECONDS: float = 30.0
+    BOOST_LINK_LOVE_ENABLED: bool = True
+    BOOST_LINK_LOVE_CHANNEL_NAME: str = "boost-my-startup"
+    BOOST_LINK_LOVE_DB_PATH: str = "data/link_love_awards.db"
+    BOOST_LINK_LOVE_NOTIFICATION_DELAY_SECONDS: int = 60
+    BOOST_LINK_LOVE_RETRY_POLL_SECONDS: float = 15.0
     JOBS_SCHEDULER_ENABLED: bool = False
     JOBS_API_URL: Optional[str] = None
     JOBS_TRIGGER_TOKEN: Optional[str] = None

--- a/roo-standalone/roo/link_love.py
+++ b/roo-standalone/roo/link_love.py
@@ -1,0 +1,870 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional
+from uuid import uuid4
+
+import httpx
+
+from .config import get_settings
+
+
+LINK_LOVE_POINTS = 2
+LINK_LOVE_REASON = "link-love"
+DEFAULT_LINK_LOVE_DB_PATH = "data/link_love_awards.db"
+DEFAULT_RETRY_POLL_SECONDS = 15.0
+DEFAULT_PROCESSING_LEASE_SECONDS = 90.0
+
+
+def _now() -> float:
+    return time.time()
+
+
+def retry_delay_seconds(attempt_count: int) -> float:
+    attempt_number = max(1, int(attempt_count or 1))
+    return min(15 * 60, 30 * (2 ** (attempt_number - 1)))
+
+
+def clean_slack_user_id(raw_value: Any) -> str:
+    value = str(raw_value or "").strip()
+    if value.startswith("<@") and value.endswith(">"):
+        value = value[2:-1]
+    return value.strip()
+
+
+def is_thread_reply_event(event: dict[str, Any]) -> bool:
+    thread_ts = str(event.get("thread_ts") or "").strip()
+    message_ts = str(event.get("ts") or "").strip()
+    return bool(thread_ts and message_ts and thread_ts != message_ts)
+
+
+def is_retryable_link_love_exception(exc: Exception) -> bool:
+    from .clients.mlai_backend import MLAIBackendUnavailableError
+
+    if isinstance(exc, MLAIBackendUnavailableError):
+        return True
+    if isinstance(exc, httpx.TransportError):
+        return True
+    if isinstance(exc, httpx.HTTPStatusError):
+        status_code = exc.response.status_code
+        return status_code in {408, 425, 429} or 500 <= status_code < 600
+    return False
+
+
+@dataclass(frozen=True)
+class LinkLoveClassification:
+    engaged: bool
+    confidence: float
+    reason: str
+    raw_response: str
+
+
+def build_link_love_classification_messages(
+    *,
+    root_text: str,
+    reply_text: str,
+) -> list[dict[str, str]]:
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You classify Slack thread replies in #boost-my-startup. "
+                "Founders post social content and other founders reply after engaging off Slack. "
+                "Return only JSON with keys engaged, confidence, and reason. "
+                "Set engaged=true only when the reply clearly claims the user liked, commented, "
+                "shared, reposted, boosted, supported, or otherwise engaged with the original "
+                "social post. Count short channel shorthand like 'done' or 'liked'. "
+                "Do not count questions, discussion about the post, pure praise, or vague support "
+                "such as 'love it', 'great launch', 'congrats', 'huge', or 'this is awesome'."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                "Examples:\n"
+                'Reply: "Liked" -> {"engaged": true, "confidence": 0.98, "reason": "explicit like"}\n'
+                'Reply: "Done" -> {"engaged": true, "confidence": 0.9, "reason": "channel shorthand for completed engagement"}\n'
+                'Reply: "Liked and commented" -> {"engaged": true, "confidence": 0.99, "reason": "explicit like and comment"}\n'
+                'Reply: "Love it!!" -> {"engaged": false, "confidence": 0.9, "reason": "vague support only"}\n'
+                'Reply: "How did you get Batko as cofounder?" -> {"engaged": false, "confidence": 0.96, "reason": "question only"}\n\n'
+                f"Original top-level post:\n{root_text[:2000]}\n\n"
+                f"Thread reply to classify:\n{reply_text[:1000]}"
+            ),
+        },
+    ]
+
+
+def _extract_json_object(raw_content: str) -> dict[str, Any]:
+    content = str(raw_content or "").strip()
+    if content.startswith("```"):
+        lines = content.splitlines()
+        if lines and lines[0].startswith("```"):
+            lines = lines[1:]
+        if lines and lines[-1].strip().startswith("```"):
+            lines = lines[:-1]
+        content = "\n".join(lines).strip()
+
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        start = content.find("{")
+        end = content.rfind("}")
+        if start == -1 or end == -1 or end <= start:
+            raise
+        parsed = json.loads(content[start : end + 1])
+
+    if not isinstance(parsed, dict):
+        raise ValueError("classifier response must be a JSON object")
+    return parsed
+
+
+def parse_link_love_classification(raw_content: str) -> LinkLoveClassification:
+    try:
+        payload = _extract_json_object(raw_content)
+        confidence = float(payload.get("confidence") or 0.0)
+        return LinkLoveClassification(
+            engaged=bool(payload.get("engaged")),
+            confidence=max(0.0, min(1.0, confidence)),
+            reason=str(payload.get("reason") or "").strip(),
+            raw_response=str(raw_content or ""),
+        )
+    except Exception as exc:
+        return LinkLoveClassification(
+            engaged=False,
+            confidence=0.0,
+            reason=f"classifier_parse_error: {exc}",
+            raw_response=str(raw_content or ""),
+        )
+
+
+async def classify_link_love_reply(
+    *,
+    root_text: str,
+    reply_text: str,
+    llm_chat: Optional[Callable[..., Any]] = None,
+) -> LinkLoveClassification:
+    if llm_chat is None:
+        from .llm import chat as llm_chat
+
+    response = await llm_chat(
+        build_link_love_classification_messages(root_text=root_text, reply_text=reply_text),
+        max_tokens=160,
+        temperature=0,
+    )
+    return parse_link_love_classification(getattr(response, "content", response))
+
+
+class LinkLoveAwardStore:
+    def __init__(self, db_path: str | Path = DEFAULT_LINK_LOVE_DB_PATH):
+        self.db_path = Path(db_path)
+        self._lock = threading.RLock()
+        self._initialized = False
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.db_path), timeout=30, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=30000")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        with self._lock:
+            if self._initialized:
+                return
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS link_love_reply_checks (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        channel_id TEXT NOT NULL,
+                        root_message_ts TEXT NOT NULL,
+                        reply_message_ts TEXT NOT NULL,
+                        slack_user_id TEXT NOT NULL,
+                        root_author_slack_id TEXT,
+                        reply_text TEXT,
+                        root_text TEXT,
+                        classification_status TEXT NOT NULL,
+                        qualifies INTEGER NOT NULL DEFAULT 0,
+                        classifier_reason TEXT,
+                        classifier_response_json TEXT,
+                        award_id INTEGER,
+                        created_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        UNIQUE(channel_id, reply_message_ts)
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS link_love_awards (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        channel_id TEXT NOT NULL,
+                        root_message_ts TEXT NOT NULL,
+                        slack_user_id TEXT NOT NULL,
+                        root_author_slack_id TEXT,
+                        source_reply_message_ts TEXT,
+                        status TEXT NOT NULL,
+                        attempt_count INTEGER NOT NULL DEFAULT 0,
+                        next_attempt_at REAL NOT NULL,
+                        locked_until REAL,
+                        locked_by TEXT,
+                        last_error TEXT,
+                        backend_result_json TEXT,
+                        points_awarded INTEGER,
+                        new_balance INTEGER,
+                        notification_available_at REAL,
+                        notified_at REAL,
+                        created_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        UNIQUE(channel_id, root_message_ts, slack_user_id)
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_link_love_awards_due
+                    ON link_love_awards (status, next_attempt_at)
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_link_love_awards_notifications
+                    ON link_love_awards (status, notification_available_at)
+                    """
+                )
+            self._initialized = True
+
+    @staticmethod
+    def _row_to_dict(row: sqlite3.Row | None) -> Optional[dict[str, Any]]:
+        return dict(row) if row is not None else None
+
+    def get_reply_check(self, channel_id: str, reply_message_ts: str) -> Optional[dict[str, Any]]:
+        self._ensure_schema()
+        with self._connect() as conn:
+            return self._row_to_dict(
+                conn.execute(
+                    """
+                    SELECT * FROM link_love_reply_checks
+                    WHERE channel_id = ? AND reply_message_ts = ?
+                    """,
+                    (channel_id, reply_message_ts),
+                ).fetchone()
+            )
+
+    def create_reply_check(
+        self,
+        *,
+        channel_id: str,
+        root_message_ts: str,
+        reply_message_ts: str,
+        slack_user_id: str,
+        root_author_slack_id: str,
+        reply_text: str,
+        root_text: str,
+    ) -> Optional[dict[str, Any]]:
+        self._ensure_schema()
+        now = _now()
+        with self._lock, self._connect() as conn:
+            try:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO link_love_reply_checks (
+                        channel_id,
+                        root_message_ts,
+                        reply_message_ts,
+                        slack_user_id,
+                        root_author_slack_id,
+                        reply_text,
+                        root_text,
+                        classification_status,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+                    """,
+                    (
+                        channel_id,
+                        root_message_ts,
+                        reply_message_ts,
+                        slack_user_id,
+                        root_author_slack_id,
+                        reply_text,
+                        root_text,
+                        now,
+                        now,
+                    ),
+                )
+            except sqlite3.IntegrityError:
+                return None
+            return self._row_to_dict(
+                conn.execute(
+                    "SELECT * FROM link_love_reply_checks WHERE id = ?",
+                    (cursor.lastrowid,),
+                ).fetchone()
+            )
+
+    def mark_reply_check_classified(
+        self,
+        reply_check_id: int,
+        *,
+        status: str,
+        qualifies: bool,
+        reason: str,
+        raw_response: str,
+        award_id: Optional[int] = None,
+    ) -> None:
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE link_love_reply_checks
+                SET classification_status = ?,
+                    qualifies = ?,
+                    classifier_reason = ?,
+                    classifier_response_json = ?,
+                    award_id = COALESCE(?, award_id),
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    status,
+                    1 if qualifies else 0,
+                    reason,
+                    raw_response,
+                    award_id,
+                    _now(),
+                    reply_check_id,
+                ),
+            )
+
+    def create_award(
+        self,
+        *,
+        channel_id: str,
+        root_message_ts: str,
+        slack_user_id: str,
+        root_author_slack_id: str,
+        source_reply_message_ts: str,
+        locked_by: Optional[str] = None,
+        lease_seconds: float = DEFAULT_PROCESSING_LEASE_SECONDS,
+    ) -> tuple[bool, dict[str, Any]]:
+        self._ensure_schema()
+        now = _now()
+        locked_until = now + lease_seconds if locked_by else None
+        with self._lock, self._connect() as conn:
+            try:
+                cursor = conn.execute(
+                    """
+                    INSERT INTO link_love_awards (
+                        channel_id,
+                        root_message_ts,
+                        slack_user_id,
+                        root_author_slack_id,
+                        source_reply_message_ts,
+                        status,
+                        next_attempt_at,
+                        locked_until,
+                        locked_by,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (?, ?, ?, ?, ?, 'pending_award', ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        channel_id,
+                        root_message_ts,
+                        slack_user_id,
+                        root_author_slack_id,
+                        source_reply_message_ts,
+                        now,
+                        locked_until,
+                        locked_by,
+                        now,
+                        now,
+                    ),
+                )
+                created = True
+                award_id = cursor.lastrowid
+            except sqlite3.IntegrityError:
+                created = False
+                award_id = None
+
+            row = (
+                conn.execute(
+                    "SELECT * FROM link_love_awards WHERE id = ?",
+                    (award_id,),
+                ).fetchone()
+                if award_id is not None
+                else conn.execute(
+                    """
+                    SELECT * FROM link_love_awards
+                    WHERE channel_id = ? AND root_message_ts = ? AND slack_user_id = ?
+                    """,
+                    (channel_id, root_message_ts, slack_user_id),
+                ).fetchone()
+            )
+            return created, dict(row)
+
+    def claim_due_awards(
+        self,
+        *,
+        limit: int,
+        owner: str,
+        lease_seconds: float = DEFAULT_PROCESSING_LEASE_SECONDS,
+    ) -> list[dict[str, Any]]:
+        self._ensure_schema()
+        now = _now()
+        locked_until = now + lease_seconds
+        with self._lock, self._connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM link_love_awards
+                WHERE status = 'pending_award'
+                  AND next_attempt_at <= ?
+                  AND (locked_until IS NULL OR locked_until <= ?)
+                ORDER BY next_attempt_at, id
+                LIMIT ?
+                """,
+                (now, now, limit),
+            ).fetchall()
+            ids = [int(row["id"]) for row in rows]
+            if not ids:
+                return []
+            placeholders = ",".join("?" for _ in ids)
+            conn.execute(
+                f"""
+                UPDATE link_love_awards
+                SET locked_until = ?, locked_by = ?, updated_at = ?
+                WHERE id IN ({placeholders})
+                """,
+                (locked_until, owner, now, *ids),
+            )
+            claimed = conn.execute(
+                f"SELECT * FROM link_love_awards WHERE id IN ({placeholders}) ORDER BY id",
+                ids,
+            ).fetchall()
+            return [dict(row) for row in claimed]
+
+    def mark_awarded(
+        self,
+        award_id: int,
+        *,
+        backend_result: dict[str, Any],
+        notification_delay_seconds: float,
+    ) -> dict[str, Any]:
+        self._ensure_schema()
+        now = _now()
+        notification_available_at = now + max(0.0, float(notification_delay_seconds))
+        points_awarded = backend_result.get("points_awarded")
+        new_balance = backend_result.get("new_balance")
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE link_love_awards
+                SET status = 'awarded',
+                    locked_until = NULL,
+                    locked_by = NULL,
+                    last_error = NULL,
+                    backend_result_json = ?,
+                    points_awarded = ?,
+                    new_balance = ?,
+                    notification_available_at = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    json.dumps(backend_result, sort_keys=True),
+                    int(points_awarded) if points_awarded is not None else None,
+                    int(new_balance) if new_balance is not None else None,
+                    notification_available_at,
+                    now,
+                    award_id,
+                ),
+            )
+            return dict(
+                conn.execute(
+                    "SELECT * FROM link_love_awards WHERE id = ?",
+                    (award_id,),
+                ).fetchone()
+            )
+
+    def mark_retryable_failure(self, award_id: int, *, error: str) -> dict[str, Any]:
+        self._ensure_schema()
+        now = _now()
+        with self._lock, self._connect() as conn:
+            row = conn.execute(
+                "SELECT attempt_count FROM link_love_awards WHERE id = ?",
+                (award_id,),
+            ).fetchone()
+            next_attempt_count = int(row["attempt_count"] or 0) + 1 if row else 1
+            conn.execute(
+                """
+                UPDATE link_love_awards
+                SET attempt_count = ?,
+                    next_attempt_at = ?,
+                    locked_until = NULL,
+                    locked_by = NULL,
+                    last_error = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    next_attempt_count,
+                    now + retry_delay_seconds(next_attempt_count),
+                    error,
+                    now,
+                    award_id,
+                ),
+            )
+            return dict(
+                conn.execute(
+                    "SELECT * FROM link_love_awards WHERE id = ?",
+                    (award_id,),
+                ).fetchone()
+            )
+
+    def mark_blocked(self, award_id: int, *, error: str) -> dict[str, Any]:
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE link_love_awards
+                SET status = 'blocked',
+                    locked_until = NULL,
+                    locked_by = NULL,
+                    last_error = ?,
+                    updated_at = ?
+                WHERE id = ?
+                """,
+                (error, _now(), award_id),
+            )
+            return dict(
+                conn.execute(
+                    "SELECT * FROM link_love_awards WHERE id = ?",
+                    (award_id,),
+                ).fetchone()
+            )
+
+    def get_due_notification_groups(self, *, limit: int = 50) -> list[dict[str, Any]]:
+        self._ensure_schema()
+        now = _now()
+        with self._connect() as conn:
+            rows = [
+                dict(row)
+                for row in conn.execute(
+                    """
+                    SELECT * FROM link_love_awards
+                    WHERE status = 'awarded'
+                      AND notified_at IS NULL
+                      AND notification_available_at <= ?
+                    ORDER BY channel_id, root_message_ts, created_at
+                    LIMIT ?
+                    """,
+                    (now, limit),
+                ).fetchall()
+            ]
+        groups_by_key: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        for row in rows:
+            key = (str(row["channel_id"]), str(row["root_message_ts"]))
+            groups_by_key.setdefault(key, []).append(row)
+        return [
+            {"channel_id": key[0], "root_message_ts": key[1], "awards": awards}
+            for key, awards in groups_by_key.items()
+        ]
+
+    def mark_notified(self, award_ids: list[int]) -> None:
+        if not award_ids:
+            return
+        self._ensure_schema()
+        now = _now()
+        with self._lock, self._connect() as conn:
+            placeholders = ",".join("?" for _ in award_ids)
+            conn.execute(
+                f"""
+                UPDATE link_love_awards
+                SET status = 'notified',
+                    notified_at = ?,
+                    updated_at = ?
+                WHERE id IN ({placeholders})
+                """,
+                (now, now, *award_ids),
+            )
+
+
+_store: LinkLoveAwardStore | None = None
+
+
+def get_link_love_store() -> LinkLoveAwardStore:
+    global _store
+    if _store is None:
+        settings = get_settings()
+        db_path = getattr(settings, "BOOST_LINK_LOVE_DB_PATH", DEFAULT_LINK_LOVE_DB_PATH)
+        _store = LinkLoveAwardStore(db_path)
+    return _store
+
+
+def _build_backend_client():
+    from .clients.mlai_backend import MLAIBackendClient
+
+    settings = get_settings()
+    return MLAIBackendClient(
+        base_url=settings.MLAI_BACKEND_URL,
+        api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY,
+        internal_api_key=settings.INTERNAL_API_KEY or settings.ROO_API_KEY or settings.MLAI_API_KEY,
+    )
+
+
+def _build_notification_text(awards: list[dict[str, Any]]) -> str:
+    if len(awards) == 1:
+        heading = ":tada: Awarded 2 points for link-love."
+    else:
+        heading = ":tada: Awarded 2 points each for link-love."
+
+    lines = [heading]
+    for award in awards:
+        user_id = award.get("slack_user_id")
+        new_balance = award.get("new_balance")
+        if new_balance is None:
+            lines.append(f":white_check_mark: <@{user_id}>: awarded 2 pts")
+        else:
+            lines.append(f":white_check_mark: <@{user_id}>: now has {new_balance} pts")
+    return "\n".join(lines)
+
+
+async def process_link_love_award(
+    award: dict[str, Any],
+    *,
+    store: Optional[LinkLoveAwardStore] = None,
+    client: Any = None,
+    bot_user_id: Optional[str] = None,
+    notification_delay_seconds: Optional[float] = None,
+) -> dict[str, Any]:
+    store = store or get_link_love_store()
+    client = client or _build_backend_client()
+    if bot_user_id is None:
+        from .slack_client import get_bot_user_id
+
+        bot_user_id = get_bot_user_id()
+
+    if notification_delay_seconds is not None:
+        delay = notification_delay_seconds
+    else:
+        settings = get_settings()
+        delay = getattr(settings, "BOOST_LINK_LOVE_NOTIFICATION_DELAY_SECONDS", 60)
+
+    try:
+        backend_result = await client.system_award_points(
+            admin_slack_id=bot_user_id,
+            target_slack_id=str(award["slack_user_id"]),
+            points=LINK_LOVE_POINTS,
+            reason=LINK_LOVE_REASON,
+        )
+        updated = store.mark_awarded(
+            int(award["id"]),
+            backend_result=backend_result,
+            notification_delay_seconds=float(delay),
+        )
+        return {"status": "awarded", "award": updated, "backend_result": backend_result}
+    except Exception as exc:
+        error = f"{exc.__class__.__name__}: {exc}"
+        if is_retryable_link_love_exception(exc):
+            updated = store.mark_retryable_failure(int(award["id"]), error=error)
+            print(
+                "🔁 link_love_award_retryable_failure "
+                f"award_id={award.get('id')} slack_user_id={award.get('slack_user_id')} error={error}"
+            )
+            return {"status": "pending_retry", "award": updated, "error": error}
+        updated = store.mark_blocked(int(award["id"]), error=error)
+        print(
+            "⚠️ link_love_award_blocked "
+            f"award_id={award.get('id')} slack_user_id={award.get('slack_user_id')} error={error}"
+        )
+        return {"status": "blocked", "award": updated, "error": error}
+
+
+async def handle_link_love_reply(
+    event: dict[str, Any],
+    *,
+    store: Optional[LinkLoveAwardStore] = None,
+    client: Any = None,
+    get_root_message: Optional[Callable[[str, str], Optional[dict[str, Any]]]] = None,
+    llm_chat: Optional[Callable[..., Any]] = None,
+    bot_user_id: Optional[str] = None,
+    notification_delay_seconds: Optional[float] = None,
+) -> dict[str, Any]:
+    if not is_thread_reply_event(event):
+        return {"status": "ignored", "reason": "not_thread_reply"}
+
+    store = store or get_link_love_store()
+    channel_id = str(event.get("channel") or "").strip()
+    root_message_ts = str(event.get("thread_ts") or "").strip()
+    reply_message_ts = str(event.get("ts") or "").strip()
+    slack_user_id = clean_slack_user_id(event.get("user"))
+    reply_text = str(event.get("text") or "")
+    if not channel_id or not root_message_ts or not reply_message_ts or not slack_user_id:
+        return {"status": "ignored", "reason": "missing_required_event_fields"}
+
+    if store.get_reply_check(channel_id, reply_message_ts):
+        return {"status": "duplicate_reply"}
+
+    if get_root_message is None:
+        from .slack_client import get_message
+
+        get_root_message = get_message
+    root_message = get_root_message(channel_id, root_message_ts)
+    if not root_message:
+        print(
+            "⚠️ link_love_missing_root "
+            f"channel_id={channel_id} root_message_ts={root_message_ts} reply_message_ts={reply_message_ts}"
+        )
+        return {"status": "ignored", "reason": "missing_root_message"}
+
+    root_author_slack_id = clean_slack_user_id(root_message.get("user"))
+    root_text = str(root_message.get("text") or "")
+    reply_check = store.create_reply_check(
+        channel_id=channel_id,
+        root_message_ts=root_message_ts,
+        reply_message_ts=reply_message_ts,
+        slack_user_id=slack_user_id,
+        root_author_slack_id=root_author_slack_id,
+        reply_text=reply_text,
+        root_text=root_text,
+    )
+    if reply_check is None:
+        return {"status": "duplicate_reply"}
+
+    if not root_author_slack_id:
+        store.mark_reply_check_classified(
+            int(reply_check["id"]),
+            status="ineligible",
+            qualifies=False,
+            reason="root author missing",
+            raw_response="",
+        )
+        return {"status": "ignored", "reason": "root_author_missing"}
+
+    if root_author_slack_id == slack_user_id:
+        store.mark_reply_check_classified(
+            int(reply_check["id"]),
+            status="ineligible",
+            qualifies=False,
+            reason="root author cannot earn link-love on their own post",
+            raw_response="",
+        )
+        return {"status": "ignored", "reason": "root_author_reply"}
+
+    try:
+        classification = await classify_link_love_reply(
+            root_text=root_text,
+            reply_text=reply_text,
+            llm_chat=llm_chat,
+        )
+    except Exception as exc:
+        classification = LinkLoveClassification(
+            engaged=False,
+            confidence=0.0,
+            reason=f"classifier_error: {exc.__class__.__name__}: {exc}",
+            raw_response="",
+        )
+
+    if not classification.engaged:
+        store.mark_reply_check_classified(
+            int(reply_check["id"]),
+            status="ineligible",
+            qualifies=False,
+            reason=classification.reason,
+            raw_response=classification.raw_response,
+        )
+        return {"status": "ineligible", "classification": classification}
+
+    award_created, award = store.create_award(
+        channel_id=channel_id,
+        root_message_ts=root_message_ts,
+        slack_user_id=slack_user_id,
+        root_author_slack_id=root_author_slack_id,
+        source_reply_message_ts=reply_message_ts,
+        locked_by=f"roo-link-love-handler-{reply_message_ts}",
+    )
+    store.mark_reply_check_classified(
+        int(reply_check["id"]),
+        status="eligible",
+        qualifies=True,
+        reason=classification.reason,
+        raw_response=classification.raw_response,
+        award_id=int(award["id"]),
+    )
+    if not award_created:
+        return {"status": "already_awarded", "award": award}
+
+    result = await process_link_love_award(
+        award,
+        store=store,
+        client=client,
+        bot_user_id=bot_user_id,
+        notification_delay_seconds=notification_delay_seconds,
+    )
+    return {**result, "classification": classification}
+
+
+def post_due_link_love_notifications(
+    *,
+    store: Optional[LinkLoveAwardStore] = None,
+) -> int:
+    store = store or get_link_love_store()
+    groups = store.get_due_notification_groups()
+    posted_count = 0
+    if not groups:
+        return posted_count
+
+    from .slack_client import post_message
+
+    for group in groups:
+        awards = list(group["awards"])
+        if not awards:
+            continue
+        award_ids = [int(award["id"]) for award in awards]
+        post_message(
+            channel=str(group["channel_id"]),
+            thread_ts=str(group["root_message_ts"]),
+            text=_build_notification_text(awards),
+        )
+        store.mark_notified(award_ids)
+        posted_count += 1
+    return posted_count
+
+
+async def link_love_retry_loop(
+    *,
+    store: Optional[LinkLoveAwardStore] = None,
+    poll_seconds: Optional[float] = None,
+) -> None:
+    settings = get_settings()
+    store = store or get_link_love_store()
+    poll_interval = float(
+        poll_seconds
+        if poll_seconds is not None
+        else getattr(settings, "BOOST_LINK_LOVE_RETRY_POLL_SECONDS", DEFAULT_RETRY_POLL_SECONDS)
+    )
+    owner = f"roo-link-love-worker-{uuid4().hex}"
+    print(f"🔗 Link-love worker started owner={owner} poll_seconds={poll_interval}")
+
+    while True:
+        try:
+            due = store.claim_due_awards(limit=10, owner=owner)
+            for award in due:
+                await process_link_love_award(award, store=store)
+            post_due_link_love_notifications(store=store)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            print(f"🔗 link_love_worker_error exc_type={exc.__class__.__name__} exc={exc}")
+        await asyncio.sleep(poll_interval)

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -46,6 +46,7 @@ from .points_request_approval import (
 )
 from .slack_client import get_message, post_message, send_dm
 from .coworking_booking_intents import coworking_booking_retry_loop
+from .link_love import handle_link_love_reply, link_love_retry_loop
 
 # Pending intents for auto-continue after prerequisite steps complete.
 # Key: "{slack_user_id}:{domain}" → {"action": "write", "topic": "...", "channel_id": "...", "thread_ts": "..."}
@@ -1383,6 +1384,7 @@ async def lifespan(app: FastAPI):
     settings = get_settings()
     app.state.startup_complete = False
     coworking_retry_task: Optional[asyncio.Task] = None
+    link_love_task: Optional[asyncio.Task] = None
     jobs_scheduler_task: Optional[asyncio.Task] = None
     print(f"🦘 Roo Standalone starting...")
     print(f"   LLM Provider: {settings.default_llm_provider}")
@@ -1393,6 +1395,9 @@ async def lifespan(app: FastAPI):
     print(f"   Loaded {len(agent.skills)} skills")
     coworking_retry_task = asyncio.create_task(coworking_booking_retry_loop())
     app.state.coworking_retry_task = coworking_retry_task
+    if settings.BOOST_LINK_LOVE_ENABLED:
+        link_love_task = asyncio.create_task(link_love_retry_loop())
+        app.state.link_love_task = link_love_task
     if settings.JOBS_SCHEDULER_ENABLED:
         _validate_jobs_scheduler_settings(settings)
         jobs_scheduler_task = asyncio.create_task(_jobs_daily_run_loop())
@@ -1420,6 +1425,10 @@ async def lifespan(app: FastAPI):
             coworking_retry_task.cancel()
             with suppress(asyncio.CancelledError):
                 await coworking_retry_task
+        if link_love_task:
+            link_love_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await link_love_task
 
     # Cancel the background task on shutdown (disabled)
     # medhack_task.cancel()
@@ -1590,6 +1599,24 @@ async def slack_events(request: Request):
 
             asyncio.create_task(_handle_start_here_intro(event))
             return JSONResponse(status_code=200, content={})
+
+        try:
+            settings = get_settings()
+            boost_link_love_enabled = settings.BOOST_LINK_LOVE_ENABLED
+            boost_channel_name = settings.BOOST_LINK_LOVE_CHANNEL_NAME
+        except Exception as exc:
+            print(f"⚠️ Link-love config unavailable; skipping boost channel routing: {exc}")
+            boost_link_love_enabled = False
+            boost_channel_name = "boost-my-startup"
+
+        if boost_link_love_enabled:
+            boost_channel_id = get_channel_id(boost_channel_name)
+            if boost_channel_id and event.get("channel") == boost_channel_id:
+                thread_ts = str(event.get("thread_ts") or "")
+                message_ts = str(event.get("ts") or "")
+                if thread_ts and message_ts and thread_ts != message_ts:
+                    asyncio.create_task(handle_link_love_reply(event))
+                return JSONResponse(status_code=200, content={})
         
         is_dm = event.get("channel_type") == "im"
         if is_dm:

--- a/roo-standalone/roo/tests/test_link_love.py
+++ b/roo-standalone/roo/tests/test_link_love.py
@@ -1,0 +1,450 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("frontmatter", SimpleNamespace(load=lambda *args, **kwargs: None))
+
+link_love = importlib.import_module("roo.link_love")
+main_module = importlib.import_module("roo.main")
+slack_client_module = importlib.import_module("roo.slack_client")
+
+
+class FakeLLMResponse:
+    def __init__(self, content):
+        self.content = content
+
+
+class FakeAwardClient:
+    def __init__(self, balances=None):
+        self.calls = []
+        self.balances = balances or {}
+
+    async def system_award_points(self, admin_slack_id, target_slack_id, points, reason):
+        self.calls.append(
+            {
+                "admin_slack_id": admin_slack_id,
+                "target_slack_id": target_slack_id,
+                "points": points,
+                "reason": reason,
+            }
+        )
+        return {
+            "points_awarded": points,
+            "new_balance": self.balances.get(target_slack_id, 10),
+        }
+
+
+class RetryableFailureAwardClient:
+    def __init__(self):
+        self.calls = []
+
+    async def system_award_points(self, admin_slack_id, target_slack_id, points, reason):
+        self.calls.append((admin_slack_id, target_slack_id, points, reason))
+        raise httpx.TransportError("backend temporarily unavailable")
+
+
+def make_store(tmp_path):
+    return link_love.LinkLoveAwardStore(tmp_path / "link-love.db")
+
+
+def root_message(user="UROOT", text="Launch post"):
+    return {"user": user, "text": text}
+
+
+def reply_event(user="UHELPER", channel="CBOOST", root_ts="111.000", reply_ts="222.000", text="Done"):
+    return {
+        "type": "message",
+        "user": user,
+        "channel": channel,
+        "thread_ts": root_ts,
+        "ts": reply_ts,
+        "text": text,
+    }
+
+
+async def llm_engaged(*args, **kwargs):
+    return FakeLLMResponse('{"engaged": true, "confidence": 0.98, "reason": "explicit engagement"}')
+
+
+async def llm_not_engaged(*args, **kwargs):
+    return FakeLLMResponse('{"engaged": false, "confidence": 0.93, "reason": "vague support only"}')
+
+
+def test_parse_link_love_classification_handles_fenced_json():
+    result = link_love.parse_link_love_classification(
+        '```json\n{"engaged": true, "confidence": 0.87, "reason": "liked"}\n```'
+    )
+
+    assert result.engaged is True
+    assert result.confidence == 0.87
+    assert result.reason == "liked"
+
+
+def test_link_love_prompt_excludes_vague_support():
+    messages = link_love.build_link_love_classification_messages(
+        root_text="Please support my launch",
+        reply_text="Love it!",
+    )
+    prompt_text = "\n".join(message["content"] for message in messages)
+
+    assert "Do not count questions" in prompt_text
+    assert "love it" in prompt_text.lower()
+    assert "done" in prompt_text.lower()
+    assert "liked" in prompt_text.lower()
+
+
+@pytest.mark.asyncio
+async def test_qualifying_reply_awards_points_without_immediate_slack_post(tmp_path, monkeypatch):
+    store = make_store(tmp_path)
+    client = FakeAwardClient(balances={"UHELPER": 42})
+    posted_messages = []
+    monkeypatch.setattr(slack_client_module, "post_message", lambda **kwargs: posted_messages.append(kwargs))
+
+    result = await link_love.handle_link_love_reply(
+        reply_event(text="Liked and commented"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=60,
+    )
+
+    assert result["status"] == "awarded"
+    assert client.calls == [
+        {
+            "admin_slack_id": "UROO",
+            "target_slack_id": "UHELPER",
+            "points": 2,
+            "reason": "link-love",
+        }
+    ]
+    assert posted_messages == []
+    assert store.get_due_notification_groups() == []
+
+
+@pytest.mark.asyncio
+async def test_same_user_gets_one_award_per_root_post(tmp_path):
+    store = make_store(tmp_path)
+    client = FakeAwardClient()
+
+    first = await link_love.handle_link_love_reply(
+        reply_event(reply_ts="222.000", text="Done"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+    second = await link_love.handle_link_love_reply(
+        reply_event(reply_ts="333.000", text="Liked"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert first["status"] == "awarded"
+    assert second["status"] == "already_awarded"
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_same_user_can_earn_for_different_root_posts(tmp_path):
+    store = make_store(tmp_path)
+    client = FakeAwardClient()
+
+    await link_love.handle_link_love_reply(
+        reply_event(root_ts="111.000", reply_ts="222.000"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+    await link_love.handle_link_love_reply(
+        reply_event(root_ts="444.000", reply_ts="555.000"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_root_author_cannot_earn_on_own_post(tmp_path):
+    store = make_store(tmp_path)
+    client = FakeAwardClient()
+
+    async def fail_if_called(*args, **kwargs):
+        raise AssertionError("LLM should not be called for root author replies")
+
+    result = await link_love.handle_link_love_reply(
+        reply_event(user="UROOT", text="Done"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(user="UROOT"),
+        llm_chat=fail_if_called,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert result == {"status": "ignored", "reason": "root_author_reply"}
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
+async def test_non_proof_reply_can_be_followed_by_later_proof_reply(tmp_path):
+    store = make_store(tmp_path)
+    client = FakeAwardClient()
+
+    first = await link_love.handle_link_love_reply(
+        reply_event(reply_ts="222.000", text="Love it!"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_not_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+    second = await link_love.handle_link_love_reply(
+        reply_event(reply_ts="333.000", text="Liked"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert first["status"] == "ineligible"
+    assert second["status"] == "awarded"
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_retryable_backend_failure_keeps_award_pending(tmp_path):
+    store = make_store(tmp_path)
+    client = RetryableFailureAwardClient()
+
+    result = await link_love.handle_link_love_reply(
+        reply_event(text="Done"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert result["status"] == "pending_retry"
+    assert client.calls == [("UROO", "UHELPER", 2, "link-love")]
+    assert result["award"]["status"] == "pending_award"
+    assert result["award"]["attempt_count"] == 1
+    assert store.get_due_notification_groups() == []
+
+
+@pytest.mark.asyncio
+async def test_batched_notification_groups_awarded_users_in_root_thread(tmp_path, monkeypatch):
+    store = make_store(tmp_path)
+    client = FakeAwardClient(balances={"UONE": 12, "UTWO": 18})
+    posted_messages = []
+    monkeypatch.setattr(
+        slack_client_module,
+        "post_message",
+        lambda **kwargs: posted_messages.append(kwargs) or {"ts": "999.000"},
+    )
+
+    await link_love.handle_link_love_reply(
+        reply_event(user="UONE", reply_ts="222.000", text="Done"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+    await link_love.handle_link_love_reply(
+        reply_event(user="UTWO", reply_ts="333.000", text="Liked and reposted"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert link_love.post_due_link_love_notifications(store=store) == 1
+    assert posted_messages == [
+        {
+            "channel": "CBOOST",
+            "thread_ts": "111.000",
+            "text": (
+                ":tada: Awarded 2 points each for link-love.\n"
+                ":white_check_mark: <@UONE>: now has 12 pts\n"
+                ":white_check_mark: <@UTWO>: now has 18 pts"
+            ),
+        }
+    ]
+    assert link_love.post_due_link_love_notifications(store=store) == 0
+
+
+@pytest.mark.asyncio
+async def test_slack_events_boost_thread_reply_triggers_link_love_handler(monkeypatch):
+    handled_events = []
+    scheduled_tasks = []
+    real_create_task = asyncio.create_task
+
+    async def fake_handle_link_love_reply(event):
+        handled_events.append(event)
+
+    def fake_create_task(coro):
+        task = real_create_task(coro)
+        scheduled_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            BOOST_LINK_LOVE_ENABLED=True,
+            BOOST_LINK_LOVE_CHANNEL_NAME="boost-my-startup",
+        ),
+    )
+    monkeypatch.setattr(
+        slack_client_module,
+        "get_channel_id",
+        lambda name: "CSTART" if name == "_start-here" else "CBOOST",
+    )
+    monkeypatch.setattr(main_module, "handle_link_love_reply", fake_handle_link_love_reply)
+    monkeypatch.setattr(main_module.asyncio, "create_task", fake_create_task)
+
+    payload = {
+        "event": reply_event(channel="CBOOST", root_ts="111.000", reply_ts="222.000")
+    }
+
+    class FakeRequest:
+        async def json(self):
+            return payload
+
+    response = await main_module.slack_events(FakeRequest())
+
+    assert response.status_code == 200
+    await asyncio.gather(*scheduled_tasks)
+    assert handled_events == [payload["event"]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"type": "message", "user": "UHELPER", "channel": "CBOOST", "ts": "111.000", "text": "Top level"},
+        {"type": "message", "user": "UHELPER", "channel": "COTHER", "thread_ts": "111.000", "ts": "222.000"},
+        {"type": "message", "user": "UBOT", "channel": "CBOOST", "thread_ts": "111.000", "ts": "222.000", "bot_id": "B123"},
+        {"type": "message", "user": "UHELPER", "channel": "CBOOST", "thread_ts": "111.000", "ts": "222.000", "subtype": "message_changed"},
+    ],
+)
+async def test_slack_events_non_qualifying_messages_do_not_trigger_link_love(event, monkeypatch):
+    handled_events = []
+
+    def fake_create_task(coro):
+        coro.close()
+        return None
+
+    async def fake_handle_link_love_reply(event):
+        handled_events.append(event)
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            BOOST_LINK_LOVE_ENABLED=True,
+            BOOST_LINK_LOVE_CHANNEL_NAME="boost-my-startup",
+        ),
+    )
+    monkeypatch.setattr(
+        slack_client_module,
+        "get_channel_id",
+        lambda name: "CSTART" if name == "_start-here" else "CBOOST",
+    )
+    monkeypatch.setattr(main_module, "handle_link_love_reply", fake_handle_link_love_reply)
+    monkeypatch.setattr(main_module.asyncio, "create_task", fake_create_task)
+
+    class FakeRequest:
+        async def json(self):
+            return {"event": event}
+
+    response = await main_module.slack_events(FakeRequest())
+
+    assert response.status_code == 200
+    assert handled_events == []
+
+
+@pytest.mark.asyncio
+async def test_slack_events_dm_does_not_trigger_link_love(monkeypatch):
+    link_love_events = []
+    mention_events = []
+    scheduled_tasks = []
+    real_create_task = asyncio.create_task
+
+    async def fake_handle_link_love_reply(event):
+        link_love_events.append(event)
+
+    async def fake_handle_mention(event):
+        mention_events.append(event)
+
+    def fake_create_task(coro):
+        task = real_create_task(coro)
+        scheduled_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            BOOST_LINK_LOVE_ENABLED=True,
+            BOOST_LINK_LOVE_CHANNEL_NAME="boost-my-startup",
+        ),
+    )
+    monkeypatch.setattr(
+        slack_client_module,
+        "get_channel_id",
+        lambda name: "CSTART" if name == "_start-here" else "CBOOST",
+    )
+    monkeypatch.setattr(main_module, "handle_link_love_reply", fake_handle_link_love_reply)
+    monkeypatch.setattr(main_module, "_handle_mention", fake_handle_mention)
+    monkeypatch.setattr(main_module.asyncio, "create_task", fake_create_task)
+
+    event = {
+        "type": "message",
+        "user": "UHELPER",
+        "channel": "D123",
+        "channel_type": "im",
+        "ts": "222.000",
+        "text": "hello",
+    }
+
+    class FakeRequest:
+        async def json(self):
+            return {"event": event}
+
+    response = await main_module.slack_events(FakeRequest())
+
+    assert response.status_code == 200
+    await asyncio.gather(*scheduled_tasks)
+    assert link_love_events == []
+    assert mention_events == [event]


### PR DESCRIPTION
## Summary
- add automatic #boost-my-startup thread-reply handling for link-love rewards
- classify reply proof with an LLM and persist reply/award state in SQLite
- award 2 Roo points with reason `link-love`, retry transient backend failures, and batch Slack notifications

## Validation
- `pytest roo/tests/test_points_requests.py roo/tests/test_link_love.py -q` passed: 92 passed
- `python3 -m py_compile roo/link_love.py roo/main.py roo/config.py roo/tests/test_link_love.py` passed

## Note
- Full `pytest` currently has unrelated existing failures in content-factory confirm-topic action tests; the targeted link-love and points suites pass.