### PR TITLE
[codex] Add Linear meeting file sources

### DIFF
--- a/roo-standalone/requirements.txt
+++ b/roo-standalone/requirements.txt
@@ -23,6 +23,8 @@ python-frontmatter>=1.0.0
 python-multipart>=0.0.9
 httpx>=0.25.0
 python-dotenv>=1.0.0
+PyMuPDF>=1.24.0
+python-docx>=1.1.0
 
 # Testing
 pytest>=7.4.0

--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -141,6 +141,7 @@ class RooAgent:
             thread_history,
             channel_id,
             thread_ts,
+            has_file_context=bool(kwargs.get("event_files")),
         )
 
         if skill:
@@ -394,6 +395,19 @@ class RooAgent:
         )
         return any(re.search(pattern, text) for pattern in patterns)
 
+    def _looks_like_linear_meeting_request(self, text: str, has_file_context: bool = False) -> bool:
+        has_linear = bool(re.search(r'\blinear\b', text))
+        has_meeting_source = bool(
+            re.search(
+                r'\b(meeting|transcript|summary|notes?|action\s+items?|to-?dos?|file|pdf|docx?|document|image|screenshot)\b',
+                text,
+            )
+        ) or has_file_context
+        has_creation_intent = bool(
+            re.search(r'\b(extract|sync|turn|send|create|add|tickets?|issues?|tasks?)\b', text)
+        )
+        return has_linear and has_meeting_source and has_creation_intent
+
     def _looks_like_content_follow_up(self, text: str) -> bool:
         patterns = (
             r'\bwrite\b',
@@ -421,6 +435,7 @@ class RooAgent:
         self,
         text: str,
         thread_context: Optional[Dict[str, Any]] = None,
+        has_file_context: bool = False,
     ) -> Optional[Skill]:
         routing_intent = self._get_routing_intent(text, thread_context)
         if routing_intent:
@@ -430,12 +445,16 @@ class RooAgent:
         content_skill = self._get_skill_by_name("content-factory")
         luma_skill = self._get_skill_by_name("luma-events")
         points_skill = self._get_skill_by_name("mlai-points")
+        linear_meeting_skill = self._get_skill_by_name("linear-meeting-actions")
 
         if luma_skill and self._looks_like_luma_request(text_lower):
             return luma_skill
 
         if content_skill and self._looks_like_content_request(text_lower):
             return content_skill
+
+        if linear_meeting_skill and self._looks_like_linear_meeting_request(text_lower, has_file_context):
+            return linear_meeting_skill
 
         if points_skill and self._looks_like_points_request(text_lower):
             return points_skill
@@ -658,6 +677,7 @@ class RooAgent:
         history: List[dict] = None,
         channel_id: Optional[str] = None,
         thread_ts: Optional[str] = None,
+        has_file_context: bool = False,
     ) -> Optional[Skill]:
         """Use LLM to decide which skill to use."""
         if not self.skills:
@@ -668,7 +688,12 @@ class RooAgent:
         if routing_intent:
             return routing_intent["skill"]
 
-        trigger_skill = self._select_skill_from_triggers(text, thread_context)
+        has_slack_files = has_file_context or any(message.get("files") for message in history or [])
+        trigger_skill = self._select_skill_from_triggers(
+            text,
+            thread_context,
+            has_file_context=has_slack_files,
+        )
         if trigger_skill:
             return trigger_skill
 
@@ -723,6 +748,7 @@ User message: "{text}"
 Routing rules:
 - Prefer content-factory for domain-backed repo scans, article/blog writing, SEO research, content planning, scaffolding blog/article pages, and requests like "scan the domain mlai.au" or "scan the repo for the domain mlai.au".
 - Prefer github-integration for GitHub auth, reconnecting GitHub, or account/integration management.
+- Prefer linear-meeting-actions for requests to turn Slack meeting notes, summaries, transcripts, action items, or attached files into Linear issues/tasks/tickets.
 - Prefer mlai-points for points, rewards, coworking, and task management.
 - Prefer luma-events for Luma registration counts, attendee reports, guest lists, CSV documents, and recent/past MLAI event attendee CSVs.
 
@@ -732,6 +758,9 @@ Examples:
 - "scan the domain woofya.com.au" -> content-factory
 - "reconnect github for woofya.com.au" -> github-integration
 - "write me an article about how to build an ai agent harness for long-running specific tasks" -> content-factory
+- "turn this meeting summary into Linear tasks" -> linear-meeting-actions
+- "extract action items from this transcript and add them to Linear" -> linear-meeting-actions
+- "send this attached PDF to Linear as tasks" -> linear-meeting-actions
 - "create a task called fix docs worth 5 points" -> mlai-points
 - "give me CSVs for the past 3 MLAI events" -> luma-events
 - "how many people registered for the april 29 event" -> luma-events

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     
     # LLM Providers (at least one required)
     OPENAI_API_KEY: Optional[str] = None
+    OPENAI_VISION_MODEL: str = "gpt-4.1-mini"
     GOOGLE_API_KEY: Optional[str] = None
     ANTHROPIC_API_KEY: Optional[str] = None
     
@@ -32,6 +33,8 @@ class Settings(BaseSettings):
     MLAI_API_KEY: Optional[str] = None
     ROO_API_KEY: Optional[str] = None
     INTERNAL_API_KEY: Optional[str] = None
+    LINEAR_API_KEY: Optional[str] = None
+    LINEAR_DEFAULT_TEAM: Optional[str] = None
 
     # GitHub OAuth
     GITHUB_CLIENT_ID: Optional[str] = None
@@ -44,6 +47,8 @@ class Settings(BaseSettings):
     SKILLS_DIR: str = "skills"
     TIMEZONE: str = "Australia/Melbourne"
     ROUTER_MODEL: str = "gpt-5.4"
+    LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE: float = 0.85
+    LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE: float = 0.65
     COWORKING_INTENTS_DB_PATH: str = "data/coworking_booking_intents.db"
     COWORKING_RETRY_POLL_SECONDS: float = 30.0
     BOOST_LINK_LOVE_ENABLED: bool = True

