### PR TITLE
Add thread context fallback for Linear issues

### DIFF
--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -128,6 +128,10 @@ class RooAgent:
                 thread_history = raw_history[-10:] if raw_history else []
             except Exception as e:
                 print(f"⚠️ Failed to fetch thread history: {e}")
+        has_prior_thread_context = self._has_prior_slack_thread_context(
+            thread_history,
+            current_message_ts=kwargs.get("current_message_ts"),
+        )
 
         # 1. Try Fast Path (Direct Command Execution)
         fast_result = await self._try_fast_path(clean_text, user_id, channel_id, thread_ts)
@@ -142,6 +146,7 @@ class RooAgent:
             channel_id,
             thread_ts,
             has_file_context=bool(kwargs.get("event_files")),
+            has_thread_context=has_prior_thread_context,
         )
 
         if skill:
@@ -398,7 +403,36 @@ class RooAgent:
         )
         return any(re.search(pattern, text) for pattern in patterns)
 
-    def _looks_like_linear_meeting_request(self, text: str, has_file_context: bool = False) -> bool:
+    def _has_prior_slack_thread_context(
+        self,
+        history: Optional[List[dict]],
+        current_message_ts: Optional[str] = None,
+    ) -> bool:
+        current_ts = str(current_message_ts or "").strip()
+        for message in history or []:
+            if message.get("is_bot") or message.get("bot_id"):
+                continue
+            if current_ts and str(message.get("ts") or "").strip() == current_ts:
+                continue
+            if str(message.get("text") or "").strip() or message.get("files"):
+                return True
+        return False
+
+    def _looks_like_linear_thread_reference_request(self, text: str) -> bool:
+        if not re.search(r'\blinear\b', text):
+            return False
+        reference = r'(?:this|that|above|thread|conversation|message|discussion)'
+        return bool(
+            re.search(rf'\b(?:add|put|send|sync|create)\b.*\b{reference}\b.*\blinear\b', text)
+            or re.search(rf'\blinear\b.*\b(?:add|put|send|sync|create)\b.*\b{reference}\b', text)
+        )
+
+    def _looks_like_linear_meeting_request(
+        self,
+        text: str,
+        has_file_context: bool = False,
+        has_thread_context: bool = False,
+    ) -> bool:
         has_linear = bool(re.search(r'\blinear\b', text))
         has_meeting_source = bool(
             re.search(
@@ -407,9 +441,15 @@ class RooAgent:
             )
         ) or has_file_context
         has_creation_intent = bool(
-            re.search(r'\b(extract|sync|turn|send|create|add|tickets?|issues?|tasks?)\b', text)
+            re.search(r'\b(extract|sync|turn|send|put|create|add|tickets?|issues?|tasks?)\b', text)
         )
-        return has_linear and has_meeting_source and has_creation_intent
+        if has_linear and has_meeting_source and has_creation_intent:
+            return True
+        return (
+            has_creation_intent
+            and (has_file_context or has_thread_context)
+            and self._looks_like_linear_thread_reference_request(text)
+        )
 
     def _looks_like_content_follow_up(self, text: str) -> bool:
         patterns = (
@@ -439,6 +479,7 @@ class RooAgent:
         text: str,
         thread_context: Optional[Dict[str, Any]] = None,
         has_file_context: bool = False,
+        has_thread_context: bool = False,
     ) -> Optional[Skill]:
         routing_intent = self._get_routing_intent(text, thread_context)
         if routing_intent:
@@ -456,11 +497,15 @@ class RooAgent:
         if content_skill and self._looks_like_content_request(text_lower):
             return content_skill
 
-        if linear_meeting_skill and self._looks_like_linear_meeting_request(text_lower, has_file_context):
-            return linear_meeting_skill
-
         if points_skill and self._looks_like_points_request(text_lower):
             return points_skill
+
+        if linear_meeting_skill and self._looks_like_linear_meeting_request(
+            text_lower,
+            has_file_context,
+            has_thread_context,
+        ):
+            return linear_meeting_skill
 
         if (
             thread_context
@@ -679,6 +724,7 @@ class RooAgent:
         channel_id: Optional[str] = None,
         thread_ts: Optional[str] = None,
         has_file_context: bool = False,
+        has_thread_context: bool = False,
     ) -> Optional[Skill]:
         """Use LLM to decide which skill to use."""
         if not self.skills:
@@ -694,6 +740,7 @@ class RooAgent:
             text,
             thread_context,
             has_file_context=has_slack_files,
+            has_thread_context=has_thread_context,
         )
         if trigger_skill:
             return trigger_skill

