### PR TITLE
[codex] Route Linear meeting actions through backend

### DIFF
--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -33,7 +33,6 @@ class Settings(BaseSettings):
     MLAI_API_KEY: Optional[str] = None
     ROO_API_KEY: Optional[str] = None
     INTERNAL_API_KEY: Optional[str] = None
-    LINEAR_API_KEY: Optional[str] = None
     LINEAR_DEFAULT_TEAM: Optional[str] = None
 
     # GitHub OAuth

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -3180,16 +3180,6 @@ async def slack_actions(request: Request):
                 )
             return JSONResponse(status_code=200, content={})
 
-        settings = get_settings()
-        if not settings.LINEAR_API_KEY:
-            if reply_channel:
-                post_message(
-                    channel=reply_channel,
-                    thread_ts=reply_thread_ts,
-                    text="Linear is not configured for Roo yet. Set `LINEAR_API_KEY` before approving this action item.",
-                )
-            return JSONResponse(status_code=200, content={})
-
         skill = get_agent()._get_skill_by_name("linear-meeting-actions")
         ClientClass = skill.get_client_class("LinearMeetingActionsClient") if skill else None
         if ClientClass is None:
@@ -3202,9 +3192,7 @@ async def slack_actions(request: Request):
             return JSONResponse(status_code=200, content={})
 
         try:
-            issue = await ClientClass(api_key=settings.LINEAR_API_KEY).create_issue(
-                **pending["issue_input"]
-            )
+            issue = await ClientClass().create_issue(**pending["issue_input"])
             pop_pending_linear_meeting_action(pending_id)
         except Exception as exc:
             if reply_channel:

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -1522,11 +1522,6 @@ Keep the response concise but informative."""
         event_files: Optional[List[dict]] = None,
     ) -> dict:
         settings = get_settings()
-        if not getattr(settings, "LINEAR_API_KEY", None):
-            return {
-                "message": "Linear meeting actions are not configured yet. Set `LINEAR_API_KEY` for Roo first."
-            }
-
         source_result = await self._build_linear_meeting_source_result(
             text=text,
             params=params,
@@ -1548,7 +1543,7 @@ Keep the response concise but informative."""
         if ClientClass is None:
             return {"message": "Linear meeting actions are missing their Linear client implementation."}
 
