### PR TITLE
[codex] Fix delegated coworking booking mentions

### DIFF
--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -4222,6 +4222,9 @@ Keep the response concise but informative."""
             if params.get("task_title") or "create" in text_lower:
                 action = "create_task"
 
+        if action == "book_coworking" and self._coworking_target_mentions_present(text, params):
+            return "admin_checkin_coworking"
+
         if action and action != "task":
             return action
 
@@ -4316,14 +4319,26 @@ Keep the response concise but informative."""
         return text_lower
 
     def _is_coworking_admin_checkin_request(self, text: str) -> bool:
-        """Detect admin coworking check-in commands like `check <@U123> in today`."""
+        """Detect admin coworking check-in commands like `book <@U123> in today`."""
         return bool(
             re.search(
-                r"\bcheck\b.*<@[A-Z0-9]+>.*\bin\b",
+                r"\b(?:check|book)\b.*<@[A-Z0-9]+>.*\bin\b",
                 str(text or ""),
                 re.IGNORECASE,
             )
         )
+
+    def _coworking_target_mentions_present(self, text: str, params: dict) -> bool:
+        """Return True when a coworking booking request contains a non-Roo target mention."""
+        if re.search(r"<@[A-Z0-9]+>", str(text or ""), re.IGNORECASE):
+            return True
+        for raw_target in list(params.get("target_users", []) or []) + [
+            params.get("target_user"),
+            params.get("target_slack_id"),
+        ]:
+            if raw_target not in (None, ""):
+                return True
+        return False
 
     def _extract_task_identifier(self, text: str, explicit_task_id=None) -> Optional[str]:
         """Extract either a numeric task id or a ROO task code from text."""
@@ -5515,6 +5530,11 @@ Keep the response concise but informative."""
         thread_ts: Optional[str],
         admin_checkin: bool,
     ) -> str:
+        print(
+            "🏢 coworking_booking_execute "
+            f"requested_by_user_id={requested_by_user_id} target_user_id={target_user_id} "
+            f"booking_date={booking_date} admin_checkin={admin_checkin}"
+        )
         try:
             store = get_coworking_intent_store()
             intent = store.record_intent(
@@ -5942,8 +5962,25 @@ Keep the response concise but informative."""
             
             lines.append("\nBook a day with \"coworking book <date>\"")
             return "\n".join(lines)
-        
+
         elif action == "book_coworking":