--- a/roo-standalone/roo/linear_meeting_sources.py
+++ b/roo-standalone/roo/linear_meeting_sources.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Optional
+
+from .slack_client import download_file_bytes, get_file_info
+
+
+ImageParser = Callable[[bytes, str, str], Awaitable[str]]
+
+TEXT_EXTENSIONS = {".txt", ".md", ".csv"}
+DOCX_EXTENSIONS = {".docx"}
+PDF_EXTENSIONS = {".pdf"}
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+SUPPORTED_EXTENSIONS = TEXT_EXTENSIONS | DOCX_EXTENSIONS | PDF_EXTENSIONS | IMAGE_EXTENSIONS
+
+DEFAULT_MAX_FILES = 5
+DEFAULT_MAX_FILE_BYTES = 25 * 1024 * 1024
+DEFAULT_MAX_PDF_PAGES = 75
+DEFAULT_MAX_VISION_IMAGES = 10
+PDF_TEXT_WORD_THRESHOLD = 8
+
+
+@dataclass
+class SlackSource:
+    """Raw source discovered from Slack text or file metadata."""
+
+    kind: str
+    label: str
+    text: str = ""
+    file: Optional[dict[str, Any]] = None
+    user: Optional[str] = None
+    ts: Optional[str] = None
+
+
+@dataclass
+class ParsedSource:
+    """Text extracted from one source for downstream action-item extraction."""
+
+    label: str
+    text: str
+    kind: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class SourceParseResult:
+    sources: list[ParsedSource] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    files_seen: int = 0
+    files_parsed: int = 0
+    files_skipped: int = 0
+
+    def combined_text(self) -> str:
+        parts = []
+        for source in self.sources:
+            text = source.text.strip()
+            if text:
+                parts.append(f"Source: {source.label}\n{text}")
+        return "\n\n".join(parts).strip()
+
+
+async def parse_linear_meeting_sources(
+    *,
+    text: str,
+    params: dict[str, Any],
+    thread_history: Optional[list[dict[str, Any]]] = None,
+    event_files: Optional[list[dict[str, Any]]] = None,
+    image_parser: Optional[ImageParser] = None,
+    max_files: int = DEFAULT_MAX_FILES,
+    max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
+    max_pdf_pages: int = DEFAULT_MAX_PDF_PAGES,
+    max_vision_images: int = DEFAULT_MAX_VISION_IMAGES,
+) -> SourceParseResult:
+    """Parse Slack text and supported Slack files into text sources."""
+    result = SourceParseResult()
+
+    text_source = _build_thread_text_source(text, params, thread_history)
+    if text_source and text_source.text.strip():
+        result.sources.append(
+            ParsedSource(label=text_source.label, text=text_source.text, kind="slack_text")
+        )
+
+    files = _collect_slack_files(thread_history or [], event_files or [])
+    result.files_seen = len(files)
+    vision_budget = {"remaining": max_vision_images}
+
+    for index, file in enumerate(files):
+        if index >= max_files:
+            result.files_skipped += 1
+            result.warnings.append(
+                f"Skipped `{_file_label(file)}` because only {max_files} files are processed per request."
+            )
+            continue
+
+        try:
+            full_file = await asyncio.to_thread(_resolve_file_metadata, file)
+            label = _file_label(full_file)
+            size = int(full_file.get("size") or 0)
+            if size > max_file_bytes:
+                result.files_skipped += 1
+                result.warnings.append(
+                    f"Skipped `{label}` because it is larger than {max_file_bytes // (1024 * 1024)} MB."
+                )
+                continue
+
+            extension = _file_extension(full_file)
+            if extension not in SUPPORTED_EXTENSIONS:
+                result.files_skipped += 1
+                result.warnings.append(
+                    f"Skipped `{label}` because `{extension or 'unknown'}` files are not supported yet."
+                )
+                continue
+
+            file_bytes = await asyncio.to_thread(download_file_bytes, full_file)
+            parsed = await _parse_file_bytes(
+                file=full_file,
+                file_bytes=file_bytes,
+                image_parser=image_parser,
+                vision_budget=vision_budget,
+                max_pdf_pages=max_pdf_pages,
+            )
+            if parsed:
+                result.sources.extend(parsed)
+                result.files_parsed += 1
+            else:
+                result.files_skipped += 1
+                result.warnings.append(f"No readable text was found in `{label}`.")
+        except Exception as exc:
+            result.files_skipped += 1
+            result.warnings.append(
+                f"Could not parse `{_file_label(file)}`: {exc.__class__.__name__}: {exc}"
+            )
+
+    return result
+
+
+def _build_thread_text_source(
+    text: str,
+    params: dict[str, Any],
+    thread_history: Optional[list[dict[str, Any]]],
+) -> Optional[SlackSource]:
+    explicit = str(params.get("transcript") or "").strip()
+    parts: list[str] = []
+    if explicit:
+        parts.append(explicit)
+
+    for message in thread_history or []:
+        if message.get("is_bot") or message.get("bot_id"):
+            continue
+        message_text = str(message.get("text") or "").strip()
+        if not message_text:
+            continue
+        speaker = str(message.get("user") or "user").strip()
+        parts.append(f"{speaker}: {message_text}")
+
+    clean_text = str(text or "").strip()
+    if clean_text and all(clean_text not in part for part in parts):
+        parts.append(clean_text)
+
+    if not parts:
+        return None
+    return SlackSource(kind="text", label="Slack thread", text="\n".join(dict.fromkeys(parts)))
+
+
+def _collect_slack_files(
+    thread_history: list[dict[str, Any]],
+    event_files: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    files: list[dict[str, Any]] = []
+    seen: set[str] = set()
+
+    def add_file(file: dict[str, Any]) -> None:
+        if not isinstance(file, dict):
+            return
+        key = (
+            str(file.get("id") or "").strip()
+            or str(file.get("url_private_download") or file.get("url_private") or "").strip()
+            or str(file.get("name") or file.get("title") or "").strip()
+        )
+        if not key or key in seen:
+            return
+        seen.add(key)
+        files.append(file)
+
+    for file in event_files:
+        add_file(file)
+    for message in thread_history:
+        for file in message.get("files") or []:
+            add_file(file)
+
+    return files
+
+
+def _resolve_file_metadata(file: dict[str, Any]) -> dict[str, Any]:
+    file_id = str(file.get("id") or "").strip()
+    needs_info = (
+        file.get("file_access") == "check_file_info"
+        or not (file.get("url_private_download") or file.get("url_private"))
+    )
+    if needs_info and file_id:
+        return get_file_info(file_id)
+    return dict(file)
+
+
+async def _parse_file_bytes(
+    *,
+    file: dict[str, Any],
+    file_bytes: bytes,
+    image_parser: Optional[ImageParser],
+    vision_budget: dict[str, int],
+    max_pdf_pages: int,
+) -> list[ParsedSource]:
+    extension = _file_extension(file)
+    label = _file_label(file)
+
+    if extension in TEXT_EXTENSIONS:
+        return [ParsedSource(label=label, text=_decode_text(file_bytes), kind=extension.lstrip("."))]
+
+    if extension in DOCX_EXTENSIONS:
+        return [ParsedSource(label=label, text=_parse_docx(file_bytes), kind="docx")]
+
+    if extension in PDF_EXTENSIONS:
+        return await _parse_pdf(
+            label=label,
+            file_bytes=file_bytes,
+            image_parser=image_parser,
+            vision_budget=vision_budget,
+            max_pdf_pages=max_pdf_pages,
+        )
+
+    if extension in IMAGE_EXTENSIONS:
+        if extension == ".gif" and _is_animated_gif(file_bytes):
+            raise RuntimeError("Animated GIF files are not supported yet")
+        text = await _parse_image(
+            label=label,
+            file_bytes=file_bytes,
+            mime_type=_file_mimetype(file),
+            image_parser=image_parser,
+            vision_budget=vision_budget,
+        )
+        return [ParsedSource(label=label, text=text, kind="image")] if text.strip() else []
+
+    return []
+
+
+def _decode_text(file_bytes: bytes) -> str:
+    for encoding in ("utf-8-sig", "utf-8", "latin-1"):
+        try:
+            return file_bytes.decode(encoding).strip()
+        except UnicodeDecodeError:
+            continue
+    return file_bytes.decode("utf-8", errors="replace").strip()
+
+
+def _parse_docx(file_bytes: bytes) -> str:
+    try:
+        from docx import Document
+    except ImportError as exc:
+        raise RuntimeError("python-docx is required to parse DOCX files") from exc
+
+    document = Document(io.BytesIO(file_bytes))
+    parts = [paragraph.text.strip() for paragraph in document.paragraphs if paragraph.text.strip()]
+    for table in document.tables:
+        for row in table.rows:
+            values = [cell.text.strip() for cell in row.cells if cell.text.strip()]
+            if values:
+                parts.append(" | ".join(values))
+    return "\n".join(parts).strip()
+
+
+async def _parse_pdf(
+    *,
+    label: str,
+    file_bytes: bytes,
+    image_parser: Optional[ImageParser],
+    vision_budget: dict[str, int],
+    max_pdf_pages: int,
+) -> list[ParsedSource]:
+    try:
+        import fitz
+    except ImportError as exc:
+        raise RuntimeError("PyMuPDF is required to parse PDF files") from exc
+
+    document = fitz.open(stream=file_bytes, filetype="pdf")
+    try:
+        page_count = min(len(document), max_pdf_pages)
+        parts: list[str] = []
+
+        for page_index in range(page_count):
+            page = document.load_page(page_index)
+            page_label = f"{label} page {page_index + 1}"
+            page_text = (page.get_text("text") or "").strip()
+            if len(page_text.split()) >= PDF_TEXT_WORD_THRESHOLD:
+                parts.append(f"[{page_label}]\n{page_text}")
+                continue
+
+            if image_parser and vision_budget["remaining"] > 0:
+                pixmap = page.get_pixmap(matrix=fitz.Matrix(2, 2), alpha=False)
+                image_bytes = pixmap.tobytes("png")
+                image_text = await _parse_image(
+                    label=page_label,
+                    file_bytes=image_bytes,
+                    mime_type="image/png",
+                    image_parser=image_parser,
+                    vision_budget=vision_budget,
+                )
+                if image_text.strip():
+                    parts.append(f"[{page_label}]\n{image_text.strip()}")
+
+        if len(document) > max_pdf_pages:
+            parts.append(f"[Parser note] Remaining pages after page {max_pdf_pages} were not processed.")
+    finally:
+        close = getattr(document, "close", None)
+        if callable(close):
+            close()
+
+    text = "\n\n".join(parts).strip()
+    return [ParsedSource(label=label, text=text, kind="pdf")] if text else []
+
+
+async def _parse_image(
+    *,
+    label: str,
+    file_bytes: bytes,
+    mime_type: str,
+    image_parser: Optional[ImageParser],
+    vision_budget: dict[str, int],
+) -> str:
+    if not image_parser:
+        raise RuntimeError("Image parsing is unavailable because OPENAI_API_KEY is not configured")
+    if vision_budget["remaining"] <= 0:
+        raise RuntimeError("Image parsing limit reached for this request")
+    vision_budget["remaining"] -= 1
+    return (await image_parser(file_bytes, mime_type, label)).strip()
+
+
+def _file_label(file: dict[str, Any]) -> str:
+    return str(
+        file.get("name")
+        or file.get("title")
+        or file.get("id")
+        or "Slack file"
+    ).strip()
+
+
+def _file_extension(file: dict[str, Any]) -> str:
+    name = _file_label(file)
+    extension = Path(name).suffix.lower()
+    if extension:
+        return extension
+
+    filetype = str(file.get("filetype") or "").lower().strip(".")
+    if filetype:
+        return f".{filetype}"
+
+    mimetype = _file_mimetype(file)
+    if mimetype == "application/pdf":
+        return ".pdf"
+    if mimetype in {
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/msword",
+    }:
+        return ".docx" if "openxmlformats" in mimetype else ".doc"
+    if mimetype.startswith("image/"):
+        return f".{mimetype.split('/', 1)[1].replace('jpeg', 'jpg')}"
+    if mimetype.startswith("text/"):
+        return ".txt"
+    return ""
+
+
+def _file_mimetype(file: dict[str, Any]) -> str:
+    mimetype = str(file.get("mimetype") or "").strip().lower()
+    if mimetype:
+        return mimetype
+
+    extension = Path(_file_label(file)).suffix.lower()
+    return {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".webp": "image/webp",
+        ".gif": "image/gif",
+        ".pdf": "application/pdf",
+        ".txt": "text/plain",
+        ".md": "text/markdown",
+        ".csv": "text/csv",
+        ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    }.get(extension, "application/octet-stream")
+
+
+def _is_animated_gif(file_bytes: bytes) -> bool:
+    if not file_bytes.startswith((b"GIF87a", b"GIF89a")):
+        return False
+    return file_bytes.count(b"\x21\xf9\x04") > 1
+
+
+def source_text_chunks(source: ParsedSource, max_chars: int = 10000) -> list[str]:
+    """Split source text into chunks without dropping source attribution."""
+    text = source.text.strip()
+    if len(text) <= max_chars:
+        return [f"Source: {source.label}\n{text}"] if text else []
+
+    chunks: list[str] = []
+    paragraphs = re.split(r"\n{2,}", text)
+    current = ""
+    for paragraph in paragraphs:
+        paragraph = paragraph.strip()
+        if not paragraph:
+            continue
+        next_value = f"{current}\n\n{paragraph}".strip() if current else paragraph
+        if len(next_value) > max_chars and current:
+            chunks.append(f"Source: {source.label}\n{current}")
+            current = paragraph
+        elif len(next_value) > max_chars:
+            for start in range(0, len(paragraph), max_chars):
+                chunks.append(f"Source: {source.label}\n{paragraph[start:start + max_chars]}")
+            current = ""
+        else:
+            current = next_value
+    if current:
+        chunks.append(f"Source: {source.label}\n{current}")
+    return chunks

--- a/roo-standalone/roo/llm.py
+++ b/roo-standalone/roo/llm.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
 from enum import Enum
+import base64
 
 from .config import get_settings
 
@@ -221,3 +222,36 @@ async def embed(text: str) -> List[float]:
     """Convenience function for generating embeddings."""
     client = get_default_client()
     return await client.embed(text)
+
+
+async def extract_text_from_image(
+    *,
+    image_bytes: bytes,
+    mime_type: str,
+    prompt: str,
+    model: Optional[str] = None,
+) -> str:
+    """Extract structured text from an image using an OpenAI vision-capable model."""
+    from openai import AsyncOpenAI
+
+    settings = get_settings()
+    if not settings.OPENAI_API_KEY:
+        raise ValueError("OPENAI_API_KEY not configured")
+
+    image_base64 = base64.b64encode(image_bytes).decode("ascii")
+    data_url = f"data:{mime_type};base64,{image_base64}"
+    client = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)
+    response = await client.chat.completions.create(
+        model=model or settings.OPENAI_VISION_MODEL,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image_url", "image_url": {"url": data_url}},
+                ],
+            }
+        ],
+        max_tokens=2048,
+    )
+    return response.choices[0].message.content or ""

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import hmac
 import hashlib
+import re
 import time
 from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass
@@ -70,6 +71,16 @@ CONTENT_FACTORY_WATCHDOG_STOP_STATUSES = {
     "denied",
     "cancelled",
 }
+
+
+def _looks_like_linear_meeting_file_request(text: str, has_files: bool = False) -> bool:
+    text_lower = str(text or "").lower()
+    has_linear = bool(re.search(r"\blinear\b", text_lower))
+    has_source = bool(
+        re.search(r"\b(file|pdf|docx?|document|image|screenshot|meeting|transcript|notes?|to-?dos?|action\s+items?)\b", text_lower)
+    ) or has_files
+    has_action = bool(re.search(r"\b(send|sync|turn|extract|create|add|tasks?|tickets?|issues?)\b", text_lower))
+    return has_linear and has_source and has_action
 
 
 def _app_mention_event_key(payload: dict[str, Any], event: dict[str, Any]) -> Optional[str]:
@@ -1588,11 +1599,15 @@ async def slack_events(request: Request):
         asyncio.create_task(_handle_reaction_added(event))
         return JSONResponse(status_code=200, content={})
     
-    if event_type == "message" and not event.get("bot_id") and not event.get("subtype"):
+    if (
+        event_type == "message"
+        and not event.get("bot_id")
+        and (not event.get("subtype") or event.get("subtype") == "file_share")
+    ):
         from .slack_client import get_channel_id
 
         start_here_id = get_channel_id("_start-here")
-        if start_here_id and event.get("channel") == start_here_id:
+        if start_here_id and event.get("channel") == start_here_id and not event.get("subtype"):
             if event.get("thread_ts"):
                 print(f"🧵 Ignoring thread reply in #_start-here from {event.get('user')}")
                 return JSONResponse(status_code=200, content={})
