### PR TITLE
[codex] Award 4 points for start-here intros

### DIFF
--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -1653,10 +1653,15 @@ async def _handle_start_here_intro(event: dict):
     if not result.get("awarded"):
         return
 
+    try:
+        points_awarded = int(result.get("points_awarded") or 4)
+    except (TypeError, ValueError):
+        points_awarded = 4
+
     post_message(
         channel=channel_id,
         thread_ts=message_ts,
-        text=f"Welcome <@{user_id}>! You've earned 2 Roo points for introducing yourself here.",
+        text=f"Welcome <@{user_id}>! You've earned {points_awarded} Roo points for introducing yourself here.",
     )
 
 

--- a/roo-standalone/roo/quests.py
+++ b/roo-standalone/roo/quests.py
@@ -38,7 +38,7 @@ QUESTS = {
         "name": "First Contact",
         "description": "First post in #_start-here",
         "target_count": 1,
-        "points": 2,
+        "points": 4,
         "event_type": "message",
         "channel_name": "_start-here"
     },

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -1062,7 +1062,7 @@ class RecordingAsyncClient:
 
 class FakeStartHereAwardClient:
     last_instance = None
-    response = {"awarded": True, "new_balance": 2}
+    response = {"awarded": True, "new_balance": 4, "points_awarded": 4}
 
     def __init__(self, *args, **kwargs):
         self.init_kwargs = kwargs
@@ -1576,7 +1576,7 @@ def test_app_mention_dedupe_logs_ttl_expiry(capsys):
 @pytest.mark.asyncio
 async def test_handle_start_here_intro_awards_and_posts_thread_reply(monkeypatch):
     posted_messages = []
-    FakeStartHereAwardClient.response = {"awarded": True, "new_balance": 2}
+    FakeStartHereAwardClient.response = {"awarded": True, "new_balance": 4, "points_awarded": 4}
 
     monkeypatch.setattr(
         main_module,
@@ -1608,9 +1608,42 @@ async def test_handle_start_here_intro_awards_and_posts_thread_reply(monkeypatch
         {
             "channel": "CSTART",
             "thread_ts": "111.222",
-            "text": "Welcome <@UINTRO>! You've earned 2 Roo points for introducing yourself here.",
+            "text": "Welcome <@UINTRO>! You've earned 4 Roo points for introducing yourself here.",
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_handle_start_here_intro_defaults_to_four_points_for_legacy_backend_response(monkeypatch):
+    posted_messages = []
+    FakeStartHereAwardClient.response = {"awarded": True, "new_balance": 4}
+
+    monkeypatch.setattr(
+        main_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-api-key",
+            INTERNAL_API_KEY="internal-key",
+        ),
+    )
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeStartHereAwardClient)
+    monkeypatch.setattr(
+        main_module,
+        "post_message",
+        lambda **kwargs: posted_messages.append(kwargs),
+    )
+
+    await main_module._handle_start_here_intro(
+        {
+            "user": "UINTRO",
+            "channel": "CSTART",
+            "ts": "111.222",
+        }
+    )
+
+    assert posted_messages[0]["text"] == "Welcome <@UINTRO>! You've earned 4 Roo points for introducing yourself here."
 
 
 @pytest.mark.asyncio
@@ -1781,7 +1814,7 @@ async def test_backend_client_approve_points_request_uses_canonical_endpoint(mon
 
 @pytest.mark.asyncio
 async def test_backend_client_award_first_channel_post_uses_canonical_endpoint(monkeypatch):
-    recorder = RecordingAsyncClient(json_data={"awarded": True, "new_balance": 2})
+    recorder = RecordingAsyncClient(json_data={"awarded": True, "new_balance": 4, "points_awarded": 4})
     monkeypatch.setattr(backend_module.httpx, "AsyncClient", lambda: recorder)
 
     client = backend_module.MLAIBackendClient(
@@ -1795,7 +1828,7 @@ async def test_backend_client_award_first_channel_post_uses_canonical_endpoint(m
         channel_id="CSTART",
     )
 
-    assert result == {"awarded": True, "new_balance": 2}
+    assert result == {"awarded": True, "new_balance": 4, "points_awarded": 4}
     assert len(recorder.calls) == 1
     assert recorder.calls[0]["method"] == "POST"
     assert recorder.calls[0]["url"] == "https://backend.test/api/v1/activity/first-post-award/"


### PR DESCRIPTION
## Summary
- display the backend-returned intro award amount in the #_start-here thread reply
- default legacy backend responses to 4 Roo points
- update the disabled First Contact quest constant and start-here tests

## Validation
- git diff --check
- python3 -m pytest roo/tests/test_points_requests.py