+            from ..slack_client import get_bot_user_id
+            try:
+                bot_id = get_bot_user_id()
+            except Exception:
+                bot_id = None
+            target_slack_ids = self._extract_coworking_checkin_targets(
+                text,
+                params,
+                bot_id=bot_id,
+            )
+            if target_slack_ids:
+                return (
+                    "I saw a tagged user in that coworking booking request, so I didn't book you. "
+                    "Please retry as `book @user in today` or `check @user in today` so I can run "
+                    "the admin check-in flow."
+                )
+
             booking_date = self._resolve_coworking_booking_date(
                 params,
                 text,

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -104,6 +104,8 @@ def test_coworking_booking_shortcuts_route_to_points():
         "book me in",
         "book me in today",
         "check <@U123ABC> in today",
+        "book <@U123ABC> in today",
+        "also book <@U123ABC> in today",
     ]:
         skill = agent._select_skill_from_triggers(text)
         assert skill is not None

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -2015,6 +2015,38 @@ async def test_admin_checkin_books_target_for_today(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_admin_checkin_book_mention_phrase_books_target_for_today(tmp_path, monkeypatch):
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "intents.db")
+    client = FakeAdminCheckinCoworkingClient(balance=13)
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+
+    action = executor._resolve_points_action(
+        {"action": "book_coworking", "target_users": ["<@UTARGET>"]},
+        "also book <@UTARGET> in today",
+    )
+    result = await executor._handle_points_action(
+        client=client,
+        action=action,
+        params={"action": "book_coworking", "target_users": ["<@UTARGET>"]},
+        text="also book <@UTARGET> in today",
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    intent = store.get_by_key("coworking:UTARGET:2026-05-04")
+    assert action == "admin_checkin_coworking"
+    assert "Checked <@UTARGET> in for **2026-05-04**" in result
+    assert client.book_args == ("UTARGET", "2026-05-04", "C123")
+    assert client.balance_args == "UTARGET"
+    assert intent["requested_by_slack_id"] == "UADMIN"
+
+
+@pytest.mark.asyncio
 async def test_admin_checkin_honors_explicit_date(tmp_path, monkeypatch):
     store = coworking_module.CoworkingBookingIntentStore(tmp_path / "intents.db")
     client = FakeAdminCheckinCoworkingClient()
@@ -2050,7 +2082,7 @@ async def test_admin_checkin_denies_partner_without_booking(tmp_path, monkeypatc
         client=client,
         action="admin_checkin_coworking",
         params={},
-        text="check <@UTARGET> in today",
+        text="book <@UTARGET> in today",
         user_id="UPARTNER",
         channel_id="C123",
         thread_ts="111.222",
@@ -2082,7 +2114,7 @@ async def test_admin_checkin_requires_exactly_one_target(monkeypatch):
         client=client,
         action="admin_checkin_coworking",
         params={},
-        text="check <@UONE> and <@UTWO> in today",
+        text="book <@UONE> and <@UTWO> in today",
         user_id="UADMIN",
         channel_id="C123",
         thread_ts="111.222",
@@ -2092,6 +2124,31 @@ async def test_admin_checkin_requires_exactly_one_target(monkeypatch):
     assert "Mention exactly one user" in missing_result
     assert "Tag exactly one user" in multiple_result
     assert client.book_args is None
+
+
+@pytest.mark.asyncio
+async def test_book_coworking_with_target_mention_refuses_self_booking(tmp_path, monkeypatch):
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "intents.db")
+    client = FakeAdminCheckinCoworkingClient()
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="book_coworking",
+        params={"action": "book_coworking", "target_users": ["<@UTARGET>"]},
+        text="book <@UTARGET> in today",
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "I saw a tagged user" in result
+    assert client.book_args is None
+    assert store.counts_by_status() == {}
 
 
 @pytest.mark.asyncio
@@ -2670,8 +2727,24 @@ def test_resolve_points_action_detects_coworking_shortcuts():
     executor = SkillExecutor()
 
     assert executor._resolve_points_action({}, "book me in") == "book_coworking"
+    assert executor._resolve_points_action({}, "book me in today") == "book_coworking"
     assert (
         executor._resolve_points_action({}, "check <@UTARGET> in today")
+        == "admin_checkin_coworking"
+    )
+    assert (
+        executor._resolve_points_action({}, "book <@UTARGET> in today")
+        == "admin_checkin_coworking"
+    )
+    assert (
+        executor._resolve_points_action(
+            {"action": "book_coworking", "target_users": ["<@UTARGET>"]},
+            "also book <@UTARGET> in today",
+        )
+        == "admin_checkin_coworking"
+    )
+    assert (
+        executor._resolve_points_action({}, "book <@UONE> and <@UTWO> in today")
         == "admin_checkin_coworking"
     )
 

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -124,7 +124,7 @@ Parse user messages to identify the action and parameters:
 | `coworking report last 3/6 months` | coworking_report | "Coworking report last 3 months" |
 | `coworking report last year` | coworking_report | "Coworking report last year" |
 | `coworking book <date/today>` | book_coworking | "Book me in", "Book me in for today", "@Roo coworking book" |
-| `check <@USER> in <date/today>` | admin_checkin_coworking | (Admin) "Check <@U123> in", "Check <@U123> in today" |
+| `check/book <@USER> in <date/today>` | admin_checkin_coworking | (Admin) "Check <@U123> in", "Book <@U123> in today" |
 | `coworking cancel <date>` | cancel_coworking | "Cancel my booking for Friday", "@Roo coworking cancel" |
 | `rewards`, `points rewards` | list_rewards | "What rewards are available?", "@Roo points rewards" |
 | `reward request <code>` | request_reward | "I want to get the HOTDESK_DAY reward" |


### PR DESCRIPTION
## Summary
- Route `book <@USER> in today` and similar mention-based coworking bookings through the admin check-in flow.
- Keep `book me in today` as normal self-booking.
- Add a defensive guard so `book_coworking` refuses tagged target mentions instead of silently booking the requester.
- Document the delegated `check/book <@USER> in` syntax and add regression tests for the Slack failure mode.

## Validation
- `python3 -m pytest roo/tests/test_agent_routing.py roo/tests/test_coworking_booking_intents.py roo/tests/test_points_requests.py -q` passed: 118 tests.