@@ -1620,6 +1635,12 @@ async def slack_events(request: Request):
         
         is_dm = event.get("channel_type") == "im"
         if is_dm:
+            event_files = event.get("files") if isinstance(event.get("files"), list) else []
+            if event.get("subtype") == "file_share" and not _looks_like_linear_meeting_file_request(
+                event.get("text", ""),
+                has_files=bool(event_files),
+            ):
+                return JSONResponse(status_code=200, content={})
             print(f"📨 Received DM from {event.get('user')}")
             asyncio.create_task(_handle_mention(event))
             return JSONResponse(status_code=200, content={})
@@ -1668,6 +1689,7 @@ async def _handle_mention(event: dict):
         channel_id = event.get("channel")
         thread_ts = event.get("thread_ts") or event.get("ts")
         param_overrides = event.get("param_overrides")
+        event_files = event.get("files") if isinstance(event.get("files"), list) else None
         
         print(f"\n🦘 ROO MENTION: from {user_id} in {channel_id}")
         print(f"   Text: {text[:100]}...")
@@ -1679,6 +1701,7 @@ async def _handle_mention(event: dict):
             channel_id=channel_id,
             thread_ts=thread_ts,
             param_overrides=param_overrides if isinstance(param_overrides, dict) else None,
+            event_files=event_files,
         )
         
         if result.get("message") and not result.get("suppress_post"):
@@ -3101,6 +3124,100 @@ async def slack_actions(request: Request):
     thread_ts = message.get("thread_ts") or message.get("ts")
     
     print(f"🖱️ Action: {action_id} from {user_id}")
+
+    if action_id in {"linear_meeting_approve", "linear_meeting_reject"}:
+        value = actions[0].get("value", "")
+        try:
+            value_data = json.loads(value) if value else {}
+        except json.JSONDecodeError:
+            value_data = {}
+
+        pending_id = str(value_data.get("pending_id") or "").strip()
+        requested_by = str(value_data.get("requested_by") or "").strip()
+        reply_channel = channel_id
+        reply_thread_ts = thread_ts
+
+        from .skills.executor import (
+            get_pending_linear_meeting_action,
+            pop_pending_linear_meeting_action,
+        )
+
+        pending = get_pending_linear_meeting_action(pending_id)
+        if not pending:
+            if reply_channel:
+                post_message(
+                    channel=reply_channel,
+                    thread_ts=reply_thread_ts,
+                    text="That Linear meeting action is no longer available. Re-run the meeting notes request if you still need it.",
+                )
+            return JSONResponse(status_code=200, content={})
+
+        pending_requested_by = str(pending.get("requested_by") or requested_by).strip()
+        if pending_requested_by and user_id != pending_requested_by:
+            if reply_channel:
+                post_message(
+                    channel=reply_channel,
+                    thread_ts=reply_thread_ts,
+                    text="Only the person who requested this Linear meeting action can approve or reject it.",
+                )
+            return JSONResponse(status_code=200, content={})
+
+        display = pending.get("display") or {}
+        title = display.get("title") or "that action item"
+
+        if action_id == "linear_meeting_reject":
+            pop_pending_linear_meeting_action(pending_id)
+            if reply_channel:
+                post_message(
+                    channel=reply_channel,
+                    thread_ts=reply_thread_ts,
+                    text=f"Skipped Linear issue creation for: {title}",
+                )
+            return JSONResponse(status_code=200, content={})
+
+        settings = get_settings()
+        if not settings.LINEAR_API_KEY:
+            if reply_channel:
+                post_message(
+                    channel=reply_channel,
+                    thread_ts=reply_thread_ts,
+                    text="Linear is not configured for Roo yet. Set `LINEAR_API_KEY` before approving this action item.",
+                )
+            return JSONResponse(status_code=200, content={})
+
+        skill = get_agent()._get_skill_by_name("linear-meeting-actions")
+        ClientClass = skill.get_client_class("LinearMeetingActionsClient") if skill else None
+        if ClientClass is None:
+            if reply_channel:
+                post_message(
+                    channel=reply_channel,
+                    thread_ts=reply_thread_ts,
+                    text="Roo could not load the Linear meeting actions client for this approval.",
+                )
+            return JSONResponse(status_code=200, content={})
+
+        try:
+            issue = await ClientClass(api_key=settings.LINEAR_API_KEY).create_issue(
+                **pending["issue_input"]
+            )
+            pop_pending_linear_meeting_action(pending_id)
+        except Exception as exc:
+            if reply_channel:
+                post_message(
+                    channel=reply_channel,
+                    thread_ts=reply_thread_ts,
+                    text=f"I couldn't create that Linear issue yet: {exc.__class__.__name__}: {exc}",
+                )
+            return JSONResponse(status_code=200, content={})
+
+        issue_label = issue.get("identifier") or issue.get("title") or title
+        if issue.get("url"):
+            created_text = f"Created <{issue['url']}|{issue_label}> from: {title}"
+        else:
+            created_text = f"Created {issue_label} from: {title}"
+        if reply_channel:
+            post_message(channel=reply_channel, thread_ts=reply_thread_ts, text=created_text)
+        return JSONResponse(status_code=200, content={})
     
     if action_id == "resume_scan":
         value = actions[0].get("value", "")

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -33,7 +33,13 @@ from ..content_factory_identity import (
     resolve_content_factory_identity_context,
 )
 from ..content_intent import detect_content_action, is_explicit_scan_request
