### PR TITLE
[codex] Stabilize link-love award retries

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -2252,7 +2252,8 @@ class MLAIBackendClient:
         admin_slack_id: str,
         target_slack_id: str,
         points: int,
-        reason: str
+        reason: str,
+        idempotency_key: Optional[str] = None,
     ) -> dict:
         """System award points (bypasses client-side admin checks)."""
         payload = {
@@ -2261,6 +2262,8 @@ class MLAIBackendClient:
             "points": points,
             "reason": reason,
         }
+        if idempotency_key:
+            payload["idempotency_key"] = str(idempotency_key)
         response = await self._request(
             "POST",
             f"{self._points_base}/system/award/",

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
     BOOST_LINK_LOVE_DB_PATH: str = "data/link_love_awards.db"
     BOOST_LINK_LOVE_NOTIFICATION_DELAY_SECONDS: int = 60
     BOOST_LINK_LOVE_RETRY_POLL_SECONDS: float = 15.0
+    BOOST_LINK_LOVE_MAX_RETRY_ATTEMPTS: int = 5
     JOBS_SCHEDULER_ENABLED: bool = False
     JOBS_API_URL: Optional[str] = None
     JOBS_TRIGGER_TOKEN: Optional[str] = None

--- a/roo-standalone/roo/link_love.py
+++ b/roo-standalone/roo/link_love.py
@@ -20,6 +20,7 @@ LINK_LOVE_REASON = "link-love"
 DEFAULT_LINK_LOVE_DB_PATH = "data/link_love_awards.db"
 DEFAULT_RETRY_POLL_SECONDS = 15.0
 DEFAULT_PROCESSING_LEASE_SECONDS = 90.0
+DEFAULT_MAX_RETRY_ATTEMPTS = 5
 
 
 def _now() -> float:
@@ -29,6 +30,21 @@ def _now() -> float:
 def retry_delay_seconds(attempt_count: int) -> float:
     attempt_number = max(1, int(attempt_count or 1))
     return min(15 * 60, 30 * (2 ** (attempt_number - 1)))
+
+
+def link_love_backend_idempotency_key(award: dict[str, Any]) -> str:
+    return (
+        f"link_love:{award['channel_id']}:"
+        f"{award['root_message_ts']}:{award['slack_user_id']}"
+    )
+
+
+def link_love_max_retry_attempts() -> int:
+    try:
+        value = int(getattr(get_settings(), "BOOST_LINK_LOVE_MAX_RETRY_ATTEMPTS", DEFAULT_MAX_RETRY_ATTEMPTS))
+    except Exception:
+        value = DEFAULT_MAX_RETRY_ATTEMPTS
+    return max(1, value)
 
 
 def clean_slack_user_id(raw_value: Any) -> str:
@@ -497,7 +513,13 @@ class LinkLoveAwardStore:
                 ).fetchone()
             )
 
-    def mark_retryable_failure(self, award_id: int, *, error: str) -> dict[str, Any]:
+    def mark_retryable_failure(
+        self,
+        award_id: int,
+        *,
+        error: str,
+        max_attempts: Optional[int] = None,
+    ) -> dict[str, Any]:
         self._ensure_schema()
         now = _now()
         with self._lock, self._connect() as conn:
@@ -506,10 +528,12 @@ class LinkLoveAwardStore:
                 (award_id,),
             ).fetchone()
             next_attempt_count = int(row["attempt_count"] or 0) + 1 if row else 1
