### PR TITLE
[codex] Add Roo Points top-ups and link-love retry guards

### DIFF
--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -354,6 +354,9 @@ class RooAgent:
         text = self._normalize_points_routing_text(text)
         patterns = (
             r'\bpoints?\b',
+            r'\btop\s*up\b',
+            r'\btopup\b',
+            r'\btop-up\b',
             r'\bbalance\b',
             r'\bcoworking\b',
             r'\bbook\s+me\s+in\b',

--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -2084,6 +2084,33 @@ class MLAIBackendClient:
         )
         return response.json()
 
+    async def create_points_purchase(
+        self,
+        slack_user_id: str,
+        pack_id: Optional[str] = None,
+        points_amount: Optional[int] = None,
+        purchase_from: Optional[dict] = None,
+    ) -> dict:
+        """Create a pending Roo Points top-up purchase."""
+        payload = {
+            "slack_user_id": self._clean_slack_id(slack_user_id),
+            "purchase_from": {"source": "slack", **(purchase_from or {})},
+        }
+        if pack_id:
+            payload["pack_id"] = pack_id
+        if points_amount is not None:
+            payload["points_amount"] = points_amount
+
+        response = await self._request(
+            "POST",
+            f"{self._points_base}/purchases/",
+            json=payload,
+            timeout=10.0,
+            circuit_breaker=True,
+        )
+        response.raise_for_status()
+        return response.json()
+
     async def attach_points_request_slack_summary(
         self,
         request_id: int,

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
     LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE: float = 0.65
     COWORKING_INTENTS_DB_PATH: str = "data/coworking_booking_intents.db"
     COWORKING_RETRY_POLL_SECONDS: float = 30.0
+    ROO_POINTS_TOPUP_ENABLED: bool = False
     BOOST_LINK_LOVE_ENABLED: bool = True
     BOOST_LINK_LOVE_CHANNEL_NAME: str = "boost-my-startup"
     BOOST_LINK_LOVE_DB_PATH: str = "data/link_love_awards.db"

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -57,6 +57,27 @@ POINTS_SUPER_ADMIN_SLACK_ID = "U05QPB483K9"
 FULL_POINTS_ADMIN_ROLES = {"admin", "committee", "portfolio_lead"}
 COWORKING_REPORT_ROLES = {*FULL_POINTS_ADMIN_ROLES, "partner"}
 LINEAR_MEETING_PENDING_ACTIONS: dict[str, dict[str, Any]] = {}
+ROO_TOPUP_PACKS = {
+    "topup_5": {
+        "points": 5,
+        "label": "5 Top-up Roo Points",
+        "price": "A$19.99",
+    },
+    "topup_10": {
+        "points": 10,
+        "label": "10 Top-up Roo Points",
+        "price": "A$36.99",
+    },
+    "topup_25": {
+        "points": 25,
+        "label": "25 Top-up Roo Points",
+        "price": "A$63.99",
+    },
+}
+ROO_TOPUP_PACK_BY_POINTS = {
+    pack["points"]: pack_id for pack_id, pack in ROO_TOPUP_PACKS.items()
+}
+
 
 @dataclass
 class SkillResult:
@@ -5063,6 +5084,9 @@ Only include actionable work someone agreed to do. Do not include decisions, FYI
         if self._is_task_list_request(text, params):
             return "list_tasks"
 
+        if self._looks_like_points_topup_request(text):
+            return "topup_points"
+
         if explicit_points_request:
             return "request_points"
 
@@ -5101,6 +5125,8 @@ Only include actionable work someone agreed to do. Do not include decisions, FYI
             return "balance"
         if "history" in text_lower:
             return "history"
+        if self._looks_like_points_topup_request(text):
+            return "topup_points"
         if "request" in text_lower and "point" in text_lower and "reward" not in text_lower:
             return "request_points"
         if any(w in text_lower for w in ["tasks mine", "my tasks", "tasks review", "review tasks", "tasks all", "all tasks"]):
@@ -5171,6 +5197,74 @@ Only include actionable work someone agreed to do. Do not include decisions, FYI
         if any(w in text_lower for w in ["deduct", "remove points"]):
             return "deduct_points"
         return action
+
+    def _looks_like_points_topup_request(self, text: str) -> bool:
+        """Return True for member requests to buy fixed top-up Roo Points packs."""
+        text_lower = self._normalize_points_routing_text(text)
+        if re.search(r"\btop\s*up\b|\btopup\b|\btop-up\b", text_lower):
+            return True
+        if re.search(r"\bbuy\b.*\b(?:roo\s+)?points?\b", text_lower):
+            return True
+        if re.search(r"\badd\b.*\b(?:roo\s+)?points?\b", text_lower):
+            return True
+        return bool(re.search(r"\bi\s+need\s+more\s+(?:roo\s+)?points?\b", text_lower))
+
+    def _resolve_topup_pack_id(self, text: str, params: dict) -> tuple[Optional[str], Optional[int]]:
+        """Resolve a top-up pack ID; return unsupported amount when a non-pack amount is present."""
+        pack_candidates = [
+            params.get("pack_id"),
+            params.get("pack"),
+            params.get("topup_pack"),
+        ]
+        for candidate in pack_candidates:
+            value = str(candidate or "").strip().lower()
+            if not value:
+                continue
+            value = value.replace("-", "_")
+            if value in ROO_TOPUP_PACKS:
+                return value, None
+            match = re.search(r"\b(\d+)\b", value)
+            if match:
+                amount = int(match.group(1))
+                return ROO_TOPUP_PACK_BY_POINTS.get(amount), amount
+
+        point_candidates = [
+            params.get("points_amount"),
+            params.get("points"),
+            params.get("amount"),
+        ]
+        for candidate in point_candidates:
+            if candidate in (None, ""):
+                continue
+            try:
+                amount = int(candidate)
+            except (TypeError, ValueError):
+                continue
+            return ROO_TOPUP_PACK_BY_POINTS.get(amount), amount
+
+        text_lower = self._normalize_points_routing_text(text)
+        exact_pack = re.search(r"\btopup[_\s-]*(5|10|25)\b", text_lower)
+        if exact_pack:
+            amount = int(exact_pack.group(1))
+            return ROO_TOPUP_PACK_BY_POINTS[amount], None
+
+        amount_match = re.search(r"\b(\d+)\b", text_lower)
+        if amount_match:
+            amount = int(amount_match.group(1))
+            return ROO_TOPUP_PACK_BY_POINTS.get(amount), amount
+
+        return None, None
+
+    def _topup_pack_list_message(self) -> str:
+        lines = ["Available Top-up Roo Points packs:"]
+        for pack_id in ("topup_5", "topup_10", "topup_25"):
+            pack = ROO_TOPUP_PACKS[pack_id]
+            lines.append(f"- {pack['label']} - {pack['price']}")
+        lines.append("")
+        lines.append(
+            "Top-up Roo Points are optional and do not count toward lifetime earned contribution."
+        )
+        return "\n".join(lines)
 
     def _normalize_points_routing_text(self, text: str) -> str:
         """Normalize common Slack typo variants before deterministic routing."""
@@ -6486,6 +6580,45 @@ Only include actionable work someone agreed to do. Do not include decisions, FYI
         # Member Actions
         # =====================================================================
         
+        if action == "topup_points":
+            settings = get_settings()
+            if not getattr(settings, "ROO_POINTS_TOPUP_ENABLED", False):
+                return "Top-up checkout is not enabled yet. Ask the MLAI team to finish enabling Stripe top-ups first."
+
+            pack_id, unsupported_amount = self._resolve_topup_pack_id(text, params)
+            if not pack_id:
+                if unsupported_amount is None:
+                    return self._topup_pack_list_message()
+                return "I can only help with these fixed top-up packs right now: 5, 10, or 25 Top-up Roo Points."
+
+            purchase_from = {"source": "slack"}
+            if channel_id:
+                purchase_from["slack_channel_id"] = channel_id
+            if thread_ts:
+                purchase_from["slack_thread_ts"] = thread_ts
+
+            try:
+                purchase = await client.create_points_purchase(
+                    slack_user_id=user_id,
+                    pack_id=pack_id,
+                    purchase_from=purchase_from,
+                )
+            except httpx.HTTPStatusError as exc:
+                error_detail = self._extract_http_error_detail(exc)
+                detail = f" {error_detail}" if error_detail else ""
+                return f"I couldn't create that top-up checkout yet.{detail}"
+
+            checkout_url = str(purchase.get("frontend_checkout_page_url") or "").strip()
+            if not checkout_url:
+                return "I created the top-up request, but the checkout link was missing. Ask the MLAI team to check the points purchase API."
+
+            return (
+                "I created your Top-up Roo Points checkout. Continue here:\n"
+                f"{checkout_url}\n\n"
+                "Top-up Roo Points are MLAI community reward points. They are not money, "
+                "have no cash value, cannot be converted to cash, and cannot be sold or transferred."
+            )
+
         if action == "balance":
             data = await client.get_balance(user_id)
             balance = data.get("balance", 0)

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -44,7 +44,37 @@ def _make_agent() -> RooAgent:
         ),
         _make_skill(
             "mlai-points",
-            ["points", "balance", "coworking", "book", "task", "tasks", "reward", "rewards"],
+            [
+                "points",
+                "balance",
+                "coworking",
+                "book",
+                "task",
+                "tasks",
+                "reward",
+                "rewards",
+                "topup",
+                "top-up",
+                "top up",
+                "buy points",
+                "buy roo points",
+                "add points",
+                "add roo points",
+            ],
+        ),
+        _make_skill(
+            "linear-meeting-actions",
+            [
+                "meeting actions",
+                "meeting action items",
+                "meeting notes to linear",
+                "meeting summary to linear",
+                "transcript to linear",
+                "linear tasks from meeting",
+                "create linear tickets from transcript",
+                "extract action items",
+                "sync meeting notes to linear",
+            ],
         ),
         _make_skill(
             "github-integration",
@@ -88,6 +118,33 @@ def test_points_request_still_routes_to_points():
     assert skill.name == "mlai-points"
 
 
+def test_linear_meeting_tasks_route_to_linear_meeting_actions():
+    agent = _make_agent()
+
+    for text in [
+        "turn this meeting summary into Linear tasks",
+        "extract action items from this transcript and add them to Linear",
+        "sync meeting notes to Linear project Alpha",
+        "send this PDF to Linear as tasks",
+        "create Linear issues from this image",
+    ]:
+        skill = agent._select_skill_from_triggers(text)
+        assert skill is not None
+        assert skill.name == "linear-meeting-actions"
+
+
+def test_linear_file_context_routes_short_attached_file_request():
+    agent = _make_agent()
+
+    skill = agent._select_skill_from_triggers(
+        "send this to Linear as tasks",
+        has_file_context=True,
+    )
+
+    assert skill is not None
+    assert skill.name == "linear-meeting-actions"
+
+
 def test_request_points_phrase_routes_to_points():
     agent = _make_agent()
 
@@ -95,6 +152,21 @@ def test_request_points_phrase_routes_to_points():
 
     assert skill is not None
     assert skill.name == "mlai-points"
+
+
+def test_topup_phrases_route_to_points():
+    agent = _make_agent()
+
+    for text in [
+        "/roo topup",
+        "top up Roo Points",
+        "buy 10 roo points",
+        "add roo points",
+        "I need more points",
+    ]:
+        skill = agent._select_skill_from_triggers(text)
+        assert skill is not None
+        assert skill.name == "mlai-points"
 
 
 def test_coworking_booking_shortcuts_route_to_points():

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -68,6 +68,56 @@ class FakePointsClient:
         return {"ok": True}
 
 
+class FakeTopupPurchaseClient:
+    def __init__(self, response=None):
+        self.created = None
+        self.response = response or {
+            "id": "purchase-uuid",
+            "frontend_checkout_page_url": "https://mlai.au/roo/topup/purchase-uuid",
+        }
+
+    async def create_points_purchase(
+        self,
+        slack_user_id,
+        pack_id=None,
+        points_amount=None,
+        purchase_from=None,
+    ):
+        self.created = {
+            "slack_user_id": slack_user_id,
+            "pack_id": pack_id,
+            "points_amount": points_amount,
+            "purchase_from": purchase_from,
+        }
+        return self.response
+
+
+class FailingTopupPurchaseClient(FakeTopupPurchaseClient):
+    async def create_points_purchase(
+        self,
+        slack_user_id,
+        pack_id=None,
+        points_amount=None,
+        purchase_from=None,
+    ):
+        self.created = {
+            "slack_user_id": slack_user_id,
+            "pack_id": pack_id,
+            "points_amount": points_amount,
+            "purchase_from": purchase_from,
+        }
+        request = httpx.Request(
+            "POST",
+            "https://backend.test/api/v1/points/purchases/",
+        )
+        response = httpx.Response(
+            400,
+            request=request,
+            json={"error": "Top-up purchases are not available for this account."},
+        )
+        raise httpx.HTTPStatusError("bad request", request=request, response=response)
+
+
 class FailingCreatePointsClient(FakePointsClient):
     async def create_points_request(
         self,
@@ -222,6 +272,30 @@ def test_resolve_points_action_maps_plain_request_to_request_points():
     action = executor._resolve_points_action(
         {"action": "request"},
         "I'm requesting 6 points for volunteering at MedHack",
+    )
+
+    assert action == "request_points"
+
+
+def test_resolve_points_action_maps_topup_phrases():
+    executor = SkillExecutor()
+
+    for text in [
+        "/roo topup",
+        "top up Roo Points",
+        "buy 10 roo points",
+        "add roo points",
+        "I need more points",
+    ]:
+        assert executor._resolve_points_action({}, text) == "topup_points"
+
+
+def test_request_points_phrase_does_not_map_to_topup():
+    executor = SkillExecutor()
+
+    action = executor._resolve_points_action(
+        {},
+        "request 5 points for helping at the event",
     )
 
     assert action == "request_points"
@@ -475,6 +549,146 @@ async def test_request_points_rejected_in_dm():
     )
 
     assert "shared channel or thread" in result
+
+
+@pytest.mark.asyncio
+async def test_topup_points_disabled_returns_feature_message(monkeypatch):
+    executor = SkillExecutor()
+    client = FakeTopupPurchaseClient()
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(ROO_POINTS_TOPUP_ENABLED=False),
+    )
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="topup_points",
+        params={"points": 10},
+        text="buy 10 roo points",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "not enabled yet" in result
+    assert client.created is None
+
+
+@pytest.mark.asyncio
+async def test_topup_points_missing_pack_lists_fixed_packs(monkeypatch):
+    executor = SkillExecutor()
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(ROO_POINTS_TOPUP_ENABLED=True),
+    )
+
+    result = await executor._handle_points_action(
+        client=FakeTopupPurchaseClient(),
+        action="topup_points",
+        params={},
+        text="top up Roo Points",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "Available Top-up Roo Points packs" in result
+    assert "5 Top-up Roo Points - A$19.99" in result
+    assert "10 Top-up Roo Points - A$36.99" in result
+    assert "25 Top-up Roo Points - A$63.99" in result
+    assert "price per point" not in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_topup_points_unsupported_pack_is_rejected(monkeypatch):
+    executor = SkillExecutor()
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(ROO_POINTS_TOPUP_ENABLED=True),
+    )
+
+    result = await executor._handle_points_action(
+        client=FakeTopupPurchaseClient(),
+        action="topup_points",
+        params={"points": 100},
+        text="buy 100 roo points",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "5, 10, or 25 Top-up Roo Points" in result
+
+
+@pytest.mark.asyncio
+async def test_topup_points_valid_pack_creates_purchase(monkeypatch):
+    executor = SkillExecutor()
+    client = FakeTopupPurchaseClient()
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(ROO_POINTS_TOPUP_ENABLED=True),
+    )
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="topup_points",
+        params={},
+        text="buy 10 roo points",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "https://mlai.au/roo/topup/purchase-uuid" in result
+    assert "not money" in result
+    assert "no cash value" in result
+    assert client.created == {
+        "slack_user_id": "U123",
+        "pack_id": "topup_10",
+        "points_amount": None,
+        "purchase_from": {
+            "source": "slack",
+            "slack_channel_id": "C123",
+            "slack_thread_ts": "111.222",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_topup_points_backend_error_is_friendly(monkeypatch):
+    executor = SkillExecutor()
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(ROO_POINTS_TOPUP_ENABLED=True),
+    )
+
+    result = await executor._handle_points_action(
+        client=FailingTopupPurchaseClient(),
+        action="topup_points",
+        params={"points": 10},
+        text="buy 10 roo points",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "couldn't create that top-up checkout" in result
+    assert "Top-up purchases are not available" in result
 
 
 @pytest.mark.asyncio
@@ -1303,6 +1517,17 @@ async def test_reaction_approval_ignores_other_emoji(monkeypatch):
     assert direct_messages == []
 
 
+def test_linear_meeting_file_request_helper_allows_short_attached_file_prompt():
+    assert main_module._looks_like_linear_meeting_file_request(
+        "send this to Linear as tasks",
+        has_files=True,
+    )
+    assert not main_module._looks_like_linear_meeting_file_request(
+        "send this to Linear as tasks",
+        has_files=False,
+    )
+
+
 @pytest.mark.asyncio
 async def test_slack_events_start_here_message_triggers_intro_handler(monkeypatch):
     handled_events = []
@@ -1711,6 +1936,55 @@ async def test_backend_client_create_points_request_uses_canonical_endpoint(monk
         "reason": "running the 21st x MLAI event",
         "slack_channel_id": "C123",
         "slack_thread_ts": "111.222",
+    }
+    assert recorder.calls[0]["params"] is None
+    assert recorder.calls[0]["headers"]["Content-Type"] == "application/json"
+    assert recorder.calls[0]["headers"]["X-API-Key"] == "api-key"
+    assert recorder.calls[0]["headers"]["X-Request-ID"].startswith("roo-")
+    assert recorder.calls[0]["timeout"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_backend_client_create_points_purchase_uses_canonical_endpoint(monkeypatch):
+    recorder = RecordingAsyncClient(
+        json_data={
+            "id": "purchase-uuid",
+            "frontend_checkout_page_url": "https://mlai.au/roo/topup/purchase-uuid",
+        }
+    )
+    monkeypatch.setattr(backend_module.httpx, "AsyncClient", lambda: recorder)
+
+    client = backend_module.MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="api-key",
+        internal_api_key="internal-key",
+    )
+
+    result = await client.create_points_purchase(
+        slack_user_id="<@U123>",
+        pack_id="topup_10",
+        purchase_from={
+            "source": "slack",
+            "slack_channel_id": "C123",
+            "slack_thread_ts": "111.222",
+        },
+    )
+
+    assert result == {
+        "id": "purchase-uuid",
+        "frontend_checkout_page_url": "https://mlai.au/roo/topup/purchase-uuid",
+    }
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0]["method"] == "POST"
+    assert recorder.calls[0]["url"] == "https://backend.test/api/v1/points/purchases/"
+    assert recorder.calls[0]["json"] == {
+        "slack_user_id": "U123",
+        "pack_id": "topup_10",
+        "purchase_from": {
+            "source": "slack",
+            "slack_channel_id": "C123",
+            "slack_thread_ts": "111.222",
+        },
     }
     assert recorder.calls[0]["params"] is None
     assert recorder.calls[0]["headers"]["Content-Type"] == "application/json"

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -10,6 +10,13 @@ trigger_keywords:
   - tasks
   - reward
   - rewards
+  - topup
+  - top-up
+  - top up
+  - buy points
+  - buy roo points
+  - add points
+  - add roo points
 ---
 
 # MLAI Points System Skill
@@ -27,6 +34,7 @@ This skill enables Roo to interact with the MLAI Points System via API, allowing
 - Book and cancel coworking days
 - Points Admins can check another member in for coworking from Slack
 - View rewards catalog and request redemptions
+- Buy fixed packs of Top-up Roo Points through MLAI checkout
 
 ### Full Admin Actions (requires `admin`, `committee`, or `portfolio_lead` role)
 - Create new tasks with point values
@@ -67,6 +75,7 @@ Example responses:
 ## Parameters
 
 - **action**: The action to perform (required) - e.g., "balance", "request_points", "book_coworking", "admin_checkin_coworking", "coworking_report", "claim_task", "submit_task", "award_points", "create_task"
+- **pack_id**: Top-up pack ID for `topup_points`; one of `topup_5`, `topup_10`, or `topup_25`
 - **task_id**: Task ID number or task code (for example `42` or `ROO-0042`) for task-related actions
 - **date**: Date for coworking bookings (YYYY-MM-DD format)
 - **start_date**: Start date for coworking reports (YYYY-MM-DD format)
@@ -104,6 +113,7 @@ Parse user messages to identify the action and parameters:
 | Pattern | Action | Example |
 |---------|--------|---------|
 | `points`, `balance` | balance | "What's my points balance?", "@Roo points" |
+| `topup`, `top up Roo Points`, `buy <n> Roo Points`, `add Roo Points`, `I need more points` | topup_points | "@Roo buy 10 Roo Points" |
 | `request <n> points for <reason>` | request_points | "Request 5 points for helping at the event" |
 | `points earn` | list_tasks | "How do I earn points?", "@Roo points earn" |
 | `tasks`, `tasks open` | list_tasks | "What can I claim right now?" |
@@ -195,9 +205,21 @@ Call the appropriate MLAIBackendClient method with extracted parameters.
 ### Step 4: Format Response
 Generate friendly response with relevant information:
 - Balance: Show points count and encourage engagement
+- Top-up: Show only fixed pack prices or the MLAI checkout link; never show a price-per-point value
 - Tasks: Format as a short list with task code, points, and portfolio
 - Bookings: Confirm date and show remaining balance
 - Errors: Explain what went wrong and suggest alternatives
+
+## Top-up Roo Points
+
+Allowed fixed packs:
+- `topup_5`: 5 Top-up Roo Points - A$19.99
+- `topup_10`: 10 Top-up Roo Points - A$36.99
+- `topup_25`: 25 Top-up Roo Points - A$63.99
+
+Top-up Roo Points are MLAI's internal community reward points. They are not money, have no cash value, cannot be converted to cash, and cannot be sold or transferred. The price of Top-up Roo Points does not represent a monetary value for Roo Points.
+
+Top-up Roo Points are optional and do not count toward lifetime earned contribution.
 
 ## Response Style
 


### PR DESCRIPTION
## Summary

Adds Slack-facing Roo Points top-up routing and checkout creation for fixed packs, guarded by the `ROO_POINTS_TOPUP_ENABLED` setting. Also hardens link-love awards by sending a backend idempotency key and blocking retryable failures after a configured maximum attempt count.

## Validation

- `python3 -m pytest roo/tests/test_agent_routing.py roo/tests/test_link_love.py roo/tests/test_points_requests.py`