-from ..llm import chat, embed, get_llm_client
+from ..linear_meeting_sources import (
+    ParsedSource,
+    SourceParseResult,
+    parse_linear_meeting_sources,
+    source_text_chunks,
+)
+from ..llm import chat, embed, extract_text_from_image, get_llm_client
 from ..points_request_approval import (
     build_points_request_metadata,
     build_points_request_record,
@@ -50,7 +56,7 @@ from ..coworking_booking_intents import (
 POINTS_SUPER_ADMIN_SLACK_ID = "U05QPB483K9"
 FULL_POINTS_ADMIN_ROLES = {"admin", "committee", "portfolio_lead"}
 COWORKING_REPORT_ROLES = {*FULL_POINTS_ADMIN_ROLES, "partner"}
-
+LINEAR_MEETING_PENDING_ACTIONS: dict[str, dict[str, Any]] = {}
 
 @dataclass
 class SkillResult:
@@ -61,6 +67,14 @@ class SkillResult:
     error: Optional[str] = None
     blocks: Optional[list] = None
     suppress_post: bool = False
+
+
+def get_pending_linear_meeting_action(pending_id: str) -> Optional[dict[str, Any]]:
+    return LINEAR_MEETING_PENDING_ACTIONS.get(pending_id)
+
+
+def pop_pending_linear_meeting_action(pending_id: str) -> Optional[dict[str, Any]]:
+    return LINEAR_MEETING_PENDING_ACTIONS.pop(pending_id, None)
 
 
 class SkillExecutor:
@@ -117,6 +131,17 @@ class SkillExecutor:
                 result = await self._execute_mlai_points(skill, text, params, user_id, channel_id, thread_ts)
             elif skill.name == "github-integration":
                 result = await self._execute_github_integration(skill, text, params, user_id, channel_id, thread_ts)
+            elif skill.name == "linear-meeting-actions":
+                result = await self._execute_linear_meeting_actions(
+                    skill,
+                    text,
+                    params,
+                    user_id,
+                    channel_id,
+                    thread_ts,
+                    thread_history,
+                    kwargs.get("event_files"),
+                )
             elif skill.name == "tone-of-voice":
                 result = await self._execute_tone_of_voice(skill, text, params, user_id)
             elif skill.name == "medhack":
@@ -1463,6 +1488,850 @@ Keep the response concise but informative."""
         ])
         
         return response.content
+
+    async def _execute_linear_meeting_actions(
+        self,
+        skill: Skill,
+        text: str,
+        params: dict,
+        user_id: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+        thread_history: Optional[List[dict]] = None,
+        event_files: Optional[List[dict]] = None,
+    ) -> dict:
+        settings = get_settings()
+        if not getattr(settings, "LINEAR_API_KEY", None):
+            return {
+                "message": "Linear meeting actions are not configured yet. Set `LINEAR_API_KEY` for Roo first."
+            }
+
+        source_result = await self._build_linear_meeting_source_result(
+            text=text,
+            params=params,
+            thread_history=thread_history,
+            event_files=event_files,
+            settings=settings,
+        )
+        transcript = source_result.combined_text()
+        if len(transcript.split()) < 8:
+            warning_suffix = self._format_linear_meeting_source_warnings(source_result.warnings)
+            return {
+                "message": (
+                    "Paste the meeting transcript or summary in this thread, then ask me to turn it into Linear tasks."
+                    + warning_suffix
+                )
+            }
+
+        ClientClass = skill.get_client_class("LinearMeetingActionsClient")
+        if ClientClass is None:
+            return {"message": "Linear meeting actions are missing their Linear client implementation."}
+
+        client = ClientClass(api_key=settings.LINEAR_API_KEY)
+        try:
+            teams, users, projects, labels, recent_issues = await asyncio.gather(
+                client.list_teams(),
+                client.list_users(),
+                client.list_active_projects(),
+                client.list_issue_labels(),
+                client.list_recent_open_issues(),
+            )
+        except Exception as exc:
+            return {
+                "message": f"I couldn't read Linear context yet: {exc.__class__.__name__}: {exc}"
+            }
+
+        candidates = await self._extract_linear_meeting_candidates_from_sources(
+            sources=source_result.sources,
+            params=params,
+            users=users,
+            projects=projects,
+        )
+        if not candidates:
+            return {
+                "message": (
+                    "I couldn't find any concrete action items in those meeting notes."
+                    + self._format_linear_meeting_source_warnings(source_result.warnings)
+                )
+            }
+
+        auto_threshold = float(
+            getattr(settings, "LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE", 0.85) or 0.85
+        )
+        uncertain_threshold = float(
+            getattr(settings, "LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE", 0.65) or 0.65
+        )
+        meeting_action_label_ids = [
+            str(label.get("id"))
+            for label in labels
+            if self._normalize_match_text(label.get("name")) == "meetingaction"
+        ]
+
+        created: list[dict[str, Any]] = []
+        review_needed: list[dict[str, Any]] = []
+        skipped: list[dict[str, Any]] = []
+        source = {
+            "channel_id": channel_id,
+            "thread_ts": thread_ts,
+            "requester_slack_id": user_id,
+        }
+
+        for raw_candidate in candidates[:20]:
+            candidate = self._normalize_linear_meeting_candidate(raw_candidate)
+            if not candidate.get("title"):
+                continue
+
+            owner_match = self._match_linear_meeting_owner(candidate.get("owner_hint"), users)
+            project_match = self._match_linear_meeting_project(
+                candidate,
+                projects,
+                owner_match.get("user"),
+                params.get("project_hint"),
+            )
+            team_match = self._match_linear_meeting_team(
+                project_match.get("project"),
+                teams,
+                params.get("team_hint") or candidate.get("team_hint"),
+                getattr(settings, "LINEAR_DEFAULT_TEAM", None),
+            )
+            duplicate = self._find_linear_meeting_duplicate(
+                candidate,
+                recent_issues,
+                project_match.get("project"),
+            )
+            decision, overall_confidence = self._linear_meeting_candidate_decision(
+                candidate=candidate,
+                owner_match=owner_match,
+                project_match=project_match,
+                team_match=team_match,
+                duplicate=duplicate,
+                auto_threshold=auto_threshold,
+                uncertain_threshold=uncertain_threshold,
+            )
+
+            issue_input = self._build_linear_meeting_issue_input(
+                candidate=candidate,
+                owner_match=owner_match,
+                project_match=project_match,
+                team_match=team_match,
+                label_ids=meeting_action_label_ids,
+                source=source,
+            )
+            display = self._build_linear_meeting_candidate_display(
+                candidate,
+                owner_match,
+                project_match,
+                team_match,
+                overall_confidence,
+            )
+
+            if decision == "duplicate":
+                skipped.append({
+                    **display,
+                    "reason": "Likely duplicate",
+                    "duplicate": duplicate,
+                })
+                continue
+
+            if decision == "create":
+                try:
+                    issue = await client.create_issue(**issue_input)
+                    created.append({**display, "issue": issue})
+                except Exception as exc:
+                    pending_id = self._remember_linear_meeting_pending_action(
+                        requested_by=user_id,
+                        issue_input=issue_input,
+                        display=display,
+                        reason=f"Linear create failed: {exc.__class__.__name__}: {exc}",
+                    )
+                    review_needed.append({**display, "pending_id": pending_id})
+                continue
+
+            if decision == "review":
+                pending_id = self._remember_linear_meeting_pending_action(
+                    requested_by=user_id,
+                    issue_input=issue_input,
+                    display=display,
+                    reason="Needs approval",
+                )
+                review_needed.append({**display, "pending_id": pending_id})
+                continue
+
+            skipped.append({**display, "reason": "Low confidence mapping"})
+
+        message = self._format_linear_meeting_result_message(created, review_needed, skipped)
+        message += self._format_linear_meeting_source_warnings(source_result.warnings)
+        blocks = (
+            self._build_linear_meeting_review_blocks(message, review_needed, user_id)
+            if review_needed
+            else None
+        )
+        return {
+            "message": message,
+            "blocks": blocks,
+            "data": {
+                "created_count": len(created),
+                "review_count": len(review_needed),
+                "skipped_count": len(skipped),
+            },
+        }
+
+    def _build_linear_meeting_transcript(
+        self,
+        text: str,
+        params: dict,
+        history: Optional[List[dict]] = None,
+    ) -> str:
+        explicit = str(params.get("transcript") or "").strip()
+        parts: list[str] = []
+        if explicit:
+            parts.append(explicit)
+
+        for message in history or []:
+            if message.get("is_bot") or message.get("bot_id"):
+                continue
+            message_text = str(message.get("text") or "").strip()
+            if not message_text:
+                continue
+            speaker = str(message.get("user") or "user").strip()
+            parts.append(f"{speaker}: {message_text}")
+
+        clean_text = str(text or "").strip()
+        if clean_text and all(clean_text not in part for part in parts):
+            parts.append(clean_text)
+
+        return "\n".join(dict.fromkeys(parts)).strip()
+
+    async def _build_linear_meeting_source_result(
+        self,
+        *,
+        text: str,
+        params: dict,
+        thread_history: Optional[List[dict]],
+        event_files: Optional[List[dict]],
+        settings: Any,
+    ) -> SourceParseResult:
+        image_parser = None
+        if getattr(settings, "OPENAI_API_KEY", None):
+            async def image_parser(image_bytes: bytes, mime_type: str, label: str) -> str:
+                prompt = (
+                    "Extract meeting transcript text or to-do/action items from this image. "
+                    "Preserve names, due dates, checkboxes, bullets, and project labels. "
+                    f"Return plain text only. Source label: {label}"
+                )
+                return await extract_text_from_image(
+                    image_bytes=image_bytes,
+                    mime_type=mime_type,
+                    prompt=prompt,
+                    model=getattr(settings, "OPENAI_VISION_MODEL", None),
+                )
+
+        return await parse_linear_meeting_sources(
+            text=text,
+            params=params,
+            thread_history=thread_history,
+            event_files=event_files,
+            image_parser=image_parser,
+        )
+
+    def _format_linear_meeting_source_warnings(self, warnings: list[str]) -> str:
+        if not warnings:
+            return ""
+        lines = ["", "", "Source notes:"]
+        for warning in warnings[:8]:
+            lines.append(f"- {warning}")
+        if len(warnings) > 8:
+            lines.append(f"- {len(warnings) - 8} more source note(s) omitted.")
+        return "\n".join(lines)
+
+    async def _extract_linear_meeting_candidates_from_sources(
+        self,
+        *,
+        sources: list[ParsedSource],
+        params: dict,
+        users: list[dict[str, Any]],
+        projects: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        candidates: list[dict[str, Any]] = []
+        for source in sources:
+            for chunk in source_text_chunks(source):
+                extracted = await self._extract_linear_meeting_candidates(
+                    transcript=chunk,
+                    params=params,
+                    users=users,
+                    projects=projects,
+                    source_label=source.label,
+                )
+                for item in extracted:
+                    item.setdefault("source_label", source.label)
+                    candidates.append(item)
+        return self._dedupe_linear_meeting_candidates(candidates)
+
+    async def _extract_linear_meeting_candidates(
+        self,
+        *,
+        transcript: str,
+        params: dict,
+        users: list[dict[str, Any]],
+        projects: list[dict[str, Any]],
+        source_label: Optional[str] = None,
+    ) -> list[dict[str, Any]]:
+        from ..utils import get_current_date
+
+        project_names = ", ".join(
+            str(project.get("name") or project.get("slugId") or "")
+            for project in projects[:40]
+            if project.get("name") or project.get("slugId")
+        )
+        user_names = ", ".join(
+            str(user.get("displayName") or user.get("name") or user.get("email") or "")
+            for user in users[:80]
+            if user.get("displayName") or user.get("name") or user.get("email")
+        )
+        prompt = f"""Extract concrete action items from the meeting notes.
+
+Current date: {get_current_date().isoformat()}
+Source label: {source_label or "Slack thread"}
+Project hint: {params.get("project_hint") or "none"}
+Team hint: {params.get("team_hint") or "none"}
+
+Known Linear projects: {project_names or "none loaded"}
+Known Linear users: {user_names or "none loaded"}
+
+Meeting notes:
+{transcript[:12000]}
+
+Return JSON only with this shape:
+{{
+  "action_items": [
+    {{
+      "title": "imperative issue title",
+      "description": "one or two sentence issue description",
+      "owner_hint": "person, Slack mention, or email",
+      "project_hint": "project name if clear",
+      "team_hint": "team if clear",
+      "due_date": "YYYY-MM-DD or null",
+      "priority": 3,
+      "evidence": "short source phrase from notes",
+      "source_label": "{source_label or "Slack thread"}",
+      "confidence": 0.0
+    }}
+  ]
+}}
+
+Only include actionable work someone agreed to do. Do not include decisions, FYIs, or vague follow-ups."""
+        response = await chat([
+            {"role": "system", "content": "You extract structured meeting action items. Return valid JSON only."},
+            {"role": "user", "content": prompt},
+        ])
+        content = response.content.strip()
+        if content.startswith("```"):
+            content = re.sub(r"^```\w*\n?", "", content)
+            content = re.sub(r"\n?```$", "", content)
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            return []
+        if isinstance(parsed, list):
+            return [item for item in parsed if isinstance(item, dict)]
+        items = parsed.get("action_items") if isinstance(parsed, dict) else []
+        return [item for item in items or [] if isinstance(item, dict)]
+
+    def _dedupe_linear_meeting_candidates(
+        self,
+        candidates: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        deduped: dict[str, dict[str, Any]] = {}
+        for candidate in candidates:
+            title = self._normalize_match_text(candidate.get("title") or candidate.get("task"))
+            owner = self._normalize_match_text(candidate.get("owner_hint") or candidate.get("owner"))
+            if not title:
+                continue
+            key = f"{title}:{owner}"
+            if key not in deduped:
+                deduped[key] = dict(candidate)
+                continue
+
+            existing = deduped[key]
+            try:
+                existing_confidence = float(existing.get("confidence", 0.0))
+                candidate_confidence = float(candidate.get("confidence", 0.0))
+            except (TypeError, ValueError):
+                existing_confidence = candidate_confidence = 0.0
+            if candidate_confidence > existing_confidence:
+                existing["confidence"] = candidate.get("confidence")
+
+            labels = {
+                str(existing.get("source_label") or "").strip(),
+                str(candidate.get("source_label") or "").strip(),
+            }
+            labels.discard("")
+            if labels:
+                existing["source_label"] = ", ".join(sorted(labels))
+
+            existing_evidence = str(existing.get("evidence") or "").strip()
+            candidate_evidence = str(candidate.get("evidence") or "").strip()
+            if candidate_evidence and candidate_evidence not in existing_evidence:
+                existing["evidence"] = (
+                    f"{existing_evidence}\n{candidate_evidence}".strip()
+                    if existing_evidence
+                    else candidate_evidence
+                )
+        return list(deduped.values())
+
+    def _normalize_linear_meeting_candidate(self, candidate: dict[str, Any]) -> dict[str, Any]:
+        title = str(candidate.get("title") or candidate.get("task") or "").strip()
+        description = str(candidate.get("description") or candidate.get("details") or "").strip()
+        owner_hint = str(candidate.get("owner_hint") or candidate.get("owner") or "").strip()
+        project_hint = str(candidate.get("project_hint") or candidate.get("project") or "").strip()
+        team_hint = str(candidate.get("team_hint") or candidate.get("team") or "").strip()
+        due_date = candidate.get("due_date") or candidate.get("dueDate")
+        due_date = str(due_date).strip() if due_date else None
+        if due_date and not re.match(r"^\d{4}-\d{2}-\d{2}$", due_date):
+            due_date = None
+        try:
+            priority = int(candidate.get("priority", 3))
+        except (TypeError, ValueError):
+            priority = 3
+        priority = min(max(priority, 0), 4)
+        try:
+            confidence = float(candidate.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            confidence = 0.0
+        confidence = min(max(confidence, 0.0), 1.0)
+        evidence = str(candidate.get("evidence") or candidate.get("quote") or "").strip()
+        source_label = str(candidate.get("source_label") or candidate.get("source") or "").strip()
+        return {
+            "title": title[:180],
+            "description": description,
+            "owner_hint": owner_hint,
+            "project_hint": project_hint,
+            "team_hint": team_hint,
+            "due_date": due_date,
+            "priority": priority,
+            "evidence": evidence[:700],
+            "source_label": source_label[:300],
+            "confidence": confidence,
+        }
+
+    def _match_linear_meeting_owner(
+        self,
+        owner_hint: Optional[str],
+        users: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        hint = str(owner_hint or "").strip()
+        if not hint:
+            return {"user": None, "confidence": 0.0, "reason": "No owner hint"}
+
+        emails = set(re.findall(r"[\w.\-+]+@[\w.\-]+\.\w+", hint.lower()))
+        mention_match = re.search(r"<@([A-Z0-9]+)>", hint)
+        if mention_match:
+            try:
+                from ..slack_client import get_user_info
+
+                slack_info = get_user_info(mention_match.group(1))
+                slack_email = str(slack_info.get("email") or "").strip().lower()
+                if slack_email:
+                    emails.add(slack_email)
+            except Exception:
+                pass
+
+        for user in users:
+            email = str(user.get("email") or "").strip().lower()
+            if email and email in emails:
+                return {"user": user, "confidence": 0.98, "reason": "Matched owner by email"}
+
+        normalized_hint = self._normalize_match_text(hint)
+        best_user = None
+        best_score = 0.0
+        best_reason = "No user match"
+        for user in users:
+            names = [
+                user.get("displayName"),
+                user.get("name"),
+                user.get("email"),
+            ]
+            for name in names:
+                normalized_name = self._normalize_match_text(name)
+                if not normalized_name:
+                    continue
+                if normalized_hint == normalized_name:
+                    return {"user": user, "confidence": 0.92, "reason": "Matched owner by name"}
+                if normalized_name in normalized_hint or normalized_hint in normalized_name:
+                    score = 0.86
+                else:
+                    score = SequenceMatcher(None, normalized_hint, normalized_name).ratio()
+                if score > best_score:
+                    best_user = user
+                    best_score = score
+                    best_reason = "Matched owner by name similarity"
+
+        if best_user and best_score >= 0.82:
+            return {"user": best_user, "confidence": min(best_score, 0.84), "reason": best_reason}
+        return {"user": None, "confidence": 0.0, "reason": "No user match"}
+
+    def _match_linear_meeting_project(
+        self,
+        candidate: dict[str, Any],
+        projects: list[dict[str, Any]],
+        owner_user: Optional[dict[str, Any]],
+        explicit_project_hint: Optional[str] = None,
+    ) -> dict[str, Any]:
+        hint = str(explicit_project_hint or candidate.get("project_hint") or "").strip()
+        if hint:
+            normalized_hint = self._normalize_match_text(hint)
+            best_project = None
+            best_score = 0.0
+            for project in projects:
+                names = [project.get("name"), project.get("slugId")]
+                for name in names:
+                    normalized_name = self._normalize_match_text(name)
+                    if not normalized_name:
+                        continue
+                    if normalized_hint == normalized_name:
+                        return {
+                            "project": project,
+                            "confidence": 0.96,
+                            "reason": "Matched project by exact hint",
+                        }
+                    if normalized_name in normalized_hint or normalized_hint in normalized_name:
+                        score = 0.88
+                    else:
+                        score = SequenceMatcher(None, normalized_hint, normalized_name).ratio()
+                    if score > best_score:
+                        best_project = project
+                        best_score = score
+            if best_project and best_score >= 0.78:
+                return {
+                    "project": best_project,
+                    "confidence": min(best_score, 0.86),
+                    "reason": "Matched project by name similarity",
+                }
+
+        owner_id = str((owner_user or {}).get("id") or "")
+        owner_email = str((owner_user or {}).get("email") or "").strip().lower()
+        member_projects = []
+        if owner_id or owner_email:
+            for project in projects:
+                members = self._linear_connection_nodes(project.get("members"))
+                lead = project.get("lead")
+                participants = members + ([lead] if isinstance(lead, dict) else [])
+                for member in participants:
+                    if str(member.get("id") or "") == owner_id or (
+                        owner_email
+                        and str(member.get("email") or "").strip().lower() == owner_email
+                    ):
+                        member_projects.append(project)
+                        break
+        if len(member_projects) == 1:
+            return {
+                "project": member_projects[0],
+                "confidence": 0.7,
+                "reason": "Only active project found for owner",
+            }
+        return {"project": None, "confidence": 0.0, "reason": "No project match"}
+
+    def _match_linear_meeting_team(
+        self,
+        project: Optional[dict[str, Any]],
+        teams: list[dict[str, Any]],
+        team_hint: Optional[str],
+        default_team: Optional[str],
+    ) -> dict[str, Any]:
+        if project:
+            project_teams = self._linear_connection_nodes(project.get("teams"))
+            if project_teams:
+                return {
+                    "team": project_teams[0],
+                    "confidence": 0.96,
+                    "reason": "Using matched project's team",
+                }
+
+        hint = str(team_hint or "").strip()
+        if hint:
+            match = self._find_linear_team_by_hint(teams, hint)
+            if match:
+                return {"team": match, "confidence": 0.9, "reason": "Matched team by hint"}
+
+        if default_team:
+            match = self._find_linear_team_by_hint(teams, default_team)
+            if match:
+                return {
+                    "team": match,
+                    "confidence": 0.72,
+                    "reason": "Using configured default team",
+                }
+        return {"team": None, "confidence": 0.0, "reason": "No team match"}
+
+    def _find_linear_team_by_hint(
+        self,
+        teams: list[dict[str, Any]],
+        hint: str,
+    ) -> Optional[dict[str, Any]]:
+        normalized_hint = self._normalize_match_text(hint)
+        for team in teams:
+            values = [team.get("id"), team.get("key"), team.get("name")]
+            if any(self._normalize_match_text(value) == normalized_hint for value in values):
+                return team
+        for team in teams:
+            normalized_values = [
+                self._normalize_match_text(value)
+                for value in (team.get("key"), team.get("name"))
+            ]
+            if any(value and (value in normalized_hint or normalized_hint in value) for value in normalized_values):
+                return team
+        return None
+
+    def _find_linear_meeting_duplicate(
+        self,
+        candidate: dict[str, Any],
+        issues: list[dict[str, Any]],
+        project: Optional[dict[str, Any]] = None,
+    ) -> Optional[dict[str, Any]]:
+        title = self._normalize_match_text(candidate.get("title"))
+        if not title:
+            return None
+        project_id = str((project or {}).get("id") or "")
+        for issue in issues:
+            if project_id:
+                issue_project_id = str(((issue.get("project") or {}).get("id")) or "")
+                if issue_project_id and issue_project_id != project_id:
+                    continue
+            issue_title = self._normalize_match_text(issue.get("title"))
+            if not issue_title:
+                continue
+            if title == issue_title or title in issue_title or issue_title in title:
+                return issue
+            title_tokens = self._linear_meeting_duplicate_tokens(candidate.get("title"))
+            issue_tokens = self._linear_meeting_duplicate_tokens(issue.get("title"))
+            if title_tokens and issue_tokens:
+                overlap = len(title_tokens & issue_tokens) / min(len(title_tokens), len(issue_tokens))
+                if overlap >= 0.75:
+                    return issue
+            if SequenceMatcher(None, title, issue_title).ratio() >= 0.88:
+                return issue
+        return None
+
+    def _linear_meeting_candidate_decision(
+        self,
+        *,
+        candidate: dict[str, Any],
+        owner_match: dict[str, Any],
+        project_match: dict[str, Any],
+        team_match: dict[str, Any],
+        duplicate: Optional[dict[str, Any]],
+        auto_threshold: float,
+        uncertain_threshold: float,
+    ) -> tuple[str, float]:
+        if duplicate:
+            return "duplicate", 1.0
+        confidence_parts = [
+            float(candidate.get("confidence") or 0.0),
+            float(owner_match.get("confidence") or 0.0),
+            float(project_match.get("confidence") or 0.0),
+            float(team_match.get("confidence") or 0.0),
+        ]
+        overall = min(confidence_parts)
+        if overall >= auto_threshold:
+            return "create", overall
+        if overall >= uncertain_threshold:
+            return "review", overall
+        return "skip", overall
+
+    def _build_linear_meeting_issue_input(
+        self,
+        *,
+        candidate: dict[str, Any],
+        owner_match: dict[str, Any],
+        project_match: dict[str, Any],
+        team_match: dict[str, Any],
+        label_ids: list[str],
+        source: dict[str, Any],
+    ) -> dict[str, Any]:
+        team = team_match.get("team") or {}
+        owner = owner_match.get("user") or {}
+        project = project_match.get("project") or {}
+        return {
+            "title": candidate["title"],
+            "team_id": str(team.get("id") or ""),
+            "description": self._build_linear_meeting_issue_description(candidate, source),
+            "assignee_id": str(owner.get("id") or "") or None,
+            "project_id": str(project.get("id") or "") or None,
+            "priority": candidate.get("priority", 3),
+            "due_date": candidate.get("due_date"),
+            "label_ids": label_ids,
+        }
+
+    def _build_linear_meeting_issue_description(
+        self,
+        candidate: dict[str, Any],
+        source: dict[str, Any],
+    ) -> str:
+        lines = [
+            "### Meeting action",
+            candidate.get("description") or candidate.get("title") or "",
+            "",
+        ]
+        if candidate.get("evidence"):
+            lines.extend([
+                "### Evidence",
+                f"> {candidate['evidence']}",
+                "",
+            ])
+        source_lines = []
+        if candidate.get("source_label"):
+            source_lines.append(f"- Source document: `{candidate['source_label']}`")
+        if source.get("channel_id"):
+            source_lines.append(f"- Slack channel: `{source['channel_id']}`")
+        if source.get("thread_ts"):
+            source_lines.append(f"- Slack thread: `{source['thread_ts']}`")
+        if source.get("requester_slack_id"):
+            source_lines.append(f"- Requested by: `<@{source['requester_slack_id']}>`")
+        if source_lines:
+            lines.extend(["### Source", *source_lines, ""])
+        lines.append("_Generated by Roo from meeting notes._")
+        return "\n".join(line for line in lines if line is not None).strip()
+
+    def _build_linear_meeting_candidate_display(
+        self,
+        candidate: dict[str, Any],
+        owner_match: dict[str, Any],
+        project_match: dict[str, Any],
+        team_match: dict[str, Any],
+        confidence: float,
+    ) -> dict[str, Any]:
+        owner = owner_match.get("user") or {}
+        project = project_match.get("project") or {}
+        team = team_match.get("team") or {}
+        return {
+            "title": candidate.get("title") or "Untitled action",
+            "assignee": owner.get("displayName") or owner.get("name") or owner.get("email") or "Unresolved",
+            "project": project.get("name") or "Unresolved",
+            "team": team.get("key") or team.get("name") or "Unresolved",
+            "source": candidate.get("source_label") or "Slack thread",
+            "confidence": confidence,
+            "owner_reason": owner_match.get("reason"),
+            "project_reason": project_match.get("reason"),
+            "team_reason": team_match.get("reason"),
+        }
+
+    def _remember_linear_meeting_pending_action(
+        self,
+        *,
+        requested_by: str,
+        issue_input: dict[str, Any],
+        display: dict[str, Any],
+        reason: str,
+    ) -> str:
+        pending_id = str(uuid4())
+        LINEAR_MEETING_PENDING_ACTIONS[pending_id] = {
+            "requested_by": requested_by,
+            "issue_input": issue_input,
+            "display": display,
+            "reason": reason,
+            "created_at": datetime.utcnow().isoformat(),
+        }
+        return pending_id
+
+    def _format_linear_meeting_result_message(
+        self,
+        created: list[dict[str, Any]],
+        review_needed: list[dict[str, Any]],
+        skipped: list[dict[str, Any]],
+    ) -> str:
+        lines: list[str] = []
+        if created:
+            lines.append(f"Created {len(created)} Linear issue{'s' if len(created) != 1 else ''}:")
+            for item in created[:10]:
+                issue = item.get("issue") or {}
+                issue_label = issue.get("identifier") or issue.get("title") or item["title"]
+                if issue.get("url"):
+                    lines.append(f"- <{issue['url']}|{issue_label}> - {item['title']}")
+                else:
+                    lines.append(f"- {issue_label} - {item['title']}")
+        if review_needed:
+            if lines:
+                lines.append("")
+            lines.append(f"{len(review_needed)} action item{'s' if len(review_needed) != 1 else ''} need approval:")
+            for item in review_needed[:10]:
+                lines.append(
+                    f"- {item['title']} -> {item['project']} / {item['assignee']} "
+                    f"({item['confidence']:.0%}, {item.get('source', 'Slack thread')})"
+                )
+        if skipped:
+            if lines:
+                lines.append("")
+            lines.append(f"Skipped {len(skipped)} item{'s' if len(skipped) != 1 else ''}:")
+            for item in skipped[:8]:
+                duplicate = item.get("duplicate") or {}
+                if duplicate.get("url"):
+                    lines.append(f"- {item['title']} - {item['reason']} (<{duplicate['url']}|existing issue>)")
+                else:
+                    lines.append(f"- {item['title']} - {item['reason']}")
+        return "\n".join(lines) if lines else "No Linear issues were created from those meeting notes."
+
+    def _build_linear_meeting_review_blocks(
+        self,
+        message: str,
+        review_needed: list[dict[str, Any]],
+        user_id: str,
+    ) -> list[dict[str, Any]]:
+        blocks: list[dict[str, Any]] = [
+            {"type": "section", "text": {"type": "mrkdwn", "text": message[:3000]}}
+        ]
+        for item in review_needed[:8]:
+            pending_id = item["pending_id"]
+            summary = (
+                f"*{item['title']}*\n"
+                f"Project: `{item['project']}` | Assignee: `{item['assignee']}` | "
+                f"Confidence: `{item['confidence']:.0%}` | Source: `{item.get('source', 'Slack thread')}`"
+            )
+            value = json.dumps({"pending_id": pending_id, "requested_by": user_id})
+            blocks.extend([
+                {"type": "section", "text": {"type": "mrkdwn", "text": summary[:2500]}},
+                {
+                    "type": "actions",
+                    "block_id": f"linear_meeting_{pending_id[:8]}",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "Approve"},
+                            "style": "primary",
+                            "action_id": "linear_meeting_approve",
+                            "value": value,
+                        },
+                        {
+                            "type": "button",
+                            "text": {"type": "plain_text", "text": "Reject"},
+                            "style": "danger",
+                            "action_id": "linear_meeting_reject",
+                            "value": value,
+                        },
+                    ],
+                },
+            ])
+        return blocks
+
+    def _linear_connection_nodes(self, value: Any) -> list[dict[str, Any]]:
+        if isinstance(value, dict):
+            nodes = value.get("nodes") or []
+            return [node for node in nodes if isinstance(node, dict)]
+        if isinstance(value, list):
+            return [node for node in value if isinstance(node, dict)]
+        return []
+
+    def _normalize_match_text(self, value: Any) -> str:
+        return re.sub(r"[^a-z0-9]+", "", str(value or "").lower())
+
+    def _linear_meeting_duplicate_tokens(self, value: Any) -> set[str]:
+        aliases = {
+            "doc": "documentation",
+            "docs": "documentation",
+        }
+        tokens = set()
+        for token in re.findall(r"[a-z0-9]+", str(value or "").lower()):
+            tokens.add(aliases.get(token, token))
+        return tokens
     
     async def _execute_connect_users(
         self,

--- a/roo-standalone/roo/slack_client.py
+++ b/roo-standalone/roo/slack_client.py
@@ -5,6 +5,7 @@ Handles Slack API interactions including posting messages and user lookups.
 """
 from typing import Optional, Dict, Any
 from functools import lru_cache
+import httpx
 
 from .config import get_settings
 
@@ -153,7 +154,8 @@ def get_thread_messages(channel: str, thread_ts: str) -> list[dict]:
                     "text": msg.get("text", ""),
                     "ts": msg.get("ts", ""),
                     "bot_id": msg.get("bot_id"),
-                    "is_bot": bool(msg.get("bot_id"))
+                    "is_bot": bool(msg.get("bot_id")),
+                    "files": msg.get("files", []),
                 })
             print(f"📜 Retrieved {len(messages)} messages from thread")
             return messages
