### PR TITLE
[codex] Expire old link-love threads

### DIFF
--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -33,7 +33,6 @@ class Settings(BaseSettings):
     MLAI_API_KEY: Optional[str] = None
     ROO_API_KEY: Optional[str] = None
     INTERNAL_API_KEY: Optional[str] = None
-    LINEAR_API_KEY: Optional[str] = None
     LINEAR_DEFAULT_TEAM: Optional[str] = None
 
     # GitHub OAuth
@@ -58,6 +57,7 @@ class Settings(BaseSettings):
     BOOST_LINK_LOVE_NOTIFICATION_DELAY_SECONDS: int = 60
     BOOST_LINK_LOVE_RETRY_POLL_SECONDS: float = 15.0
     BOOST_LINK_LOVE_MAX_RETRY_ATTEMPTS: int = 5
+    BOOST_LINK_LOVE_MAX_ROOT_AGE_DAYS: int = 7
     JOBS_SCHEDULER_ENABLED: bool = False
     JOBS_API_URL: Optional[str] = None
     JOBS_TRIGGER_TOKEN: Optional[str] = None

--- a/roo-standalone/roo/link_love.py
+++ b/roo-standalone/roo/link_love.py
@@ -21,6 +21,8 @@ DEFAULT_LINK_LOVE_DB_PATH = "data/link_love_awards.db"
 DEFAULT_RETRY_POLL_SECONDS = 15.0
 DEFAULT_PROCESSING_LEASE_SECONDS = 90.0
 DEFAULT_MAX_RETRY_ATTEMPTS = 5
+DEFAULT_MAX_ROOT_AGE_DAYS = 7
+SECONDS_PER_DAY = 24 * 60 * 60
 
 
 def _now() -> float:
@@ -45,6 +47,30 @@ def link_love_max_retry_attempts() -> int:
     except Exception:
         value = DEFAULT_MAX_RETRY_ATTEMPTS
     return max(1, value)
+
+
+def link_love_max_root_age_seconds() -> float:
+    try:
+        days = float(getattr(get_settings(), "BOOST_LINK_LOVE_MAX_ROOT_AGE_DAYS", DEFAULT_MAX_ROOT_AGE_DAYS))
+    except Exception:
+        days = DEFAULT_MAX_ROOT_AGE_DAYS
+    return max(0.0, days) * SECONDS_PER_DAY
+
+
+def slack_timestamp_to_epoch_seconds(slack_ts: str) -> float:
+    return float(str(slack_ts or "").strip())
+
+
+def is_link_love_root_expired(
+    root_message_ts: str,
+    *,
+    now: Optional[float] = None,
+    max_age_seconds: Optional[float] = None,
+) -> bool:
+    root_epoch_seconds = slack_timestamp_to_epoch_seconds(root_message_ts)
+    current_time = _now() if now is None else float(now)
+    allowed_age = link_love_max_root_age_seconds() if max_age_seconds is None else float(max_age_seconds)
+    return current_time - root_epoch_seconds > allowed_age
 
 
 def clean_slack_user_id(raw_value: Any) -> str:
