### PR TITLE
Add top-up points functionality to MLAI backend

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -2049,6 +2049,36 @@ class MLAIBackendClient:
         )
         return response.json()
 
+    async def create_points_purchase(
+        self,
+        slack_user_id: str,
+        pack_id: str,
+        slack_channel_id: Optional[str] = None,
+        slack_thread_ts: Optional[str] = None,
+    ) -> dict:
+        """Create a pending Roo Points top-up purchase."""
+        purchase_from = {"source": "slack"}
+        if slack_channel_id:
+            purchase_from["slack_channel_id"] = slack_channel_id
+        if slack_thread_ts:
+            purchase_from["slack_thread_ts"] = slack_thread_ts
+
+        payload = {
+            "slack_user_id": self._clean_slack_id(slack_user_id),
+            "pack_id": pack_id,
+            "purchase_from": purchase_from,
+        }
+
+        response = await self._request(
+            "POST",
+            f"{self._points_base}/purchases/",
+            json=payload,
+            timeout=10.0,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
     async def attach_points_request_slack_summary(
         self,
         request_id: int,

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -3921,6 +3921,9 @@ Keep the response concise but informative."""
         text_lower = text.lower()
         explicit_points_request = "request" in text_lower and "point" in text_lower and "reward" not in text_lower
 
+        if self._is_points_topup_request(text_lower, action):
+            return "topup_points"
+
         management_action = self._resolve_points_admin_management_action(
             text,
             explicit_action=action,
@@ -4004,6 +4007,8 @@ Keep the response concise but informative."""
             return "view_rate_card"
         if any(w in text_lower for w in ["rewards", "perks"]):
             return "list_rewards"
+        if self._is_points_topup_request(text_lower, action):
+            return "topup_points"
         if "reward" in text_lower and "request" in text_lower:
             return "request_reward"
         if "task" in text_lower and "create" in text_lower:
@@ -4017,6 +4022,24 @@ Keep the response concise but informative."""
         if any(w in text_lower for w in ["deduct", "remove points"]):
             return "deduct_points"
         return action
+
+    def _is_points_topup_request(self, text_lower: str, action: str = "") -> bool:
+        if action in {"topup_points", "top_up_points", "purchase_points", "buy_points"}:
+            return True
+        if "point" not in text_lower and "pts" not in text_lower:
+            return False
+        return any(
+            phrase in text_lower
+            for phrase in (
+                "top up",
+                "top-up",
+                "topup",
+                "buy",
+                "purchase",
+                "pay for",
+                "paid points",
+            )
+        )
 
     def _extract_task_identifier(self, text: str, explicit_task_id=None) -> Optional[str]:
         """Extract either a numeric task id or a ROO task code from text."""
@@ -4679,6 +4702,39 @@ Keep the response concise but informative."""
             return (
                 "I created the points request, but I couldn't finish wiring up emoji approval for it. "
                 "Please ask a Points Admin to use the existing manual award flow for now."
+            )
+
+        elif action == "topup_points":
+            if not channel_id:
+                return "Roo Points top-ups need to start from Slack so I can keep the payment receipt in the right thread."
+
+            points = self._extract_points_request_amount(text, params.get("points"))
+            pack_by_points = {
+                5: "topup_5",
+                10: "topup_10",
+                25: "topup_25",
+            }
+            if points is None:
+                return "How many Roo Points would you like to top up? I can do 5, 10, or 25 points."
+            if points not in pack_by_points:
+                return "I can only create top-ups for 5, 10, or 25 Roo Points right now."
+
+            purchase = await client.create_points_purchase(
+                slack_user_id=user_id,
+                pack_id=pack_by_points[points],
+                slack_channel_id=channel_id,
+                slack_thread_ts=thread_ts,
+            )
+            checkout_url = purchase.get("frontend_checkout_page_url")
+            if not checkout_url:
+                return "I created the top-up request, but I couldn't get the checkout link back. Please try again."
+
+            return (
+                f"Top-up request created for *{points} Roo Points*.\n\n"
+                f"Pay here: {checkout_url}\n\n"
+                "Roo Points are an internal MLAI rewards system. They are not cash, "
+                "not transferable, and not redeemable for money. Purchased points do not "
+                "count toward lifetime earned contribution."
             )
 
         elif action == "list_tasks":

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -167,6 +167,52 @@ async def test_get_coworking_report_uses_canonical_endpoint(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_points_purchase_sends_slack_origin(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = kwargs["json"]
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(
+            201,
+            request=request,
+            json={
+                "id": "purchase-123",
+                "frontend_checkout_page_url": "https://mlai.test/roo/topup/purchase-123",
+            },
+        )
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.create_points_purchase(
+        "<@U123>",
+        "topup_10",
+        slack_channel_id="C123",
+        slack_thread_ts="111.222",
+    )
+
+    assert captured["method"] == "POST"
+    assert captured["endpoint"] == "/api/v1/points/purchases/"
+    assert captured["json"] == {
+        "slack_user_id": "U123",
+        "pack_id": "topup_10",
+        "purchase_from": {
+            "source": "slack",
+            "slack_channel_id": "C123",
+            "slack_thread_ts": "111.222",
+        },
+    }
+    assert result["frontend_checkout_page_url"] == "https://mlai.test/roo/topup/purchase-123"
+
+
+@pytest.mark.asyncio
 async def test_get_coworking_report_503_raises_backend_unavailable(monkeypatch):
     async def fake_request(method, endpoint, **kwargs):
         request = httpx.Request(method, f"https://backend.test{endpoint}")

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -32,6 +32,7 @@ class FakePointsClient:
     def __init__(self):
         self.created = None
         self.attached = None
+        self.created_purchase = None
 
     async def create_points_request(
         self,
@@ -51,6 +52,25 @@ class FakePointsClient:
             "slack_thread_ts": slack_thread_ts,
         }
         return {"id": 42}
+
+    async def create_points_purchase(
+        self,
+        slack_user_id,
+        pack_id,
+        slack_channel_id=None,
+        slack_thread_ts=None,
+    ):
+        self.created_purchase = {
+            "slack_user_id": slack_user_id,
+            "pack_id": pack_id,
+            "slack_channel_id": slack_channel_id,
+            "slack_thread_ts": slack_thread_ts,
+        }
+        return {
+            "id": "purchase-123",
+            "points_amount": 10,
+            "frontend_checkout_page_url": "https://mlai.test/roo/topup/purchase-123",
+        }
 
     async def attach_points_request_slack_summary(
         self,
@@ -206,6 +226,17 @@ def test_resolve_points_action_maps_plain_request_to_request_points():
     assert action == "request_points"
 
 
+def test_resolve_points_action_maps_buy_points_to_topup_points():
+    executor = SkillExecutor()
+
+    action = executor._resolve_points_action(
+        {"action": "request_points"},
+        "I want to buy 10 Roo Points",
+    )
+
+    assert action == "topup_points"
+
+
 def test_extract_points_request_reason_supports_requesting_phrase():
     executor = SkillExecutor()
 
@@ -323,6 +354,67 @@ async def test_request_points_creates_request_and_suppresses_auto_post(monkeypat
             "slack_thread_ts": "111.222",
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_topup_points_creates_purchase_and_returns_checkout_link():
+    executor = SkillExecutor()
+    client = FakePointsClient()
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="topup_points",
+        params={"points": 10},
+        text="buy 10 Roo Points",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=None,
+    )
+
+    assert client.created_purchase == {
+        "slack_user_id": "U123",
+        "pack_id": "topup_10",
+        "slack_channel_id": "C123",
+        "slack_thread_ts": "111.222",
+    }
+    assert "Top-up request created for *10 Roo Points*" in result
+    assert "https://mlai.test/roo/topup/purchase-123" in result
+    assert "not cash" in result
+    assert "not transferable" in result
+    assert "not redeemable for money" in result
+    assert "do not count toward lifetime earned contribution" in result
+
+
+@pytest.mark.asyncio
+async def test_topup_points_clarifies_missing_or_unsupported_pack():
+    executor = SkillExecutor()
+    client = FakePointsClient()
+
+    missing_result = await executor._handle_points_action(
+        client=client,
+        action="topup_points",
+        params={},
+        text="top up Roo Points",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=None,
+    )
+    unsupported_result = await executor._handle_points_action(
+        client=client,
+        action="topup_points",
+        params={"points": 12},
+        text="buy 12 Roo Points",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=None,
+    )
+
+    assert "5, 10, or 25" in missing_result
+    assert "5, 10, or 25" in unsupported_result
+    assert client.created_purchase is None
 
 
 @pytest.mark.asyncio

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -63,7 +63,7 @@ Example responses:
 
 ## Parameters
 
-- **action**: The action to perform (required) - e.g., "balance", "request_points", "book_coworking", "coworking_report", "claim_task", "submit_task", "award_points", "create_task"
+- **action**: The action to perform (required) - e.g., "balance", "request_points", "topup_points", "book_coworking", "coworking_report", "claim_task", "submit_task", "award_points", "create_task"
 - **task_id**: Task ID number or task code (for example `42` or `ROO-0042`) for task-related actions
 - **date**: Date for coworking bookings (YYYY-MM-DD format)
 - **start_date**: Start date for coworking reports (YYYY-MM-DD format)
@@ -102,6 +102,7 @@ Parse user messages to identify the action and parameters:
 |---------|--------|---------|
 | `points`, `balance` | balance | "What's my points balance?", "@Roo points" |
 | `request <n> points for <reason>` | request_points | "Request 5 points for helping at the event" |
+| `top up <n> points`, `buy <n> points` | topup_points | "Buy 10 Roo Points", "Top up 5 points" |
 | `points earn` | list_tasks | "How do I earn points?", "@Roo points earn" |
 | `tasks`, `tasks open` | list_tasks | "What can I claim right now?" |
 | `tasks mine` | list_tasks | "Show me my tasks" |
@@ -149,6 +150,7 @@ Parse the user's message to determine which action they want:
 - Extract any IDs, dates, or amounts mentioned
 - Accept both numeric task ids and `ROO-xxxx` task codes
 - Treat `request ... points for ...` as `request_points`, not `award_points`
+- Treat `buy/top up/purchase ... points` as `topup_points`, not `request_points`
 - For admin actions, verify the Slack mention format
 - For super admin actions, require exactly one tagged Slack user, never fall through into `award_points`, and require a positive numeric allowance when changing allowance
 


### PR DESCRIPTION
Implement a new method for creating Roo Points top-up purchases in the MLAIBackendClient. Enhance the executor to recognize and handle top-up requests, returning appropriate responses and checkout links. Update tests to cover the new functionality and ensure correct behavior for various scenarios, including unsupported pack amounts.