@@ -189,6 +191,63 @@ def get_message(channel: str, message_ts: str) -> Optional[Dict[str, Any]]:
     except Exception as e:
         print(f"❌ Slack message lookup error for {channel}:{message_ts}: {e}")
         return None
+
+
+def get_file_info(file_id: str) -> Dict[str, Any]:
+    """
+    Get full Slack file metadata.
+
+    Requires the Slack bot token to have the files:read scope.
+    """
+    client = get_slack_client()
+
+    try:
+        response = client.files_info(file=file_id)
+        if response.get("ok"):
+            return response.get("file", {})
+        error = response.get("error") or "unknown_error"
+        raise RuntimeError(f"Slack files.info failed: {error}")
+    except Exception as e:
+        print(f"❌ Slack file info error for {file_id}: {e}")
+        raise
+
+
+def download_file_bytes(file: Dict[str, Any]) -> bytes:
+    """
+    Download a private Slack file using the bot token.
+
+    Requires files:read and a file object with url_private_download/url_private.
+    If Slack Connect requires a metadata refresh, pass the file through files.info first.
+    """
+    resolved_file = dict(file or {})
+    file_id = str(resolved_file.get("id") or "").strip()
+    if resolved_file.get("file_access") == "check_file_info" and file_id:
+        resolved_file = get_file_info(file_id)
+
+    url = (
+        resolved_file.get("url_private_download")
+        or resolved_file.get("url_private")
+        or ""
+    )
+    if not url and file_id:
+        resolved_file = get_file_info(file_id)
+        url = (
+            resolved_file.get("url_private_download")
+            or resolved_file.get("url_private")
+            or ""
+        )
+
+    if not url:
+        raise ValueError("Slack file is missing url_private_download/url_private")
+
+    settings = get_settings()
+    response = httpx.get(
+        url,
+        headers={"Authorization": f"Bearer {settings.SLACK_BOT_TOKEN}"},
+        timeout=30.0,
+    )
+    response.raise_for_status()
+    return response.content
 
 
 @lru_cache(maxsize=100)