--- a/roo-standalone/roo/linear_meeting_sources.py
+++ b/roo-standalone/roo/linear_meeting_sources.py
@@ -71,6 +71,8 @@ async def parse_linear_meeting_sources(
     thread_history: Optional[list[dict[str, Any]]] = None,
     event_files: Optional[list[dict[str, Any]]] = None,
     image_parser: Optional[ImageParser] = None,
+    current_message_ts: Optional[str] = None,
+    exclude_current_message: bool = False,
     max_files: int = DEFAULT_MAX_FILES,
     max_file_bytes: int = DEFAULT_MAX_FILE_BYTES,
     max_pdf_pages: int = DEFAULT_MAX_PDF_PAGES,
@@ -79,7 +81,13 @@ async def parse_linear_meeting_sources(
     """Parse Slack text and supported Slack files into text sources."""
     result = SourceParseResult()
 
-    text_source = _build_thread_text_source(text, params, thread_history)
+    text_source = _build_thread_text_source(
+        text,
+        params,
+        thread_history,
+        current_message_ts=current_message_ts,
+        exclude_current_message=exclude_current_message,
+    )
     if text_source and text_source.text.strip():
         result.sources.append(
             ParsedSource(label=text_source.label, text=text_source.text, kind="slack_text")
@@ -143,14 +151,20 @@ def _build_thread_text_source(
     text: str,
     params: dict[str, Any],
     thread_history: Optional[list[dict[str, Any]]],
+    *,
+    current_message_ts: Optional[str] = None,
+    exclude_current_message: bool = False,
 ) -> Optional[SlackSource]:
     explicit = str(params.get("transcript") or "").strip()
     parts: list[str] = []
     if explicit:
         parts.append(explicit)
 
+    current_ts = str(current_message_ts or "").strip()
     for message in thread_history or []:
         if message.get("is_bot") or message.get("bot_id"):
+            continue
+        if exclude_current_message and current_ts and str(message.get("ts") or "").strip() == current_ts:
             continue
         message_text = str(message.get("text") or "").strip()
         if not message_text:
@@ -159,7 +173,7 @@ def _build_thread_text_source(
         parts.append(f"{speaker}: {message_text}")
 
     clean_text = str(text or "").strip()
-    if clean_text and all(clean_text not in part for part in parts):
+    if not exclude_current_message and clean_text and all(clean_text not in part for part in parts):
         parts.append(clean_text)
 
     if not parts:

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -1815,6 +1815,7 @@ async def _handle_mention(event: dict):
             channel_id=channel_id,
             thread_ts=thread_ts,
             param_overrides=param_overrides if isinstance(param_overrides, dict) else None,
+            current_message_ts=event.get("ts"),
             event_files=event_files,
         )
         

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -162,6 +162,7 @@ class SkillExecutor:
                     thread_ts,
                     thread_history,
                     kwargs.get("event_files"),
+                    kwargs.get("current_message_ts"),
                 )
             elif skill.name == "tone-of-voice":
                 result = await self._execute_tone_of_voice(skill, text, params, user_id)
@@ -1520,14 +1521,19 @@ Keep the response concise but informative."""
         thread_ts: Optional[str],
         thread_history: Optional[List[dict]] = None,
         event_files: Optional[List[dict]] = None,
+        current_message_ts: Optional[str] = None,
     ) -> dict:
         settings = get_settings()
+        params = self._apply_linear_meeting_project_hint_prepass(text, params)
+        thread_reference_request = self._is_linear_thread_reference_request(text, params)
         source_result = await self._build_linear_meeting_source_result(
             text=text,
             params=params,
             thread_history=thread_history,
             event_files=event_files,
             settings=settings,
+            current_message_ts=current_message_ts,
+            exclude_current_message=thread_reference_request,
         )
         transcript = source_result.combined_text()
         if len(transcript.split()) < 8:
@@ -1565,6 +1571,17 @@ Keep the response concise but informative."""
             projects=projects,
         )
         project_update_requested = self._linear_meeting_project_update_requested(text, params)
+        contextual_review_mode = False
+        if not candidates and thread_reference_request and not project_update_requested:
+            contextual_candidate = await self._extract_linear_thread_context_candidate(
+                sources=source_result.sources,
+                params=params,
+                users=users,
+                projects=projects,
+            )
+            if contextual_candidate:
+                candidates = [contextual_candidate]
+                contextual_review_mode = True
         if not candidates and not project_update_requested:
             return {
                 "message": (
@@ -1623,6 +1640,8 @@ Keep the response concise but informative."""
 
         for raw_candidate in candidates[:20]:
             candidate = self._normalize_linear_meeting_candidate(raw_candidate)
+            if raw_candidate.get("contextual_review_only"):
+                candidate["contextual_review_only"] = True
             if not candidate.get("title"):
                 continue
 
@@ -1653,6 +1672,8 @@ Keep the response concise but informative."""
                 auto_threshold=auto_threshold,
                 uncertain_threshold=uncertain_threshold,
             )
+            if candidate.get("contextual_review_only") and decision == "create":
+                decision = "review"
 
             issue_input = self._build_linear_meeting_issue_input(
                 candidate=candidate,
@@ -1702,7 +1723,15 @@ Keep the response concise but informative."""
                 review_needed.append({**display, "pending_id": pending_id})
                 continue
 
-            skipped.append({**display, "reason": "Low confidence mapping"})
+            skip_reason = "Low confidence mapping"
+            if candidate.get("contextual_review_only"):
+                if float(owner_match.get("confidence") or 0.0) < uncertain_threshold:
+                    skip_reason = "Assignee unclear; mention who should own this and I can add it to Linear."
+                elif float(project_match.get("confidence") or 0.0) < uncertain_threshold:
+                    skip_reason = "Project unclear; mention the Linear project and I can add it."
+                elif float(team_match.get("confidence") or 0.0) < uncertain_threshold:
+                    skip_reason = "Linear team unclear; mention the team and I can add it."
+            skipped.append({**display, "reason": skip_reason})
 
         message = self._format_linear_meeting_result_message(
             created,
@@ -1710,6 +1739,7 @@ Keep the response concise but informative."""
             skipped,
             project_update=project_update,
             project_update_error=project_update_error,
+            contextual_review_mode=contextual_review_mode,
         )
         message += self._format_linear_meeting_source_warnings(source_result.warnings)
         blocks = (
@@ -1761,6 +1791,8 @@ Keep the response concise but informative."""
         thread_history: Optional[List[dict]],
         event_files: Optional[List[dict]],
         settings: Any,
+        current_message_ts: Optional[str] = None,
+        exclude_current_message: bool = False,
     ) -> SourceParseResult:
         image_parser = None
         if getattr(settings, "OPENAI_API_KEY", None):
@@ -1783,6 +1815,8 @@ Keep the response concise but informative."""
             thread_history=thread_history,
             event_files=event_files,
             image_parser=image_parser,
+            current_message_ts=current_message_ts,
+            exclude_current_message=exclude_current_message,
         )
 
     def _format_linear_meeting_source_warnings(self, warnings: list[str]) -> str:
@@ -1794,6 +1828,143 @@ Keep the response concise but informative."""
         if len(warnings) > 8:
             lines.append(f"- {len(warnings) - 8} more source note(s) omitted.")
         return "\n".join(lines)
+
+    def _apply_linear_meeting_project_hint_prepass(
+        self,
+        text: str,
+        params: dict,
+    ) -> dict:
+        if params.get("project_hint"):
+            return params
+        project_hint = self._extract_linear_meeting_project_hint_from_text(text)
+        if not project_hint:
+            return params
+        return {**params, "project_hint": project_hint}
+
+    def _extract_linear_meeting_project_hint_from_text(self, text: str) -> Optional[str]:
+        value = str(text or "").strip()
+        quoted_patterns = (
+            r'\blinear\s+project\s+(?:called|named)\s+["“]([^"”]+)["”]',
+            r'\bproject\s+(?:called|named)\s+["“]([^"”]+)["”]',
+        )
+        for pattern in quoted_patterns:
+            match = re.search(pattern, value, flags=re.IGNORECASE)
+            if match:
+                return self._clean_linear_meeting_project_hint(match.group(1))
+
+        unquoted_patterns = (
+            r'\bproject\s+(?:called|named)\s+([A-Za-z0-9][A-Za-z0-9 _/&-]{1,80}?)(?=\s+(?:and|with|please|from|as)\b|[.!?,;]|$)',
+            r'\bto\s+(?:the\s+)?linear\s+project\s+([A-Za-z0-9][A-Za-z0-9 _/&-]{1,80}?)(?=\s+(?:and|with|please|from|as)\b|[.!?,;]|$)',
+        )
+        for pattern in unquoted_patterns:
+            match = re.search(pattern, value, flags=re.IGNORECASE)
+            if match:
+                return self._clean_linear_meeting_project_hint(match.group(1))
+        return None
+
+    @staticmethod
+    def _clean_linear_meeting_project_hint(value: str) -> Optional[str]:
+        cleaned = str(value or "").strip(" \t\n\r'\"“”`")
+        return cleaned or None
+
+    def _is_linear_thread_reference_request(self, text: str, params: dict[str, Any]) -> bool:
+        normalized = str(text or "").lower()
+        if "linear" not in normalized:
+            return False
+        if self._normalize_match_text(params.get("action")) in {"threadreference", "addthread", "addthis"}:
+            return True
+        reference = r'(?:this|that|above|thread|conversation|message|discussion)'
+        return bool(
+            re.search(rf'\b(?:add|put|send|sync|create)\b.*\b{reference}\b.*\blinear\b', normalized)
+            or re.search(rf'\blinear\b.*\b(?:add|put|send|sync|create)\b.*\b{reference}\b', normalized)
+        )
+
+    async def _extract_linear_thread_context_candidate(
+        self,
+        *,
+        sources: list[ParsedSource],
+        params: dict,
+        users: list[dict[str, Any]],
+        projects: list[dict[str, Any]],
+    ) -> Optional[dict[str, Any]]:
+        source_excerpt = "\n\n".join(
+            chunk
+            for source in sources
+            for chunk in source_text_chunks(source, max_chars=5000)[:1]
+        )[:12000]
+        if len(source_excerpt.split()) < 8:
+            return None
+
+        project_names = ", ".join(
+            str(project.get("name") or project.get("slugId") or "")
+            for project in projects[:40]
+            if project.get("name") or project.get("slugId")
+        )
+        user_names = ", ".join(
+            str(user.get("displayName") or user.get("name") or user.get("email") or "")
+            for user in users[:80]
+            if user.get("displayName") or user.get("name") or user.get("email")
+        )
+        prompt = f"""Draft exactly one possible Linear issue from the referenced Slack thread.
+
+This is not a formal meeting transcript. The user asked Roo to add the thread context to Linear, so infer the likely follow-up item from the prior conversation only.
+
+Rules:
+- Return null if the thread is too vague to turn into one useful Linear issue.
+- Do not create a task called "add this to Linear" or similar.
+- For a discussion or decision, write the issue as a concrete follow-up such as "Decide ..." or "Confirm ...".
+- Infer the owner from direct address, mentions, and conversational responsibility. Prefer an exact Slack mention token like <@U123> when present.
+- Use the explicit project hint if present.
+
+Project hint: {params.get("project_hint") or "none"}
+Known Linear projects: {project_names or "none loaded"}
+Known Linear users: {user_names or "none loaded"}
+
+Referenced Slack thread:
+{source_excerpt}
+
+Return JSON only with this shape:
+{{
+  "issue": {{
+    "title": "imperative issue title",
+    "description": "one or two sentence issue description",
+    "owner_hint": "person, Slack mention, or email",
+    "project_hint": "project name if clear",
+    "team_hint": "team if clear",
+    "evidence": "short phrase from the thread",
+    "source_label": "Slack thread",
+    "confidence": 0.0
+  }}
+}}"""
+        settings = get_settings()
+        response = await chat(
+            [
+                {"role": "system", "content": "You draft one review-only Linear issue from Slack context. Return valid JSON only."},
+                {"role": "user", "content": prompt},
+            ],
+            model=getattr(settings, "LINEAR_MEETING_LLM_MODEL", "gpt-5.5"),
+            reasoning_effort=getattr(settings, "LINEAR_MEETING_LLM_REASONING_EFFORT", "low"),
+        )
+        content = response.content.strip()
+        if content.startswith("```"):
+            content = re.sub(r"^```\w*\n?", "", content)
+            content = re.sub(r"\n?```$", "", content)
+        try:
+            parsed = json.loads(content)
+        except json.JSONDecodeError:
+            return None
+        issue = parsed.get("issue") if isinstance(parsed, dict) else None
+        if not isinstance(issue, dict):
+            return None
+        candidate = self._normalize_linear_meeting_candidate(issue)
+        if not candidate.get("title"):
+            return None
+        if params.get("project_hint") and not candidate.get("project_hint"):
+            candidate["project_hint"] = str(params["project_hint"])
+        candidate["contextual_review_only"] = True
+        candidate["source_label"] = candidate.get("source_label") or "Slack thread"
+        candidate["priority"] = candidate.get("priority", 3)
+        return candidate
 
     async def _extract_linear_meeting_candidates_from_sources(
         self,
@@ -2524,6 +2695,7 @@ Extracted action candidates:
             "project": project.get("name") or "Unresolved",
             "team": team.get("key") or team.get("name") or "Unresolved",
             "source": candidate.get("source_label") or "Slack thread",
+            "evidence": candidate.get("evidence") or "",
             "confidence": confidence,
             "owner_reason": owner_match.get("reason"),
             "project_reason": project_match.get("reason"),
@@ -2556,6 +2728,7 @@ Extracted action candidates:
         *,
         project_update: Optional[dict[str, Any]] = None,
         project_update_error: Optional[str] = None,
+        contextual_review_mode: bool = False,
     ) -> str:
         lines: list[str] = []
         if project_update:
@@ -2570,6 +2743,11 @@ Extracted action candidates:
                 lines.append(f"Created Linear project update: {project_update_label}")
         elif project_update_error:
             lines.append(project_update_error)
+
+        if contextual_review_mode and review_needed:
+            if lines:
+                lines.append("")
+            lines.append("I found a possible Linear issue from this thread. Please review before I create it.")
 
         if created:
             if lines:
@@ -2619,6 +2797,8 @@ Extracted action candidates:
                 f"Project: `{item['project']}` | Assignee: `{item['assignee']}` | "
                 f"Confidence: `{item['confidence']:.0%}` | Source: `{item.get('source', 'Slack thread')}`"
             )
+            if item.get("evidence"):
+                summary += f"\nEvidence: “{item['evidence']}”"
             value = json.dumps({"pending_id": pending_id, "requested_by": user_id})
             blocks.extend([
                 {"type": "section", "text": {"type": "mrkdwn", "text": summary[:2500]}},

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -145,6 +145,30 @@ def test_linear_file_context_routes_short_attached_file_request():
     assert skill.name == "linear-meeting-actions"
 
 
+def test_linear_thread_reference_routes_when_thread_context_exists():
+    agent = _make_agent()
+
+    for text in [
+        '@Roo add this to the Linear project called "BITGET EVENT"',
+        "add this thread to Linear project BITGET EVENT",
+        "put the above in Linear project called BITGET EVENT",
+    ]:
+        skill = agent._select_skill_from_triggers(
+            text,
+            has_thread_context=True,
+        )
+        assert skill is not None
+        assert skill.name == "linear-meeting-actions"
+
+
+def test_linear_thread_reference_does_not_route_without_context():
+    agent = _make_agent()
+
+    skill = agent._select_skill_from_triggers("add this to Linear")
+
+    assert skill is None
+
+
 def test_request_points_phrase_routes_to_points():
     agent = _make_agent()
 

--- a/roo-standalone/roo/tests/test_linear_meeting_actions.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_actions.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -78,6 +79,51 @@ def test_linear_meeting_project_matches_explicit_hint():
 
     assert match["project"]["id"] == "proj-1"
     assert match["confidence"] >= 0.9
+
+
+def test_linear_meeting_project_hint_prepass_extracts_named_project():
+    executor = SkillExecutor()
+
+    params = executor._apply_linear_meeting_project_hint_prepass(
+        '@Roo add this to the Linear project called “BITGET EVENT”',
+        {},
+    )
+
+    assert params["project_hint"] == "BITGET EVENT"
+
+
+@pytest.mark.asyncio
+async def test_linear_thread_reference_source_excludes_current_command():
+    executor = SkillExecutor()
+
+    result = await executor._build_linear_meeting_source_result(
+        text='@Roo add this to the Linear project called "BITGET EVENT"',
+        params={},
+        thread_history=[
+            {
+                "user": "U1",
+                "text": "<@UYANA> should decide whether the event name leans into finance bro stereotypes.",
+                "ts": "1.1",
+                "is_bot": False,
+            },
+            {"user": "B1", "text": "Bot message", "ts": "1.2", "is_bot": True},
+            {
+                "user": "U2",
+                "text": '@Roo add this to the Linear project called "BITGET EVENT"',
+                "ts": "1.3",
+                "is_bot": False,
+            },
+        ],
+        event_files=[],
+        settings=SimpleNamespace(OPENAI_API_KEY=None),
+        current_message_ts="1.3",
+        exclude_current_message=True,
+    )
+
+    combined = result.combined_text()
+    assert "finance bro stereotypes" in combined
+    assert "Bot message" not in combined
+    assert "@Roo add this" not in combined
 
 
 def test_linear_meeting_duplicate_detection_uses_similar_open_issue_title():
@@ -687,3 +733,323 @@ async def test_linear_meeting_executor_creates_project_update_when_requested(mon
 
     assert created_updates == [{"project_id": "project-1", "body": "Meeting update", "health": "onTrack"}]
     assert "Created Linear project update" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_linear_thread_reference_fallback_requires_review(monkeypatch):
+    executor = SkillExecutor()
+    executor_module.LINEAR_MEETING_PENDING_ACTIONS.clear()
+    create_calls = []
+
+    async def fake_source_result(**kwargs):
+        assert kwargs["exclude_current_message"] is True
+        assert kwargs["current_message_ts"] == "1.2"
+        return SourceParseResult(
+            sources=[
+                ParsedSource(
+                    label="Slack thread",
+                    text="<@UYANA> should decide whether the AI Meets Markets event leans into finance bro stereotypes.",
+                    kind="slack_text",
+                )
+            ]
+        )
+
+    async def no_concrete_candidates(**kwargs):
+        return []
+
+    async def contextual_candidate(**kwargs):
+        return {
+            "title": "Decide AI Meets Markets event positioning and naming",
+            "description": "Decide whether the event should lean into finance bro stereotypes and confirm the name.",
+            "owner_hint": "<@UYANA>",
+            "project_hint": "BITGET EVENT",
+            "evidence": "Can we go full finance bro...",
+            "source_label": "Slack thread",
+            "confidence": 0.95,
+            "contextual_review_only": True,
+        }
+
+    team = {"id": "team-1", "key": "MKT", "name": "Marketing"}
+    user = {"id": "user-1", "name": "Yana", "displayName": "Yana", "email": "yana@example.com"}
+    project = {
+        "id": "project-1",
+        "name": "BITGET EVENT",
+        "teams": {"nodes": [team]},
+        "members": {"nodes": [user]},
+    }
+
+    class FakeClient:
+        async def list_teams(self):
+            return [team]
+
+        async def list_users(self):
+            return [user]
+
+        async def list_active_projects(self):
+            return [project]
+
+        async def list_issue_labels(self):
+            return []
+
+        async def list_recent_open_issues(self):
+            return []
+
+        async def create_issue(self, **kwargs):
+            create_calls.append(kwargs)
+            return {"identifier": "MKT-1", "title": kwargs["title"]}
+
+    class FakeSkill:
+        def get_client_class(self, name):
+            assert name == "LinearMeetingActionsClient"
+            return FakeClient
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            LINEAR_DEFAULT_TEAM=None,
+            LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE=0.85,
+            LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE=0.65,
+        ),
+    )
+    monkeypatch.setattr("roo.slack_client.get_user_info", lambda user_id: {"email": "yana@example.com"})
+    monkeypatch.setattr(executor, "_build_linear_meeting_source_result", fake_source_result)
+    monkeypatch.setattr(executor, "_extract_linear_meeting_candidates_from_sources", no_concrete_candidates)
+    monkeypatch.setattr(executor, "_extract_linear_thread_context_candidate", contextual_candidate)
+
+    result = await executor._execute_linear_meeting_actions(
+        skill=FakeSkill(),
+        text='@Roo add this to the Linear project called "BITGET EVENT"',
+        params={},
+        user_id="UASKER",
+        channel_id="C1",
+        thread_ts="1.1",
+        thread_history=[],
+        event_files=[],
+        current_message_ts="1.2",
+    )
+
+    assert create_calls == []
+    assert result["data"]["created_count"] == 0
+    assert result["data"]["review_count"] == 1
+    assert "Please review before I create it" in result["message"]
+    assert result["blocks"]
+    assert "Can we go full finance bro" in str(result["blocks"])
+    pending = next(iter(executor_module.LINEAR_MEETING_PENDING_ACTIONS.values()))
+    assert pending["issue_input"]["title"] == "Decide AI Meets Markets event positioning and naming"
+    assert pending["issue_input"]["project_id"] == "project-1"
+    assert pending["issue_input"]["assignee_id"] == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_linear_thread_reference_fallback_skips_when_assignee_unresolved(monkeypatch):
+    executor = SkillExecutor()
+
+    async def fake_source_result(**kwargs):
+        return SourceParseResult(
+            sources=[
+                ParsedSource(
+                    label="Slack thread",
+                    text="The team discussed whether AI Meets Markets should use a finance bro theme.",
+                    kind="slack_text",
+                )
+            ]
+        )
+
+    async def no_concrete_candidates(**kwargs):
+        return []
+
+    async def contextual_candidate(**kwargs):
+        return {
+            "title": "Decide AI Meets Markets event positioning and naming",
+            "description": "Confirm the event positioning and name.",
+            "owner_hint": "Someone",
+            "project_hint": "BITGET EVENT",
+            "evidence": "finance bro theme",
+            "source_label": "Slack thread",
+            "confidence": 0.95,
+            "contextual_review_only": True,
+        }
+
+    team = {"id": "team-1", "key": "MKT", "name": "Marketing"}
+    project = {
+        "id": "project-1",
+        "name": "BITGET EVENT",
+        "teams": {"nodes": [team]},
+        "members": {"nodes": []},
+    }
+
+    class FakeClient:
+        async def list_teams(self):
+            return [team]
+
+        async def list_users(self):
+            return []
+
+        async def list_active_projects(self):
+            return [project]
+
+        async def list_issue_labels(self):
+            return []
+
+        async def list_recent_open_issues(self):
+            return []
+
+        async def create_issue(self, **kwargs):
+            raise AssertionError("contextual issue with unresolved owner should not be created")
+
+    class FakeSkill:
+        def get_client_class(self, name):
+            assert name == "LinearMeetingActionsClient"
+            return FakeClient
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            LINEAR_DEFAULT_TEAM=None,
+            LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE=0.85,
+            LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE=0.65,
+        ),
+    )
+    monkeypatch.setattr(executor, "_build_linear_meeting_source_result", fake_source_result)
+    monkeypatch.setattr(executor, "_extract_linear_meeting_candidates_from_sources", no_concrete_candidates)
+    monkeypatch.setattr(executor, "_extract_linear_thread_context_candidate", contextual_candidate)
+
+    result = await executor._execute_linear_meeting_actions(
+        skill=FakeSkill(),
+        text='@Roo add this to the Linear project called "BITGET EVENT"',
+        params={},
+        user_id="UASKER",
+        channel_id="C1",
+        thread_ts="1.1",
+        thread_history=[],
+        event_files=[],
+        current_message_ts="1.2",
+    )
+
+    assert result["data"]["review_count"] == 0
+    assert result["data"]["skipped_count"] == 1
+    assert "Assignee unclear" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_linear_meeting_slack_approval_creates_contextual_issue(monkeypatch):
+    import importlib
+    import roo.main as main_module
+
+    live_executor_module = importlib.import_module("roo.skills.executor")
+    live_executor_module.LINEAR_MEETING_PENDING_ACTIONS.clear()
+    pending_id = "pending-contextual-1"
+    issue_input = {
+        "title": "Decide AI Meets Markets event positioning and naming",
+        "team_id": "team-1",
+        "description": "Meeting action description",
+        "assignee_id": "user-1",
+        "project_id": "project-1",
+        "priority": 3,
+        "due_date": None,
+        "label_ids": [],
+    }
+    live_executor_module.LINEAR_MEETING_PENDING_ACTIONS[pending_id] = {
+        "requested_by": "UASKER",
+        "issue_input": issue_input,
+        "display": {"title": issue_input["title"]},
+        "reason": "Needs approval",
+    }
+    create_calls = []
+    posted_messages = []
+
+    class FakeClient:
+        async def create_issue(self, **kwargs):
+            create_calls.append(kwargs)
+            return {
+                "identifier": "MKT-42",
+                "title": kwargs["title"],
+                "url": "https://linear.test/MKT-42",
+            }
+
+    class FakeSkill:
+        def get_client_class(self, name):
+            assert name == "LinearMeetingActionsClient"
+            return FakeClient
+
+    class FakeAgent:
+        def _get_skill_by_name(self, name):
+            assert name == "linear-meeting-actions"
+            return FakeSkill()
+
+    class FakeRequest:
+        async def form(self):
+            return {
+                "payload": json.dumps(
+                    {
+                        "user": {"id": "UASKER"},
+                        "channel": {"id": "C1"},
+                        "message": {"ts": "1.2", "thread_ts": "1.1"},
+                        "actions": [
+                            {
+                                "action_id": "linear_meeting_approve",
+                                "value": json.dumps(
+                                    {"pending_id": pending_id, "requested_by": "UASKER"}
+                                ),
+                            }
+                        ],
+                    }
+                )
+            }
+
+    monkeypatch.setattr(main_module, "get_agent", lambda: FakeAgent())
+    monkeypatch.setattr(main_module, "post_message", lambda **kwargs: posted_messages.append(kwargs))
+
+    response = await main_module.slack_actions(FakeRequest())
+
+    assert response.status_code == 200
+    assert create_calls == [issue_input]
+    assert pending_id not in live_executor_module.LINEAR_MEETING_PENDING_ACTIONS
+    assert "Created <https://linear.test/MKT-42|MKT-42>" in posted_messages[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_linear_meeting_slack_reject_clears_contextual_issue(monkeypatch):
+    import importlib
+    import roo.main as main_module
+
+    live_executor_module = importlib.import_module("roo.skills.executor")
+    live_executor_module.LINEAR_MEETING_PENDING_ACTIONS.clear()
+    pending_id = "pending-contextual-2"
+    live_executor_module.LINEAR_MEETING_PENDING_ACTIONS[pending_id] = {
+        "requested_by": "UASKER",
+        "issue_input": {"title": "Decide event positioning"},
+        "display": {"title": "Decide event positioning"},
+        "reason": "Needs approval",
+    }
+    posted_messages = []
+
+    class FakeRequest:
+        async def form(self):
+            return {
+                "payload": json.dumps(
+                    {
+                        "user": {"id": "UASKER"},
+                        "channel": {"id": "C1"},
+                        "message": {"ts": "1.2", "thread_ts": "1.1"},
+                        "actions": [
+                            {
+                                "action_id": "linear_meeting_reject",
+                                "value": json.dumps(
+                                    {"pending_id": pending_id, "requested_by": "UASKER"}
+                                ),
+                            }
+                        ],
+                    }
+                )
+            }
+
+    monkeypatch.setattr(main_module, "post_message", lambda **kwargs: posted_messages.append(kwargs))
+
+    response = await main_module.slack_actions(FakeRequest())
+
+    assert response.status_code == 200
+    assert pending_id not in live_executor_module.LINEAR_MEETING_PENDING_ACTIONS
+    assert posted_messages[0]["text"] == "Skipped Linear issue creation for: Decide event positioning"

--- a/roo-standalone/roo/tests/test_linear_meeting_routing.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_routing.py
@@ -73,3 +73,17 @@ def test_linear_file_context_routes_short_attached_file_request():
 
     assert skill is not None
     assert skill.name == "linear-meeting-actions"
+
+
+def test_linear_thread_reference_routes_only_with_context():
+    agent = _make_agent()
+
+    assert agent._select_skill_from_triggers("add this to Linear") is None
+
+    skill = agent._select_skill_from_triggers(
+        '@Roo add this to the Linear project called "BITGET EVENT"',
+        has_thread_context=True,
+    )
+
+    assert skill is not None
+    assert skill.name == "linear-meeting-actions"

--- a/roo-standalone/skills/linear_meeting_actions/SKILL.md
+++ b/roo-standalone/skills/linear_meeting_actions/SKILL.md
@@ -31,6 +31,7 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
 ## Capabilities
 
 - Parse Slack message/thread text and supported attached files for concrete to-do items.
+- Draft a review-only Linear issue from a discussion thread when the user asks to add "this" or "the thread" to Linear.
 - Create a Linear project update when the request explicitly asks for a project update and Roo can confidently match the project.
 - Download and parse `.pdf`, `.docx`, `.txt`, `.md`, `.csv`, `.png`, `.jpg`, `.jpeg`, `.webp`, and non-animated `.gif` files from the current Slack thread.
 - Inspect Linear teams, users, active projects, project members, labels, and recent open issues.
@@ -58,16 +59,18 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
    - Recent open issues for duplicate detection
 3. Extract concrete action items into structured candidates with title, description, owner hint, project hint, due date, priority, evidence, source label, and confidence.
 4. If a project update was requested, create one for the matched Linear project.
-5. Match owners by Slack mention/email first, then Linear user email, then display/name similarity.
-6. Match projects by explicit project hint, name/slug similarity, and project membership context.
-7. Create only high-confidence, non-duplicate candidates.
-8. Present uncertain candidates in Slack with Approve and Reject buttons.
-9. Report created project updates, created issues, skipped duplicates, and unresolved items clearly.
+5. If no concrete action item is found but the user asked to add the thread context to Linear, draft one contextual issue and require Slack approval before creation.
+6. Match owners by Slack mention/email first, then Linear user email, then display/name similarity.
+7. Match projects by explicit project hint, name/slug similarity, and project membership context.
+8. Create only high-confidence, non-duplicate concrete candidates.
+9. Present uncertain or contextual candidates in Slack with Approve and Reject buttons.
+10. Report created project updates, created issues, skipped duplicates, and unresolved items clearly.
 
 ## Creation Rules
 
 - Do not create an issue without a matched Linear team.
 - Do not auto-create an issue without a high-confidence assignee and project.
+- Do not auto-create contextual discussion-thread issues; always request Slack approval first.
 - Apply the `meeting-action` label if it already exists. If it does not exist, create the issue without labels.
 - Issue descriptions must include the meeting context, evidence snippet, Slack source identifiers when available, and a note that Roo generated the issue from meeting notes.
 


### PR DESCRIPTION
## Summary\n- route Slack prompts like "add this to Linear project called X" to linear-meeting-actions when there is thread or file context\n- exclude the current Roo command from evidence for thread-reference requests\n- draft one contextual Linear issue from discussion threads and force Slack approval before creation\n- pre-parse quoted/named Linear project hints for stable project matching\n- cover Slack approve/reject for contextual pending issues\n\n## Tests\n- /tmp/roo-local-venv/bin/python -m pytest roo-standalone/roo/tests/test_linear_meeting_actions.py roo-standalone/roo/tests/test_linear_meeting_routing.py roo-standalone/roo/tests/test_agent_routing.py roo-standalone/roo/tests/test_linear_meeting_sources.py\n- /tmp/roo-local-venv/bin/python -m pytest roo-standalone/roo/tests (fails: 5 existing Content Factory Slack action tests unrelated to this change)