+            should_block = max_attempts is not None and next_attempt_count >= int(max_attempts)
             conn.execute(
                 """
                 UPDATE link_love_awards
-                SET attempt_count = ?,
+                SET status = ?,
+                    attempt_count = ?,
                     next_attempt_at = ?,
                     locked_until = NULL,
                     locked_by = NULL,
@@ -518,8 +542,9 @@ class LinkLoveAwardStore:
                 WHERE id = ?
                 """,
                 (
+                    "blocked" if should_block else "pending_award",
                     next_attempt_count,
-                    now + retry_delay_seconds(next_attempt_count),
+                    now if should_block else now + retry_delay_seconds(next_attempt_count),
                     error,
                     now,
                     award_id,
@@ -647,6 +672,7 @@ async def process_link_love_award(
     client: Any = None,
     bot_user_id: Optional[str] = None,
     notification_delay_seconds: Optional[float] = None,
+    max_retry_attempts: Optional[int] = None,
 ) -> dict[str, Any]:
     store = store or get_link_love_store()
     client = client or _build_backend_client()
@@ -660,6 +686,11 @@ async def process_link_love_award(
     else:
         settings = get_settings()
         delay = getattr(settings, "BOOST_LINK_LOVE_NOTIFICATION_DELAY_SECONDS", 60)
+    resolved_max_retry_attempts = (
+        max(1, int(max_retry_attempts))
+        if max_retry_attempts is not None
+        else link_love_max_retry_attempts()
+    )
 
     try:
         backend_result = await client.system_award_points(
@@ -667,6 +698,7 @@ async def process_link_love_award(
             target_slack_id=str(award["slack_user_id"]),
             points=LINK_LOVE_POINTS,
             reason=LINK_LOVE_REASON,
+            idempotency_key=link_love_backend_idempotency_key(award),
         )
         updated = store.mark_awarded(
             int(award["id"]),
@@ -677,7 +709,19 @@ async def process_link_love_award(
     except Exception as exc:
         error = f"{exc.__class__.__name__}: {exc}"
         if is_retryable_link_love_exception(exc):
-            updated = store.mark_retryable_failure(int(award["id"]), error=error)
+            updated = store.mark_retryable_failure(
+                int(award["id"]),
+                error=error,
+                max_attempts=resolved_max_retry_attempts,
+            )
+            if updated.get("status") == "blocked":
+                print(
+                    "⚠️ link_love_award_blocked_after_retries "
+                    f"award_id={award.get('id')} slack_user_id={award.get('slack_user_id')} "
+                    f"attempt_count={updated.get('attempt_count')} max_attempts={resolved_max_retry_attempts} "
+                    f"error={error}"
+                )
+                return {"status": "blocked", "award": updated, "error": error}
             print(
                 "🔁 link_love_award_retryable_failure "
                 f"award_id={award.get('id')} slack_user_id={award.get('slack_user_id')} error={error}"

--- a/roo-standalone/roo/tests/test_link_love.py
+++ b/roo-standalone/roo/tests/test_link_love.py
@@ -25,13 +25,21 @@ class FakeAwardClient:
         self.calls = []
         self.balances = balances or {}
 
-    async def system_award_points(self, admin_slack_id, target_slack_id, points, reason):
+    async def system_award_points(
+        self,
+        admin_slack_id,
+        target_slack_id,
+        points,
+        reason,
+        idempotency_key=None,
+    ):
         self.calls.append(
             {
                 "admin_slack_id": admin_slack_id,
                 "target_slack_id": target_slack_id,
                 "points": points,
                 "reason": reason,
+                "idempotency_key": idempotency_key,
             }
         )
         return {
@@ -44,9 +52,50 @@ class RetryableFailureAwardClient:
     def __init__(self):
         self.calls = []
 
-    async def system_award_points(self, admin_slack_id, target_slack_id, points, reason):
-        self.calls.append((admin_slack_id, target_slack_id, points, reason))
+    async def system_award_points(
+        self,
+        admin_slack_id,
+        target_slack_id,
+        points,
+        reason,
+        idempotency_key=None,
+    ):
+        self.calls.append(
+            {
+                "admin_slack_id": admin_slack_id,
+                "target_slack_id": target_slack_id,
+                "points": points,
+                "reason": reason,
+                "idempotency_key": idempotency_key,
+            }
+        )
         raise httpx.TransportError("backend temporarily unavailable")
+
+
+class NonRetryableFailureAwardClient:
+    def __init__(self):
+        self.calls = []
+
+    async def system_award_points(
+        self,
+        admin_slack_id,
+        target_slack_id,
+        points,
+        reason,
+        idempotency_key=None,
+    ):
+        self.calls.append(
+            {
+                "admin_slack_id": admin_slack_id,
+                "target_slack_id": target_slack_id,
+                "points": points,
+                "reason": reason,
+                "idempotency_key": idempotency_key,
+            }
+        )
+        request = httpx.Request("POST", "https://backend.test/api/v1/points/system/award/")
+        response = httpx.Response(400, request=request)
+        raise httpx.HTTPStatusError("bad request", request=request, response=response)
 
 
 def make_store(tmp_path):
@@ -123,6 +172,7 @@ async def test_qualifying_reply_awards_points_without_immediate_slack_post(tmp_p
             "target_slack_id": "UHELPER",
             "points": 2,
             "reason": "link-love",
+            "idempotency_key": "link_love:CBOOST:111.000:UHELPER",
         }
     ]
     assert posted_messages == []
@@ -252,9 +302,91 @@ async def test_retryable_backend_failure_keeps_award_pending(tmp_path):
     )
 
     assert result["status"] == "pending_retry"
-    assert client.calls == [("UROO", "UHELPER", 2, "link-love")]
+    assert client.calls == [
+        {
+            "admin_slack_id": "UROO",
+            "target_slack_id": "UHELPER",
+            "points": 2,
+            "reason": "link-love",
+            "idempotency_key": "link_love:CBOOST:111.000:UHELPER",
+        }
+    ]
     assert result["award"]["status"] == "pending_award"
     assert result["award"]["attempt_count"] == 1
+    assert store.get_due_notification_groups() == []
+
+
+@pytest.mark.asyncio
+async def test_retryable_backend_failure_blocks_after_max_attempts(tmp_path):
+    store = make_store(tmp_path)
+    client = RetryableFailureAwardClient()
+    _, award = store.create_award(
+        channel_id="CBOOST",
+        root_message_ts="111.000",
+        slack_user_id="UHELPER",
+        root_author_slack_id="UROOT",
+        source_reply_message_ts="222.000",
+    )
+
+    first = await link_love.process_link_love_award(
+        award,
+        store=store,
+        client=client,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+        max_retry_attempts=2,
+    )
+    second = await link_love.process_link_love_award(
+        first["award"],
+        store=store,
+        client=client,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+        max_retry_attempts=2,
+    )
+
+    assert first["status"] == "pending_retry"
+    assert first["award"]["status"] == "pending_award"
+    assert first["award"]["attempt_count"] == 1
+    assert second["status"] == "blocked"
+    assert second["award"]["status"] == "blocked"
+    assert second["award"]["attempt_count"] == 2
+    assert len(client.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_non_retryable_backend_failure_blocks_immediately(tmp_path):
+    store = make_store(tmp_path)
+    client = NonRetryableFailureAwardClient()
+
+    result = await link_love.handle_link_love_reply(
+        reply_event(text="Done"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert result["status"] == "blocked"
+    assert result["award"]["status"] == "blocked"
+    assert result["award"]["attempt_count"] == 0
+    assert store.get_due_notification_groups() == []
+
+
+def test_blocked_awards_are_not_notification_candidates(tmp_path):
+    store = make_store(tmp_path)
+    _, award = store.create_award(
+        channel_id="CBOOST",
+        root_message_ts="111.000",
+        slack_user_id="UHELPER",
+        root_author_slack_id="UROOT",
+        source_reply_message_ts="222.000",
+    )
+
+    store.mark_blocked(int(award["id"]), error="HTTPStatusError: bad request")
+
     assert store.get_due_notification_groups() == []
 
 

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -1826,6 +1826,7 @@ async def test_backend_client_system_award_points_uses_system_endpoint(monkeypat
         target_slack_id="<@UTARGET>",
         points=12,
         reason="System award",
+        idempotency_key="link_love:CBOOST:111.000:UTARGET",
     )
 
     assert result == {"points_awarded": 12, "new_balance": 17}
@@ -1837,6 +1838,7 @@ async def test_backend_client_system_award_points_uses_system_endpoint(monkeypat
         "target_slack_id": "UTARGET",
         "points": 12,
         "reason": "System award",
+        "idempotency_key": "link_love:CBOOST:111.000:UTARGET",
     }
     assert recorder.calls[0]["params"] is None
     assert recorder.calls[0]["headers"]["Content-Type"] == "application/json"


### PR DESCRIPTION
## Summary
- add stable idempotency keys for Roo link-love system awards
- cap retryable link-love backend failures and mark awards blocked after the configured max attempts
- cover idempotency, retry cap, blocking, and notification behavior in tests

## Validation
- git diff --check
- python3 -m pytest roo/tests/test_points_requests.py roo/tests/test_link_love.py