--- a/roo-standalone/roo/tests/test_linear_meeting_actions.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_actions.py
@@ -1,0 +1,321 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("frontmatter", SimpleNamespace(load=lambda *args, **kwargs: None))
+sys.modules.pop("roo.skills.executor", None)
+
+from roo.skills.executor import SkillExecutor
+import roo.skills.executor as executor_module
+from roo.linear_meeting_sources import ParsedSource, SourceParseResult
+
+
+def test_linear_meeting_transcript_uses_thread_history_and_message():
+    executor = SkillExecutor()
+
+    transcript = executor._build_linear_meeting_transcript(
+        "turn this meeting summary into Linear tasks",
+        {},
+        [
+            {"user": "U1", "text": "Sam will update onboarding docs by Friday.", "is_bot": False},
+            {"user": "B1", "text": "Bot message", "is_bot": True},
+        ],
+    )
+
+    assert "U1: Sam will update onboarding docs by Friday." in transcript
+    assert "Bot message" not in transcript
+    assert "turn this meeting summary into Linear tasks" in transcript
+
+
+def test_linear_meeting_owner_matches_slack_mention_email(monkeypatch):
+    executor = SkillExecutor()
+
+    monkeypatch.setattr(
+        "roo.slack_client.get_user_info",
+        lambda user_id: {"email": "sam@example.com"},
+    )
+
+    match = executor._match_linear_meeting_owner(
+        "<@U123>",
+        [
+            {"id": "lin-user-1", "name": "Sam", "displayName": "Sam", "email": "sam@example.com"},
+        ],
+    )
+
+    assert match["user"]["id"] == "lin-user-1"
+    assert match["confidence"] == pytest.approx(0.98)
+
+
+def test_linear_meeting_owner_matches_name_fallback():
+    executor = SkillExecutor()
+
+    match = executor._match_linear_meeting_owner(
+        "Jane Doe",
+        [
+            {"id": "lin-user-1", "name": "Jane Doe", "displayName": "Jane", "email": "jane@example.com"},
+        ],
+    )
+
+    assert match["user"]["id"] == "lin-user-1"
+    assert match["confidence"] >= 0.9
+
+
+def test_linear_meeting_project_matches_explicit_hint():
+    executor = SkillExecutor()
+
+    match = executor._match_linear_meeting_project(
+        {"project_hint": "Alpha Launch"},
+        [
+            {"id": "proj-1", "name": "Alpha Launch", "slugId": "alpha-launch"},
+        ],
+        owner_user=None,
+    )
+
+    assert match["project"]["id"] == "proj-1"
+    assert match["confidence"] >= 0.9
+
+
+def test_linear_meeting_duplicate_detection_uses_similar_open_issue_title():
+    executor = SkillExecutor()
+
+    duplicate = executor._find_linear_meeting_duplicate(
+        {"title": "Update onboarding documentation"},
+        [
+            {
+                "id": "issue-1",
+                "identifier": "ENG-12",
+                "title": "Update onboarding docs",
+                "url": "https://linear.app/acme/issue/ENG-12",
+                "project": {"id": "proj-1"},
+            }
+        ],
+        {"id": "proj-1"},
+    )
+
+    assert duplicate["identifier"] == "ENG-12"
+
+
+def test_linear_meeting_decision_thresholds():
+    executor = SkillExecutor()
+    candidate = {"confidence": 0.9}
+    owner = {"confidence": 0.9}
+    project = {"confidence": 0.88}
+    team = {"confidence": 0.96}
+
+    decision, confidence = executor._linear_meeting_candidate_decision(
+        candidate=candidate,
+        owner_match=owner,
+        project_match=project,
+        team_match=team,
+        duplicate=None,
+        auto_threshold=0.85,
+        uncertain_threshold=0.65,
+    )
+    assert decision == "create"
+    assert confidence == pytest.approx(0.88)
+
+    decision, confidence = executor._linear_meeting_candidate_decision(
+        candidate={"confidence": 0.75},
+        owner_match=owner,
+        project_match=project,
+        team_match=team,
+        duplicate=None,
+        auto_threshold=0.85,
+        uncertain_threshold=0.65,
+    )
+    assert decision == "review"
+    assert confidence == pytest.approx(0.75)
+
+    decision, _ = executor._linear_meeting_candidate_decision(
+        candidate={"confidence": 0.6},
+        owner_match=owner,
+        project_match=project,
+        team_match=team,
+        duplicate=None,
+        auto_threshold=0.85,
+        uncertain_threshold=0.65,
+    )
+    assert decision == "skip"
+
+
+@pytest.mark.asyncio
+async def test_linear_client_raises_on_graphql_errors(monkeypatch):
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "skills"
+        / "linear_meeting_actions"
+        / "client.py"
+    )
+    spec = importlib.util.spec_from_file_location("linear_meeting_actions_client_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"errors": [{"message": "bad query"}]}
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, *args, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(module.httpx, "AsyncClient", FakeAsyncClient)
+
+    client = module.LinearMeetingActionsClient(api_key="lin_api_key")
+    with pytest.raises(RuntimeError, match="bad query"):
+        await client._graphql("query { viewer { id } }")
+
+
+@pytest.mark.asyncio
+async def test_linear_meeting_candidate_extraction_chunks_sources(monkeypatch):
+    executor = SkillExecutor()
+    calls = []
+
+    async def fake_extract(*, transcript, params, users, projects, source_label=None):
+        calls.append(transcript)
+        return [
+            {
+                "title": "Update onboarding docs",
+                "owner_hint": "Sam",
+                "source_label": source_label,
+                "confidence": 0.8,
+            }
+        ]
+
+    monkeypatch.setattr(executor, "_extract_linear_meeting_candidates", fake_extract)
+    long_text = ("Sam will update onboarding docs after the meeting.\n\n" * 350).strip()
+
+    candidates = await executor._extract_linear_meeting_candidates_from_sources(
+        sources=[ParsedSource(label="notes.pdf", text=long_text, kind="pdf")],
+        params={},
+        users=[],
+        projects=[],
+    )
+
+    assert len(calls) > 1
+    assert all(call.startswith("Source: notes.pdf") for call in calls)
+    assert all(len(call) <= 10100 for call in calls)
+    assert len(candidates) == 1
+    assert candidates[0]["source_label"] == "notes.pdf"
+
+
+@pytest.mark.asyncio
+async def test_linear_meeting_executor_creates_issue_from_parsed_file_source(monkeypatch):
+    executor = SkillExecutor()
+    created_inputs = []
+
+    async def fake_source_result(**kwargs):
+        return SourceParseResult(
+            sources=[
+                ParsedSource(
+                    label="meeting.pdf page 3",
+                    text="Sam will update onboarding docs in Alpha.",
+                    kind="pdf",
+                )
+            ]
+        )
+
+    async def fake_candidates_from_sources(**kwargs):
+        assert kwargs["sources"][0].label == "meeting.pdf page 3"
+        return [
+            {
+                "title": "Update onboarding docs",
+                "description": "Update the onboarding docs from the meeting.",
+                "owner_hint": "Sam",
+                "project_hint": "Alpha",
+                "team_hint": "ENG",
+                "evidence": "Sam will update onboarding docs in Alpha.",
+                "source_label": "meeting.pdf page 3",
+                "confidence": 0.95,
+            }
+        ]
+
+    team = {"id": "team-1", "key": "ENG", "name": "Engineering"}
+    user = {"id": "user-1", "name": "Sam", "displayName": "Sam", "email": "sam@example.com"}
+    project = {
+        "id": "project-1",
+        "name": "Alpha",
+        "teams": {"nodes": [team]},
+        "members": {"nodes": [user]},
+    }
+
+    class FakeClient:
+        def __init__(self, api_key):
+            assert api_key == "lin_api_key"
+
+        async def list_teams(self):
+            return [team]
+
+        async def list_users(self):
+            return [user]
+
+        async def list_active_projects(self):
+            return [project]
+
+        async def list_issue_labels(self):
+            return [{"id": "label-1", "name": "meeting-action"}]
+
+        async def list_recent_open_issues(self):
+            return []
+
+        async def create_issue(self, **kwargs):
+            created_inputs.append(kwargs)
+            return {
+                "identifier": "ENG-123",
+                "title": kwargs["title"],
+                "url": "https://linear.app/acme/issue/ENG-123",
+            }
+
+    class FakeSkill:
+        def get_client_class(self, name):
+            assert name == "LinearMeetingActionsClient"
+            return FakeClient
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            LINEAR_API_KEY="lin_api_key",
+            LINEAR_DEFAULT_TEAM=None,
+            LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE=0.85,
+            LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE=0.65,
+        ),
+    )
+    monkeypatch.setattr(executor, "_build_linear_meeting_source_result", fake_source_result)
+    monkeypatch.setattr(
+        executor,
+        "_extract_linear_meeting_candidates_from_sources",
+        fake_candidates_from_sources,
+    )
+
+    result = await executor._execute_linear_meeting_actions(
+        skill=FakeSkill(),
+        text="send this PDF to Linear as tasks",
+        params={},
+        user_id="U1",
+        channel_id="C1",
+        thread_ts="1.1",
+        thread_history=[],
+        event_files=[{"id": "F1", "name": "meeting.pdf"}],
+    )
+
+    assert "data" in result, result
+    assert result["data"]["created_count"] == 1
+    assert created_inputs[0]["title"] == "Update onboarding docs"
+    assert created_inputs[0]["assignee_id"] == "user-1"
+    assert created_inputs[0]["project_id"] == "project-1"
+    assert created_inputs[0]["label_ids"] == ["label-1"]
+    assert "meeting.pdf page 3" in created_inputs[0]["description"]