-        client = ClientClass(api_key=settings.LINEAR_API_KEY)
+        client = ClientClass()
         try:
             teams, users, projects, labels, recent_issues = await asyncio.gather(
                 client.list_teams(),

--- a/roo-standalone/roo/tests/test_linear_meeting_actions.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_actions.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib.util
 import sys
 from pathlib import Path
@@ -143,7 +144,7 @@ def test_linear_meeting_decision_thresholds():
 
 
 @pytest.mark.asyncio
-async def test_linear_client_raises_on_graphql_errors(monkeypatch):
+async def test_linear_client_reads_context_from_backend(monkeypatch):
     module_path = (
         Path(__file__).resolve().parents[2]
         / "skills"
@@ -156,27 +157,142 @@ async def test_linear_client_raises_on_graphql_errors(monkeypatch):
     spec.loader.exec_module(module)
 
     class FakeResponse:
-        def raise_for_status(self):
-            return None
+        status_code = 200
 
         def json(self):
-            return {"errors": [{"message": "bad query"}]}
+            return {
+                "teams": [{"id": "team-1"}],
+                "users": [{"id": "user-1"}],
+                "projects": [{"id": "project-1"}],
+                "labels": [{"id": "label-1"}],
+                "recentIssues": [{"id": "issue-1"}],
+            }
 
-    class FakeAsyncClient:
-        async def __aenter__(self):
-            return self
+    calls = []
 
-        async def __aexit__(self, exc_type, exc, tb):
-            return None
+    class FakeBackend:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
 
-        async def post(self, *args, **kwargs):
+        async def _request(self, method, endpoint, **kwargs):
+            calls.append((method, endpoint, kwargs))
             return FakeResponse()
 
-    monkeypatch.setattr(module.httpx, "AsyncClient", FakeAsyncClient)
+    monkeypatch.setattr(module, "MLAIBackendClient", FakeBackend)
 
-    client = module.LinearMeetingActionsClient(api_key="lin_api_key")
-    with pytest.raises(RuntimeError, match="bad query"):
-        await client._graphql("query { viewer { id } }")
+    client = module.LinearMeetingActionsClient(base_url="https://backend.test", api_key="roo-key")
+    teams, users, projects, labels, recent_issues = await asyncio.gather(
+        client.list_teams(),
+        client.list_users(),
+        client.list_active_projects(),
+        client.list_issue_labels(),
+        client.list_recent_open_issues(),
+    )
+
+    assert teams == [{"id": "team-1"}]
+    assert users == [{"id": "user-1"}]
+    assert projects == [{"id": "project-1"}]
+    assert labels == [{"id": "label-1"}]
+    assert recent_issues == [{"id": "issue-1"}]
+    assert len(calls) == 1
+    assert calls[0][0] == "GET"
+    assert calls[0][1] == "/api/v1/integrations/linear/meeting-context"
+    assert calls[0][2]["use_admin_headers"] is True
+
+
+@pytest.mark.asyncio
+async def test_linear_client_create_issue_calls_backend(monkeypatch):
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "skills"
+        / "linear_meeting_actions"
+        / "client.py"
+    )
+    spec = importlib.util.spec_from_file_location("linear_meeting_actions_client_create_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    class FakeResponse:
+        status_code = 201
+
+        def json(self):
+            return {"identifier": "ENG-123", "title": "Update onboarding docs"}
+
+    calls = []
+
+    class FakeBackend:
+        def __init__(self, **kwargs):
+            pass
+
+        async def _request(self, method, endpoint, **kwargs):
+            calls.append((method, endpoint, kwargs))
+            return FakeResponse()
+
+    monkeypatch.setattr(module, "MLAIBackendClient", FakeBackend)
+
+    client = module.LinearMeetingActionsClient(base_url="https://backend.test", api_key="roo-key")
+    issue = await client.create_issue(
+        title="Update onboarding docs",
+        team_id="team-1",
+        description="Meeting task",
+        assignee_id="user-1",
+        project_id="project-1",
+        priority=2,
+        due_date="2026-05-08",
+        label_ids=["label-1"],
+    )
+
+    assert issue["identifier"] == "ENG-123"
+    assert calls[0][0] == "POST"
+    assert calls[0][1] == "/api/v1/integrations/linear/issues"
+    assert calls[0][2]["use_admin_headers"] is True
+    assert calls[0][2]["json"] == {
+        "title": "Update onboarding docs",
+        "team_id": "team-1",
+        "description": "Meeting task",
+        "assignee_id": "user-1",
+        "project_id": "project-1",
+        "priority": 2,
+        "due_date": "2026-05-08",
+        "label_ids": ["label-1"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_linear_client_backend_error_surfaces_detail(monkeypatch):
+    module_path = (
+        Path(__file__).resolve().parents[2]
+        / "skills"
+        / "linear_meeting_actions"
+        / "client.py"
+    )
+    spec = importlib.util.spec_from_file_location("linear_meeting_actions_client_error_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+
+    class FakeResponse:
+        status_code = 503
+
+        def json(self):
+            return {
+                "detail": "Backend Linear meeting actions are not configured. Set LINEAR_API_KEY on mlai-backend.",
+                "code": "linear_not_configured",
+            }
+
+    class FakeBackend:
+        def __init__(self, **kwargs):
+            pass
+
+        async def _request(self, method, endpoint, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr(module, "MLAIBackendClient", FakeBackend)
+
+    client = module.LinearMeetingActionsClient(base_url="https://backend.test", api_key="roo-key")
+    with pytest.raises(RuntimeError, match="mlai-backend"):
+        await client.list_teams()
 
 
 @pytest.mark.asyncio
@@ -253,8 +369,8 @@ async def test_linear_meeting_executor_creates_issue_from_parsed_file_source(mon
     }
 
     class FakeClient:
-        def __init__(self, api_key):
-            assert api_key == "lin_api_key"
+        def __init__(self):
+            pass
 
         async def list_teams(self):
             return [team]
@@ -288,7 +404,6 @@ async def test_linear_meeting_executor_creates_issue_from_parsed_file_source(mon
         executor_module,
         "get_settings",
         lambda: SimpleNamespace(
-            LINEAR_API_KEY="lin_api_key",
             LINEAR_DEFAULT_TEAM=None,
             LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE=0.85,
             LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE=0.65,

--- a/roo-standalone/skills/linear_meeting_actions/client.py
+++ b/roo-standalone/skills/linear_meeting_actions/client.py
@@ -1,178 +1,89 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Optional
 
 import httpx
 
+from roo.clients.mlai_backend import MLAIBackendClient, MLAIBackendUnavailableError
 
-LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql"
+
+LINEAR_MEETING_CONTEXT_ENDPOINT = "/api/v1/integrations/linear/meeting-context"
+LINEAR_MEETING_ISSUES_ENDPOINT = "/api/v1/integrations/linear/issues"
 
 
 class LinearMeetingActionsClient:
-    """Small GraphQL client for the Linear meeting-actions Roo skill."""
+    """Backend-backed client for Roo's Linear meeting-actions skill."""
 
-    def __init__(self, api_key: str, base_url: str = LINEAR_GRAPHQL_URL):
-        if not api_key:
-            raise ValueError("LINEAR_API_KEY not configured")
-        self.api_key = api_key
-        self.base_url = base_url
-
-    @property
-    def headers(self) -> dict[str, str]:
-        return {
-            "Authorization": self.api_key,
-            "Content-Type": "application/json",
-        }
-
-    async def _graphql(
+    def __init__(
         self,
-        query: str,
-        variables: Optional[dict[str, Any]] = None,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        internal_api_key: Optional[str] = None,
+    ):
+        self.backend = MLAIBackendClient(
+            base_url=base_url,
+            api_key=api_key,
+            internal_api_key=internal_api_key,
+        )
+        self._context_task: Optional[asyncio.Task[dict[str, Any]]] = None
+
+    async def _request_json(
+        self,
+        method: str,
+        endpoint: str,
         *,
+        payload: Optional[dict[str, Any]] = None,
         timeout: float = 30.0,
     ) -> dict[str, Any]:
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                self.base_url,
-                json={"query": query, "variables": variables or {}},
-                headers=self.headers,
+        try:
+            response = await self.backend._request(
+                method,
+                endpoint,
+                json=payload,
                 timeout=timeout,
+                circuit_breaker=True,
+                use_admin_headers=True,
             )
-            response.raise_for_status()
+        except MLAIBackendUnavailableError:
+            raise
+        except ValueError as exc:
+            raise RuntimeError(str(exc)) from exc
 
-        data = response.json()
-        errors = data.get("errors")
-        if errors:
-            messages = "; ".join(str(error.get("message") or error) for error in errors)
-            raise RuntimeError(f"Linear GraphQL error: {messages}")
-        return data.get("data") or {}
+        if response.status_code >= 400:
+            raise RuntimeError(self._backend_error_message(response))
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise RuntimeError("mlai-backend returned invalid JSON for Linear meeting actions.") from exc
+        return data if isinstance(data, dict) else {}
+
+    async def _meeting_context(self) -> dict[str, Any]:
+        if self._context_task is None:
+            self._context_task = asyncio.create_task(
+                self._request_json("GET", LINEAR_MEETING_CONTEXT_ENDPOINT)
+            )
+        return await self._context_task
 
     async def list_teams(self, limit: int = 100) -> list[dict[str, Any]]:
-        query = """
-        query LinearTeams($first: Int!) {
-          teams(first: $first) {
-            nodes {
-              id
-              key
-              name
-            }
-          }
-        }
-        """
-        data = await self._graphql(query, {"first": limit})
-        return _nodes(data, "teams")
+        context = await self._meeting_context()
+        return _dict_list(context.get("teams"))
 
     async def list_users(self, limit: int = 250) -> list[dict[str, Any]]:
-        query = """
-        query LinearUsers($first: Int!) {
-          users(first: $first) {
-            nodes {
-              id
-              name
-              displayName
-              email
-              active
-            }
-          }
-        }
-        """
-        data = await self._graphql(query, {"first": limit})
-        users = _nodes(data, "users")
-        return [user for user in users if user.get("active") is not False]
+        context = await self._meeting_context()
+        return _dict_list(context.get("users"))
 
     async def list_active_projects(self, limit: int = 100) -> list[dict[str, Any]]:
-        query = """
-        query LinearProjects($first: Int!) {
-          projects(first: $first) {
-            nodes {
-              id
-              name
-              slugId
-              url
-              state
-              lead {
-                id
-                name
-                displayName
-                email
-              }
-              teams {
-                nodes {
-                  id
-                  key
-                  name
-                }
-              }
-              members {
-                nodes {
-                  id
-                  name
-                  displayName
-                  email
-                }
-              }
-            }
-          }
-        }
-        """
-        data = await self._graphql(query, {"first": limit})
-        projects = _nodes(data, "projects")
-        inactive_states = {"completed", "canceled", "cancelled", "archived"}
-        return [
-            project
-            for project in projects
-            if str(project.get("state") or "").lower() not in inactive_states
-        ]
+        context = await self._meeting_context()
+        return _dict_list(context.get("projects"))
 
     async def list_issue_labels(self, limit: int = 100) -> list[dict[str, Any]]:
-        query = """
-        query LinearIssueLabels($first: Int!) {
-          issueLabels(first: $first) {
-            nodes {
-              id
-              name
-            }
-          }
-        }
-        """
-        data = await self._graphql(query, {"first": limit})
-        return _nodes(data, "issueLabels")
+        context = await self._meeting_context()
+        return _dict_list(context.get("labels"))
 
     async def list_recent_open_issues(self, limit: int = 100) -> list[dict[str, Any]]:
-        query = """
-        query LinearRecentIssues($first: Int!) {
-          issues(first: $first) {
-            nodes {
-              id
-              identifier
-              title
-              url
-              state {
-                name
-                type
-              }
-              project {
-                id
-                name
-              }
-              assignee {
-                id
-                name
-                displayName
-                email
-              }
-            }
-          }
-        }
-        """
-        data = await self._graphql(query, {"first": limit})
-        issues = _nodes(data, "issues")
-        closed_types = {"completed", "canceled", "cancelled"}
-        return [
-            issue
-            for issue in issues
-            if str((issue.get("state") or {}).get("type") or "").lower() not in closed_types
-        ]
+        context = await self._meeting_context()
+        return _dict_list(context.get("recentIssues") or context.get("recent_issues"))
 
     async def create_issue(
         self,
@@ -186,44 +97,47 @@ class LinearMeetingActionsClient:
         due_date: Optional[str] = None,
         label_ids: Optional[list[str]] = None,
     ) -> dict[str, Any]:
-        input_data: dict[str, Any] = {
+        payload: dict[str, Any] = {
             "title": title,
-            "teamId": team_id,
+            "team_id": team_id,
         }
         if description:
-            input_data["description"] = description
+            payload["description"] = description
         if assignee_id:
-            input_data["assigneeId"] = assignee_id
+            payload["assignee_id"] = assignee_id
         if project_id:
-            input_data["projectId"] = project_id
+            payload["project_id"] = project_id
         if priority is not None:
-            input_data["priority"] = priority
+            payload["priority"] = priority
         if due_date:
-            input_data["dueDate"] = due_date
+            payload["due_date"] = due_date
         if label_ids:
-            input_data["labelIds"] = label_ids
+            payload["label_ids"] = label_ids
 
-        mutation = """
-        mutation CreateLinearMeetingIssue($input: IssueCreateInput!) {
-          issueCreate(input: $input) {
-            success
-            issue {
-              id
-              identifier
-              title
-              url
-            }
-          }
-        }
-        """
-        data = await self._graphql(mutation, {"input": input_data})
-        result = data.get("issueCreate") or {}
-        if not result.get("success"):
-            raise RuntimeError("Linear issueCreate returned success=false")
-        return result.get("issue") or {}
+        return await self._request_json(
+            "POST",
+            LINEAR_MEETING_ISSUES_ENDPOINT,
+            payload=payload,
+            timeout=30.0,
+        )
+
+    @staticmethod
+    def _backend_error_message(response: httpx.Response) -> str:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {}
+        if isinstance(payload, dict):
+            detail = payload.get("detail") or payload.get("message") or payload.get("error")
+            code = payload.get("code")
+            if detail and code:
+                return f"{detail} ({code})"
+            if detail:
+                return str(detail)
+        return f"mlai-backend Linear meeting actions request failed with HTTP {response.status_code}."
 
 
-def _nodes(data: dict[str, Any], key: str) -> list[dict[str, Any]]:
-    value = data.get(key) or {}
-    nodes = value.get("nodes") or []
-    return [node for node in nodes if isinstance(node, dict)]
+def _dict_list(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]


### PR DESCRIPTION
## Summary
- switch Roo's Linear meeting-actions client to call mlai-backend instead of Linear directly
- remove Roo-side LINEAR_API_KEY usage from the executor, Slack approval path, and settings
- add Roo client tests for backend context, create issue, and backend config errors

## Validation
- python3 -m pytest roo-standalone/roo/tests/test_linear_meeting_actions.py roo-standalone/roo/tests/test_linear_meeting_routing.py roo-standalone/roo/tests/test_linear_meeting_sources.py

## Notes
- A full clean-main Roo suite run currently has unrelated content factory action test failures; the Linear meeting targeted suite passes.