@@ -274,6 +300,30 @@ class LinkLoveAwardStore:
                     """,
                     (channel_id, reply_message_ts),
                 ).fetchone()
+            )
+
+    def has_expired_reply_check(
+        self,
+        *,
+        channel_id: str,
+        root_message_ts: str,
+        slack_user_id: str,
+    ) -> bool:
+        self._ensure_schema()
+        with self._connect() as conn:
+            return (
+                conn.execute(
+                    """
+                    SELECT 1 FROM link_love_reply_checks
+                    WHERE channel_id = ?
+                      AND root_message_ts = ?
+                      AND slack_user_id = ?
+                      AND classification_status = 'expired'
+                    LIMIT 1
+                    """,
+                    (channel_id, root_message_ts, slack_user_id),
+                ).fetchone()
+                is not None
             )
 
     def create_reply_check(
@@ -665,6 +715,23 @@ def _build_notification_text(awards: list[dict[str, Any]]) -> str:
     return "\n".join(lines)
 
 
+def _build_expired_link_love_notice(slack_user_id: str) -> str:
+    return (
+        f"Sorry <@{slack_user_id}>, this post is more than a week old, "
+        "so it no longer qualifies for link-love points."
+    )
+
+
+def post_expired_link_love_notice(*, channel_id: str, root_message_ts: str, slack_user_id: str) -> None:
+    from .slack_client import post_message
+
+    post_message(
+        channel=channel_id,
+        thread_ts=root_message_ts,
+        text=_build_expired_link_love_notice(slack_user_id),
+    )
+
+
 async def process_link_love_award(
     award: dict[str, Any],
     *,
@@ -829,6 +896,49 @@ async def handle_link_love_reply(
             raw_response=classification.raw_response,
         )
         return {"status": "ineligible", "classification": classification}
+
+    try:
+        root_expired = is_link_love_root_expired(root_message_ts)
+    except (TypeError, ValueError) as exc:
+        error = f"invalid root timestamp: {root_message_ts}"
+        print(
+            "⚠️ link_love_invalid_root_timestamp "
+            f"channel_id={channel_id} root_message_ts={root_message_ts} "
+            f"reply_message_ts={reply_message_ts} error={exc}"
+        )
+        store.mark_reply_check_classified(
+            int(reply_check["id"]),
+            status="ineligible",
+            qualifies=False,
+            reason=error,
+            raw_response=classification.raw_response,
+        )
+        return {"status": "ignored", "reason": "invalid_root_message_ts", "classification": classification}
+
+    if root_expired:
+        already_notified = store.has_expired_reply_check(
+            channel_id=channel_id,
+            root_message_ts=root_message_ts,
+            slack_user_id=slack_user_id,
+        )
+        store.mark_reply_check_classified(
+            int(reply_check["id"]),
+            status="expired",
+            qualifies=False,
+            reason="root post is older than the link-love award window",
+            raw_response=classification.raw_response,
+        )
+        if not already_notified:
+            post_expired_link_love_notice(
+                channel_id=channel_id,
+                root_message_ts=root_message_ts,
+                slack_user_id=slack_user_id,
+            )
+        return {
+            "status": "expired",
+            "classification": classification,
+            "notice_posted": not already_notified,
+        }
 
     award_created, award = store.create_award(
         channel_id=channel_id,

--- a/roo-standalone/roo/tests/test_link_love.py
+++ b/roo-standalone/roo/tests/test_link_love.py
@@ -125,6 +125,12 @@ async def llm_not_engaged(*args, **kwargs):
     return FakeLLMResponse('{"engaged": false, "confidence": 0.93, "reason": "vague support only"}')
 
 
+@pytest.fixture(autouse=True)
+def stable_link_love_clock(monkeypatch):
+    monkeypatch.setattr(link_love, "_now", lambda: 1_000_000.0)
+    monkeypatch.setattr(link_love, "link_love_max_root_age_seconds", lambda: 2_000_000.0)
+
+
 def test_parse_link_love_classification_handles_fenced_json():
     result = link_love.parse_link_love_classification(
         '```json\n{"engaged": true, "confidence": 0.87, "reason": "liked"}\n```'
@@ -146,6 +152,22 @@ def test_link_love_prompt_excludes_vague_support():
     assert "love it" in prompt_text.lower()
     assert "done" in prompt_text.lower()
     assert "liked" in prompt_text.lower()
+
+
+def test_link_love_root_expiry_boundary():
+    max_age = 7 * 24 * 60 * 60
+    now = 1_000_000.0
+
+    assert link_love.is_link_love_root_expired(
+        str(now - max_age),
+        now=now,
+        max_age_seconds=max_age,
+    ) is False
+    assert link_love.is_link_love_root_expired(
+        str(now - max_age - 0.001),
+        now=now,
+        max_age_seconds=max_age,
+    ) is True
 
 
 @pytest.mark.asyncio
@@ -284,6 +306,149 @@ async def test_non_proof_reply_can_be_followed_by_later_proof_reply(tmp_path):
     assert first["status"] == "ineligible"
     assert second["status"] == "awarded"
     assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_expired_qualifying_reply_posts_notice_and_does_not_award(tmp_path, monkeypatch):
+    store = make_store(tmp_path)
+    client = FakeAwardClient()
+    posted_messages = []
+    max_age = 7 * 24 * 60 * 60
+    root_ts = str(1_000_000.0 - max_age - 1)
+    monkeypatch.setattr(link_love, "link_love_max_root_age_seconds", lambda: max_age)
+    monkeypatch.setattr(slack_client_module, "post_message", lambda **kwargs: posted_messages.append(kwargs))
+
+    result = await link_love.handle_link_love_reply(
+        reply_event(root_ts=root_ts, text="Done"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert result["status"] == "expired"
+    assert result["notice_posted"] is True
+    assert client.calls == []
+    assert store.get_due_notification_groups() == []
+    assert posted_messages == [
+        {
+            "channel": "CBOOST",
+            "thread_ts": root_ts,
+            "text": (
+                "Sorry <@UHELPER>, this post is more than a week old, "
+                "so it no longer qualifies for link-love points."
+            ),
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_expired_non_proof_reply_does_not_post_notice_or_award(tmp_path, monkeypatch):
+    store = make_store(tmp_path)
+    client = FakeAwardClient()
+    posted_messages = []
+    max_age = 7 * 24 * 60 * 60
+    root_ts = str(1_000_000.0 - max_age - 1)
+    monkeypatch.setattr(link_love, "link_love_max_root_age_seconds", lambda: max_age)
+    monkeypatch.setattr(slack_client_module, "post_message", lambda **kwargs: posted_messages.append(kwargs))
+
+    result = await link_love.handle_link_love_reply(
+        reply_event(root_ts=root_ts, text="Love it!"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_not_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert result["status"] == "ineligible"
+    assert client.calls == []
+    assert posted_messages == []
+
+
+@pytest.mark.asyncio
+async def test_expired_qualifying_replies_post_one_notice_per_user_per_root(tmp_path, monkeypatch):
+    store = make_store(tmp_path)
+    client = FakeAwardClient()
+    posted_messages = []
+    max_age = 7 * 24 * 60 * 60
+    root_ts = str(1_000_000.0 - max_age - 1)
+    monkeypatch.setattr(link_love, "link_love_max_root_age_seconds", lambda: max_age)
+    monkeypatch.setattr(slack_client_module, "post_message", lambda **kwargs: posted_messages.append(kwargs))
+
+    first = await link_love.handle_link_love_reply(
+        reply_event(root_ts=root_ts, reply_ts="222.000", text="Done"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+    second = await link_love.handle_link_love_reply(
+        reply_event(root_ts=root_ts, reply_ts="333.000", text="Liked"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert first["status"] == "expired"
+    assert first["notice_posted"] is True
+    assert second["status"] == "expired"
+    assert second["notice_posted"] is False
+    assert client.calls == []
+    assert len(posted_messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_exactly_one_week_old_qualifying_reply_still_awards(tmp_path, monkeypatch):
+    store = make_store(tmp_path)
+    client = FakeAwardClient()
+    max_age = 7 * 24 * 60 * 60
+    root_ts = str(1_000_000.0 - max_age)
+    monkeypatch.setattr(link_love, "link_love_max_root_age_seconds", lambda: max_age)
+
+    result = await link_love.handle_link_love_reply(
+        reply_event(root_ts=root_ts, text="Done"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert result["status"] == "awarded"
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_invalid_root_timestamp_does_not_award(tmp_path, monkeypatch):
+    store = make_store(tmp_path)
+    client = FakeAwardClient()
+    posted_messages = []
+    monkeypatch.setattr(slack_client_module, "post_message", lambda **kwargs: posted_messages.append(kwargs))
+
+    result = await link_love.handle_link_love_reply(
+        reply_event(root_ts="not-a-ts", text="Done"),
+        store=store,
+        client=client,
+        get_root_message=lambda channel, ts: root_message(),
+        llm_chat=llm_engaged,
+        bot_user_id="UROO",
+        notification_delay_seconds=0,
+    )
+
+    assert result["status"] == "ignored"
+    assert result["reason"] == "invalid_root_message_ts"
+    assert client.calls == []
+    assert posted_messages == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a 7-day expiry window for link-love root posts
- skip backend awards for qualifying replies on expired threads
- post one public expiry notice per user/root thread

## Validation
- git diff --check
- python3 -m pytest roo/tests/test_link_love.py roo/tests/test_points_requests.py
- python3 -m compileall roo/link_love.py roo/config.py roo/tests/test_link_love.py