--- a/roo-standalone/roo/tests/test_linear_meeting_routing.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_routing.py
@@ -1,0 +1,75 @@
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("frontmatter", SimpleNamespace(load=lambda *args, **kwargs: None))
+fake_executor_module = types.ModuleType("roo.skills.executor")
+fake_executor_module.SkillExecutor = type("SkillExecutor", (), {})
+fake_executor_module.SkillResult = type("SkillResult", (), {})
+sys.modules.setdefault("roo.skills.executor", fake_executor_module)
+
+from roo.agent import RooAgent
+from roo.skills.loader import Skill
+
+
+def _make_skill(name: str, trigger_keywords: list[str]) -> Skill:
+    return Skill(
+        name=name,
+        description=name,
+        content="",
+        path=Path("."),
+        trigger_keywords=trigger_keywords,
+    )
+
+
+def _make_agent() -> RooAgent:
+    agent = object.__new__(RooAgent)
+    agent.skills = [
+        _make_skill(
+            "linear-meeting-actions",
+            [
+                "meeting actions",
+                "meeting action items",
+                "meeting notes to linear",
+                "meeting summary to linear",
+                "transcript to linear",
+                "linear tasks from meeting",
+                "create linear tickets from transcript",
+                "extract action items",
+                "sync meeting notes to linear",
+            ],
+        ),
+        _make_skill("mlai-points", ["points", "balance", "task", "tasks"]),
+    ]
+    agent.skill_executor = SimpleNamespace()
+    agent._thread_skill_context = {}
+    return agent
+
+
+def test_linear_meeting_file_prompts_route_to_linear_meeting_actions():
+    agent = _make_agent()
+
+    for text in [
+        "turn this meeting summary into Linear tasks",
+        "extract action items from this transcript and add them to Linear",
+        "sync meeting notes to Linear project Alpha",
+        "send this PDF to Linear as tasks",
+        "create Linear issues from this image",
+    ]:
+        skill = agent._select_skill_from_triggers(text)
+        assert skill is not None
+        assert skill.name == "linear-meeting-actions"
+
+
+def test_linear_file_context_routes_short_attached_file_request():
+    agent = _make_agent()
+
+    skill = agent._select_skill_from_triggers(
+        "send this to Linear as tasks",
+        has_file_context=True,
+    )
+
+    assert skill is not None
+    assert skill.name == "linear-meeting-actions"

--- a/roo-standalone/roo/tests/test_linear_meeting_sources.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_sources.py
@@ -1,0 +1,219 @@
+import io
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from roo import linear_meeting_sources as sources
+from roo import slack_client
+
+
+def test_get_thread_messages_preserves_file_metadata(monkeypatch):
+    class FakeSlackClient:
+        def conversations_replies(self, **kwargs):
+            return {
+                "ok": True,
+                "messages": [
+                    {
+                        "user": "U1",
+                        "text": "Attached the meeting notes.",
+                        "ts": "1.1",
+                        "files": [{"id": "F1", "name": "notes.pdf"}],
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(slack_client, "get_slack_client", lambda: FakeSlackClient())
+
+    messages = slack_client.get_thread_messages(channel="C1", thread_ts="1.1")
+
+    assert messages[0]["files"] == [{"id": "F1", "name": "notes.pdf"}]
+
+
+def test_slack_file_info_and_download(monkeypatch):
+    class FakeSlackClient:
+        def files_info(self, file):
+            assert file == "F1"
+            return {
+                "ok": True,
+                "file": {
+                    "id": "F1",
+                    "name": "notes.txt",
+                    "url_private_download": "https://files.slack.test/notes.txt",
+                },
+            }
+
+    class FakeResponse:
+        content = b"Sam will update the launch notes."
+
+        def raise_for_status(self):
+            return None
+
+    request = {}
+
+    def fake_get(url, headers, timeout):
+        request.update({"url": url, "headers": headers, "timeout": timeout})
+        return FakeResponse()
+
+    monkeypatch.setattr(slack_client, "get_slack_client", lambda: FakeSlackClient())
+    monkeypatch.setattr(slack_client, "get_settings", lambda: SimpleNamespace(SLACK_BOT_TOKEN="xoxb-test"))
+    monkeypatch.setattr(slack_client.httpx, "get", fake_get)
+
+    file = slack_client.get_file_info("F1")
+    content = slack_client.download_file_bytes(file)
+
+    assert file["name"] == "notes.txt"
+    assert content == b"Sam will update the launch notes."
+    assert request["headers"] == {"Authorization": "Bearer xoxb-test"}
+
+
+@pytest.mark.asyncio
+async def test_parse_text_markdown_and_csv_sources(monkeypatch):
+    downloads = {
+        "notes.txt": b"Sam will update onboarding docs.",
+        "notes.md": b"- Jane will send the launch summary.",
+        "actions.csv": b"owner,task\nAlex,Review launch metrics",
+    }
+
+    monkeypatch.setattr(
+        sources,
+        "download_file_bytes",
+        lambda file: downloads[file["name"]],
+    )
+
+    result = await sources.parse_linear_meeting_sources(
+        text="send these files to Linear",
+        params={},
+        event_files=[
+            {"id": "F1", "name": "notes.txt", "size": 10, "url_private_download": "https://x/1"},
+            {"id": "F2", "name": "notes.md", "size": 10, "url_private_download": "https://x/2"},
+            {"id": "F3", "name": "actions.csv", "size": 10, "url_private_download": "https://x/3"},
+        ],
+    )
+
+    combined = result.combined_text()
+    assert result.files_parsed == 3
+    assert "Sam will update onboarding docs." in combined
+    assert "Jane will send the launch summary." in combined
+    assert "Review launch metrics" in combined
+
+
+@pytest.mark.asyncio
+async def test_parse_docx_source(monkeypatch):
+    from docx import Document
+
+    document = Document()
+    document.add_paragraph("Taylor will draft the customer rollout checklist.")
+    buffer = io.BytesIO()
+    document.save(buffer)
+
+    monkeypatch.setattr(sources, "download_file_bytes", lambda file: buffer.getvalue())
+
+    result = await sources.parse_linear_meeting_sources(
+        text="send this docx to Linear",
+        params={},
+        event_files=[
+            {"id": "F1", "name": "notes.docx", "size": 10, "url_private_download": "https://x/docx"}
+        ],
+    )
+
+    assert result.files_parsed == 1
+    assert "Taylor will draft the customer rollout checklist." in result.combined_text()
+
+
+@pytest.mark.asyncio
+async def test_parse_text_pdf_source_with_mocked_pymupdf(monkeypatch):
+    class FakePage:
+        def get_text(self, mode):
+            assert mode == "text"
+            return "Sam will update the project plan with owners, milestones, risks, and launch dates."
+
+    class FakeDocument:
+        def __len__(self):
+            return 1
+
+        def load_page(self, index):
+            assert index == 0
+            return FakePage()
+
+        def close(self):
+            return None
+
+    fake_fitz = SimpleNamespace(
+        open=lambda stream, filetype: FakeDocument(),
+        Matrix=lambda x, y: (x, y),
+    )
+
+    monkeypatch.setitem(sys.modules, "fitz", fake_fitz)
+    monkeypatch.setattr(sources, "download_file_bytes", lambda file: b"%PDF-test")
+
+    result = await sources.parse_linear_meeting_sources(
+        text="send this pdf to Linear",
+        params={},
+        event_files=[
+            {"id": "F1", "name": "meeting.pdf", "size": 10, "url_private_download": "https://x/pdf"}
+        ],
+    )
+
+    assert result.files_parsed == 1
+    assert "[meeting.pdf page 1]" in result.combined_text()
+    assert "Sam will update the project plan" in result.combined_text()
+
+
+@pytest.mark.asyncio
+async def test_parse_image_source_uses_vision_parser(monkeypatch):
+    calls = []
+
+    async def image_parser(image_bytes, mime_type, label):
+        calls.append((image_bytes, mime_type, label))
+        return "Priya will follow up on the invoice list."
+
+    monkeypatch.setattr(sources, "download_file_bytes", lambda file: b"image-bytes")
+
+    result = await sources.parse_linear_meeting_sources(
+        text="send this image to Linear",
+        params={},
+        event_files=[
+            {
+                "id": "F1",
+                "name": "todos.png",
+                "mimetype": "image/png",
+                "size": 10,
+                "url_private_download": "https://x/png",
+            }
+        ],
+        image_parser=image_parser,
+    )
+
+    assert calls == [(b"image-bytes", "image/png", "todos.png")]
+    assert "Priya will follow up on the invoice list." in result.combined_text()
+
+
+@pytest.mark.asyncio
+async def test_parse_sources_reports_unsupported_and_oversized_files(monkeypatch):
+    downloaded = False
+
+    def fake_download(file):
+        nonlocal downloaded
+        downloaded = True
+        return b"unused"
+
+    monkeypatch.setattr(sources, "download_file_bytes", fake_download)
+
+    result = await sources.parse_linear_meeting_sources(
+        text="send this file to Linear",
+        params={},
+        max_file_bytes=5,
+        event_files=[
+            {"id": "F1", "name": "legacy.doc", "size": 4, "url_private_download": "https://x/doc"},
+            {"id": "F2", "name": "huge.pdf", "size": 6, "url_private_download": "https://x/pdf"},
+        ],
+    )
+
+    assert result.files_skipped == 2
+    assert not downloaded
+    assert any("not supported" in warning for warning in result.warnings)
+    assert any("larger than" in warning for warning in result.warnings)

--- a/roo-standalone/skills/linear_meeting_actions/SKILL.md
+++ b/roo-standalone/skills/linear_meeting_actions/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: linear-meeting-actions
+description: Extract action items from Slack meeting transcripts, summaries, files, PDFs, DOCX documents, or images and create correctly assigned Linear issues
+trigger_keywords:
+  - meeting actions
+  - meeting action items
+  - meeting notes to linear
+  - meeting summary to linear
+  - transcript to linear
+  - pdf to linear
+  - docx to linear
+  - image to linear
+  - file to linear
+  - linear tasks from meeting
+  - create linear tickets from transcript
+  - extract action items
+  - sync meeting notes to linear
+requires_auth: true
+parameters:
+  - action: One of extract, create, approve, or reject. Defaults to create for transcript-to-Linear requests.
+  - transcript: Pasted meeting transcript, notes, or summary text. If omitted, use the current Slack thread history and supported attached files.
+  - project_hint: Optional Linear project name or slug mentioned by the user.
+  - team_hint: Optional Linear team name or key mentioned by the user.
+  - confirm_create: Boolean flag used by Slack approval actions for uncertain items.
+---
+
+# Linear Meeting Actions Skill
+
+This skill turns pasted Slack meeting transcripts, summaries, supported Slack files, PDFs, DOCX documents, and images into Linear issues. It reads Linear context first, extracts action items, maps each item to the right owner and project, creates high-confidence issues, and asks for Slack review when assignment or project confidence is uncertain.
+
+## Capabilities
+
+- Parse Slack message/thread text and supported attached files for concrete to-do items.
+- Download and parse `.pdf`, `.docx`, `.txt`, `.md`, `.csv`, `.png`, `.jpg`, `.jpeg`, `.webp`, and non-animated `.gif` files from the current Slack thread.
+- Inspect Linear teams, users, active projects, project members, labels, and recent open issues.
+- Assign new issues to the best matching Linear user.
+- Attach new issues to the best matching Linear project and team.
+- Avoid likely duplicate open issues.
+- Ask for Slack approval when an action item is useful but not confident enough to create automatically.
+
+## Parameters
+
+- **action**: One of `extract`, `create`, `approve`, or `reject`. Defaults to `create`.
+- **transcript**: Pasted meeting transcript, notes, or summary text. If omitted, inspect the current Slack thread and attached files.
+- **project_hint**: Optional Linear project name or slug.
+- **team_hint**: Optional Linear team name or key.
+- **confirm_create**: Internal boolean used for Slack approval actions.
+
+## Workflow
+
+1. Build the source text from the current Slack message, recent thread history, and supported attached files. V1 does not proactively cache files or read Canvases.
+2. Read Linear before writing:
+   - Teams
+   - Users
+   - Active projects with teams and members
+   - Issue labels
+   - Recent open issues for duplicate detection
+3. Extract concrete action items into structured candidates with title, description, owner hint, project hint, due date, priority, evidence, source label, and confidence.
+4. Match owners by Slack mention/email first, then Linear user email, then display/name similarity.
+5. Match projects by explicit project hint, name/slug similarity, and project membership context.
+6. Create only high-confidence, non-duplicate candidates.
+7. Present uncertain candidates in Slack with Approve and Reject buttons.
+8. Report created issues, skipped duplicates, and unresolved items clearly.
+
+## Creation Rules
+
+- Do not create an issue without a matched Linear team.
+- Do not auto-create an issue without a high-confidence assignee and project.
+- Apply the `meeting-action` label if it already exists. If it does not exist, create the issue without labels.
+- Issue descriptions must include the meeting context, evidence snippet, Slack source identifiers when available, and a note that Roo generated the issue from meeting notes.
+
+## Response Style
+
+Keep Slack responses concise. Lead with created Linear links, then list review-needed or skipped items.

--- a/roo-standalone/skills/linear_meeting_actions/client.py
+++ b/roo-standalone/skills/linear_meeting_actions/client.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+
+
+LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+
+
+class LinearMeetingActionsClient:
+    """Small GraphQL client for the Linear meeting-actions Roo skill."""
+
+    def __init__(self, api_key: str, base_url: str = LINEAR_GRAPHQL_URL):
+        if not api_key:
+            raise ValueError("LINEAR_API_KEY not configured")
+        self.api_key = api_key
+        self.base_url = base_url
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return {
+            "Authorization": self.api_key,
+            "Content-Type": "application/json",
+        }
+
+    async def _graphql(
+        self,
+        query: str,
+        variables: Optional[dict[str, Any]] = None,
+        *,
+        timeout: float = 30.0,
+    ) -> dict[str, Any]:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                self.base_url,
+                json={"query": query, "variables": variables or {}},
+                headers=self.headers,
+                timeout=timeout,
+            )
+            response.raise_for_status()
+
+        data = response.json()
+        errors = data.get("errors")
+        if errors:
+            messages = "; ".join(str(error.get("message") or error) for error in errors)
+            raise RuntimeError(f"Linear GraphQL error: {messages}")
+        return data.get("data") or {}
+
+    async def list_teams(self, limit: int = 100) -> list[dict[str, Any]]:
+        query = """
+        query LinearTeams($first: Int!) {
+          teams(first: $first) {
+            nodes {
+              id
+              key
+              name
+            }
+          }
+        }
+        """
+        data = await self._graphql(query, {"first": limit})
+        return _nodes(data, "teams")
+
+    async def list_users(self, limit: int = 250) -> list[dict[str, Any]]:
+        query = """
+        query LinearUsers($first: Int!) {
+          users(first: $first) {
+            nodes {
+              id
+              name
+              displayName
+              email
+              active
+            }
+          }
+        }
+        """
+        data = await self._graphql(query, {"first": limit})
+        users = _nodes(data, "users")
+        return [user for user in users if user.get("active") is not False]
+
+    async def list_active_projects(self, limit: int = 100) -> list[dict[str, Any]]:
+        query = """
+        query LinearProjects($first: Int!) {
+          projects(first: $first) {
+            nodes {
+              id
+              name
+              slugId
+              url
+              state
+              lead {
+                id
+                name
+                displayName
+                email
+              }
+              teams {
+                nodes {
+                  id
+                  key
+                  name
+                }
+              }
+              members {
+                nodes {
+                  id
+                  name
+                  displayName
+                  email
+                }
+              }
+            }
+          }
+        }
+        """
+        data = await self._graphql(query, {"first": limit})
+        projects = _nodes(data, "projects")
+        inactive_states = {"completed", "canceled", "cancelled", "archived"}
+        return [
+            project
+            for project in projects
+            if str(project.get("state") or "").lower() not in inactive_states
+        ]
+
+    async def list_issue_labels(self, limit: int = 100) -> list[dict[str, Any]]:
+        query = """
+        query LinearIssueLabels($first: Int!) {
+          issueLabels(first: $first) {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+        """
+        data = await self._graphql(query, {"first": limit})
+        return _nodes(data, "issueLabels")
+
+    async def list_recent_open_issues(self, limit: int = 100) -> list[dict[str, Any]]:
+        query = """
+        query LinearRecentIssues($first: Int!) {
+          issues(first: $first) {
+            nodes {
+              id
+              identifier
+              title
+              url
+              state {
+                name
+                type
+              }
+              project {
+                id
+                name
+              }
+              assignee {
+                id
+                name
+                displayName
+                email
+              }
+            }
+          }
+        }
+        """
+        data = await self._graphql(query, {"first": limit})
+        issues = _nodes(data, "issues")
+        closed_types = {"completed", "canceled", "cancelled"}
+        return [
+            issue
+            for issue in issues
+            if str((issue.get("state") or {}).get("type") or "").lower() not in closed_types
+        ]
+
+    async def create_issue(
+        self,
+        *,
+        title: str,
+        team_id: str,
+        description: Optional[str] = None,
+        assignee_id: Optional[str] = None,
+        project_id: Optional[str] = None,
+        priority: Optional[int] = None,
+        due_date: Optional[str] = None,
+        label_ids: Optional[list[str]] = None,
+    ) -> dict[str, Any]:
+        input_data: dict[str, Any] = {
+            "title": title,
+            "teamId": team_id,
+        }
+        if description:
+            input_data["description"] = description
+        if assignee_id:
+            input_data["assigneeId"] = assignee_id
+        if project_id:
+            input_data["projectId"] = project_id
+        if priority is not None:
+            input_data["priority"] = priority
+        if due_date:
+            input_data["dueDate"] = due_date
+        if label_ids:
+            input_data["labelIds"] = label_ids
+
+        mutation = """
+        mutation CreateLinearMeetingIssue($input: IssueCreateInput!) {
+          issueCreate(input: $input) {
+            success
+            issue {
+              id
+              identifier
+              title
+              url
+            }
+          }
+        }
+        """
+        data = await self._graphql(mutation, {"input": input_data})
+        result = data.get("issueCreate") or {}
+        if not result.get("success"):
+            raise RuntimeError("Linear issueCreate returned success=false")
+        return result.get("issue") or {}
+
+
+def _nodes(data: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    value = data.get(key) or {}
+    nodes = value.get("nodes") or []
+    return [node for node in nodes if isinstance(node, dict)]


### PR DESCRIPTION
## Summary
- add the linear-meeting-actions Roo skill and Linear GraphQL client
- ingest Slack thread text plus supported Slack files for Linear action extraction
- parse PDF, DOCX, text/Markdown/CSV, and image sources with OpenAI vision fallback for scanned/image content
- wire Slack file-share routing, source labels, chunked extraction, duplicate checks, and approval actions
- add focused parser, routing, Linear workflow, and Slack file tests

## Validation
- python3 -m pytest roo-standalone/roo/tests
- git diff --cached --check