### PR TITLE
Improve direct Linear issue commands

### DIFF
--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -443,6 +443,8 @@ class RooAgent:
         has_creation_intent = bool(
             re.search(r'\b(extract|sync|turn|send|put|create|add|do|write|post|generate|summari[sz]e|tickets?|issues?|tasks?)\b', text)
         )
+        if self._looks_like_linear_direct_issue_request(text):
+            return True
         if self._looks_like_linear_project_update_request(text, has_file_context):
             return True
         if has_linear and has_meeting_source and has_creation_intent:
@@ -463,6 +465,26 @@ class RooAgent:
             re.search(r'\b(linear|meeting|transcript|summary|notes?|file|pdf|docx?|document|image|screenshot)\b', text)
         )
         return has_update_intent and has_source_context
+
+    def _looks_like_linear_direct_issue_request(self, text: str) -> bool:
+        if not re.search(r'\blinear\b', text):
+            return False
+        if re.search(r'\b(points?|rewards?|coworking|allowance|worth\s+\d+\s+points?)\b', text):
+            return False
+        if re.search(r'\bproject\s+updates?\b', text):
+            return False
+        has_creation_intent = bool(re.search(r'\b(create|add|open|file|make)\b', text))
+        has_issue_noun = bool(
+            re.search(r'\b(?:to\s*do\s+items?|todo\s+items?|tasks?|issues?|tickets?)\b', text)
+        )
+        has_linear_project = bool(
+            re.search(
+                r'\blinear\s+project\b|\bproject\s+(?:called|named)\b|'
+                r'\blinear\s+(?:tasks?|issues?|tickets?|to\s*do\s+items?)\s+(?:in|to|under)\b',
+                text,
+            )
+        )
+        return has_creation_intent and has_issue_noun and has_linear_project
 
     def _looks_like_content_follow_up(self, text: str) -> bool:
         patterns = (

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -1525,6 +1525,8 @@ Keep the response concise but informative."""
     ) -> dict:
         settings = get_settings()
         params = self._apply_linear_meeting_project_hint_prepass(text, params)
+        params = self._apply_linear_meeting_owner_hint_prepass(text, params)
+        direct_issue_request = self._is_linear_direct_issue_request(text, params)
         thread_reference_request = self._is_linear_thread_reference_request(text, params)
         source_result = await self._build_linear_meeting_source_result(
             text=text,
@@ -1536,7 +1538,7 @@ Keep the response concise but informative."""
             exclude_current_message=thread_reference_request,
         )
         transcript = source_result.combined_text()
-        if len(transcript.split()) < 8:
+        if len(transcript.split()) < 8 and not direct_issue_request:
             warning_suffix = self._format_linear_meeting_source_warnings(source_result.warnings)
             return {
                 "message": (
@@ -1564,12 +1566,20 @@ Keep the response concise but informative."""
                 "message": f"I couldn't read Linear context yet: {detail}"
             }
 
-        candidates = await self._extract_linear_meeting_candidates_from_sources(
-            sources=source_result.sources,
-            params=params,
-            users=users,
-            projects=projects,
-        )
+        if direct_issue_request:
+            candidates = await self._extract_linear_direct_issue_candidates(
+                text=text,
+                params=params,
+                users=users,
+                projects=projects,
+            )
+        else:
+            candidates = await self._extract_linear_meeting_candidates_from_sources(
+                sources=source_result.sources,
+                params=params,
+                users=users,
+                projects=projects,
+            )
         project_update_requested = self._linear_meeting_project_update_requested(text, params)
         contextual_review_mode = False
         if not candidates and thread_reference_request and not project_update_requested:
@@ -1724,7 +1734,13 @@ Keep the response concise but informative."""
                 review_needed.append({**display, "pending_id": pending_id})
                 continue
 
-            skip_reason = "Low confidence mapping"
+            skip_reason = self._linear_meeting_skip_reason(
+                candidate,
+                owner_match,
+                project_match,
+                team_match,
+                uncertain_threshold,
+            )
             if candidate.get("contextual_review_only"):
                 if float(owner_match.get("confidence") or 0.0) < uncertain_threshold:
                     skip_reason = "Assignee unclear; mention who should own this and I can add it to Linear."
@@ -1842,31 +1858,102 @@ Keep the response concise but informative."""
             return params
         return {**params, "project_hint": project_hint}
 
+    def _apply_linear_meeting_owner_hint_prepass(
+        self,
+        text: str,
+        params: dict,
+    ) -> dict:
+        if params.get("owner_hint") or params.get("owner"):
+            return params
+        owner_hint = self._extract_linear_meeting_owner_hint_from_text(text)
+        if not owner_hint:
+            return params
+        return {**params, "owner_hint": owner_hint}
+
     def _extract_linear_meeting_project_hint_from_text(self, text: str) -> Optional[str]:
         value = str(text or "").strip()
-        quoted_patterns = (
-            r'\blinear\s+project\s+(?:called|named)\s+["“]([^"”]+)["”]',
-            r'\bproject\s+(?:called|named)\s+["“]([^"”]+)["”]',
-        )
-        for pattern in quoted_patterns:
+        for pattern in self._linear_meeting_project_hint_patterns():
             match = re.search(pattern, value, flags=re.IGNORECASE)
             if match:
-                return self._clean_linear_meeting_project_hint(match.group(1))
+                project_hint = self._clean_linear_meeting_project_hint(match.group(1))
+                normalized_hint = self._normalize_match_text(project_hint)
+                if project_hint and normalized_hint not in {"update", "updates"} and not normalized_hint.startswith("update"):
+                    return project_hint
 
-        unquoted_patterns = (
-            r'\bproject\s+(?:called|named)\s+([A-Za-z0-9][A-Za-z0-9 _/&-]{1,80}?)(?=\s+(?:and|with|please|from|as)\b|[.!?,;]|$)',
-            r'\bto\s+(?:the\s+)?linear\s+project\s+([A-Za-z0-9][A-Za-z0-9 _/&-]{1,80}?)(?=\s+(?:and|with|please|from|as)\b|[.!?,;]|$)',
-        )
-        for pattern in unquoted_patterns:
-            match = re.search(pattern, value, flags=re.IGNORECASE)
-            if match:
-                return self._clean_linear_meeting_project_hint(match.group(1))
         return None
 
     @staticmethod
+    def _linear_meeting_project_hint_patterns() -> tuple[str, ...]:
+        quoted = r'["\'“”‘’]([^"\'“”‘’]+)["\'“”‘’]'
+        unquoted = (
+            r'([A-Za-z0-9][A-Za-z0-9 _/&-]{1,80}?)'
+            r'(?=\s+(?:to|and|assign|assigned|with|please|from|as|for|due|by)\b|[.!?,;]|$)'
+        )
+        return (
+            rf'\b(?:in|into|to|under)\s+(?:the\s+)?linear\s+project\s+{quoted}',
+            rf'\blinear\s+project\s+{quoted}',
+            rf'\b(?:in|into|to|under)\s+(?:the\s+)?project\s+{quoted}',
+            rf'\bproject\s+(?:called|named)\s+{quoted}',
+            rf'\bproject\s+{quoted}',
+            rf'\b(?:in|into|to|under)\s+(?:the\s+)?linear\s+project\s+{unquoted}',
+            rf'\bto\s+linear\s+project\s+{unquoted}',
+            rf'\bproject\s+(?:called|named)\s+{unquoted}',
+            rf'\b(?:in|into|to|under)\s+(?:the\s+)?project\s+{unquoted}',
+            rf'\bproject\s+{unquoted}',
+        )
+
+    @staticmethod
     def _clean_linear_meeting_project_hint(value: str) -> Optional[str]:
-        cleaned = str(value or "").strip(" \t\n\r'\"“”`")
+        cleaned = str(value or "").strip(" \t\n\r'\"“”‘’`")
         return cleaned or None
+
+    def _extract_linear_meeting_owner_hint_from_text(self, text: str) -> Optional[str]:
+        value = str(text or "").strip()
+        mention_assignment = re.search(
+            r'\b(?:assign(?:ed)?(?:\s+(?:it|this|task|issue))?\s+to|assignee\s*:|owner\s*:)\s*(<@[A-Z0-9]+>)',
+            value,
+            flags=re.IGNORECASE,
+        )
+        if mention_assignment:
+            return mention_assignment.group(1)
+
+        assignment = re.search(
+            r'\b(?:assign(?:ed)?(?:\s+(?:it|this|task|issue))?\s+to|assignee\s*:|owner\s*:)\s*'
+            r'(.+?)(?=\s+(?:in|to|under)\s+(?:the\s+)?linear\s+project\b|[.!?]\s|$)',
+            value,
+            flags=re.IGNORECASE,
+        )
+        if assignment:
+            return self._clean_linear_meeting_owner_hint(assignment.group(1))
+
+        for_owner = re.search(
+            r'\bfor\s+(<@[A-Z0-9]+>|@?[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+){0,3})\s*$',
+            value,
+        )
+        if for_owner:
+            return self._clean_linear_meeting_owner_hint(for_owner.group(1))
+        return None
+
+    @staticmethod
+    def _clean_linear_meeting_owner_hint(value: str) -> Optional[str]:
+        cleaned = str(value or "").strip(" \t\n\r'\"“”`")
+        cleaned = re.sub(r'^(?:@|to\s+)', '', cleaned, flags=re.IGNORECASE).strip()
+        cleaned = re.sub(r'\s+', ' ', cleaned).strip(" ,;:")
+        return cleaned or None
+
+    def _is_linear_direct_issue_request(self, text: str, params: dict[str, Any]) -> bool:
+        value = str(text or "").lower()
+        if "linear" not in value:
+            return False
+        if re.search(r'\b(points?|rewards?|coworking|allowance|worth\s+\d+\s+points?)\b', value):
+            return False
+        if self._linear_meeting_project_update_requested(text, params):
+            return False
+        has_creation_intent = bool(re.search(r'\b(create|add|open|file|make)\b', value))
+        has_issue_noun = bool(
+            re.search(r'\b(?:to\s*do\s+items?|todo\s+items?|tasks?|issues?|tickets?)\b', value)
+        )
+        return has_creation_intent and has_issue_noun
 
     def _is_linear_thread_reference_request(self, text: str, params: dict[str, Any]) -> bool:
         normalized = str(text or "").lower()
@@ -1966,6 +2053,202 @@ Return JSON only with this shape:
         candidate["source_label"] = candidate.get("source_label") or "Slack thread"
         candidate["priority"] = candidate.get("priority", 3)
         return candidate
+
+    async def _extract_linear_direct_issue_candidates(
+        self,
+        *,
+        text: str,
+        params: dict,
+        users: list[dict[str, Any]],
+        projects: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        project_hint = str(params.get("project_hint") or "").strip()
+        if not project_hint:
+            project_hint = self._infer_linear_direct_project_hint_from_known_projects(text, projects)
+            if project_hint:
+                params = {**params, "project_hint": project_hint}
+        task_body = self._extract_linear_direct_issue_body(text, params)
+        if not task_body:
+            return []
+
+        owner_hint = str(params.get("owner_hint") or params.get("owner") or "").strip()
+        fallback = {
+            "title": self._linear_direct_issue_title_from_body(task_body),
+            "description": task_body,
+            "owner_hint": owner_hint,
+            "project_hint": project_hint,
+            "evidence": text[:700],
+            "source_label": "Slack command",
+            "confidence": 0.96,
+        }
+
+        project_names = ", ".join(
+            str(project.get("name") or project.get("slugId") or "")
+            for project in projects[:40]
+            if project.get("name") or project.get("slugId")
+        )
+        user_names = ", ".join(
+            str(user.get("displayName") or user.get("name") or user.get("email") or "")
+            for user in users[:80]
+            if user.get("displayName") or user.get("name") or user.get("email")
+        )
+        prompt = f"""Clean up this explicit Slack command into Linear issue fields.
+
+The user is directly asking Roo to create Linear issue(s). Do not ignore the command as a meta-instruction.
+Use the parsed task body as the work to create, not "create a Linear task" itself.
+
+Parsed project hint: {project_hint or "none"}
+Parsed assignee hint: {owner_hint or "none"}
+Parsed task body: {task_body}
+
+Known Linear projects: {project_names or "none loaded"}
+Known Linear users: {user_names or "none loaded"}
+
+Slack command:
+{text[:12000]}
+
+Return JSON only:
+{{
+  "issues": [
+    {{
+      "title": "imperative issue title",
+      "description": "one or two sentence issue description",
+      "owner_hint": "{owner_hint}",
+      "project_hint": "{project_hint}",
+      "due_date": null,
+      "priority": 3,
+      "evidence": "short phrase from the command",
+      "source_label": "Slack command",
+      "confidence": 0.96
+    }}
+  ]
+}}"""
+        settings = get_settings()
+        try:
+            response = await chat(
+                [
+                    {"role": "system", "content": "You convert explicit Slack commands into Linear issue fields. Return valid JSON only."},
+                    {"role": "user", "content": prompt},
+                ],
+                model=getattr(settings, "LINEAR_MEETING_LLM_MODEL", "gpt-5.5"),
+                reasoning_effort=getattr(settings, "LINEAR_MEETING_LLM_REASONING_EFFORT", "low"),
+            )
+            content = response.content.strip()
+            if content.startswith("```"):
+                content = re.sub(r"^```\w*\n?", "", content)
+                content = re.sub(r"\n?```$", "", content)
+            parsed = json.loads(content)
+        except Exception:
+            parsed = {}
+
+        issues = parsed.get("issues") if isinstance(parsed, dict) else []
+        candidates: list[dict[str, Any]] = []
+        for issue in issues or []:
+            if not isinstance(issue, dict):
+                continue
+            candidate = {
+                **fallback,
+                **issue,
+                "owner_hint": issue.get("owner_hint") or owner_hint,
+                "project_hint": issue.get("project_hint") or project_hint,
+                "source_label": issue.get("source_label") or "Slack command",
+                "evidence": issue.get("evidence") or text[:700],
+                "confidence": issue.get("confidence", 0.96),
+            }
+            normalized = self._normalize_linear_meeting_candidate(candidate)
+            if normalized.get("title"):
+                candidates.append(normalized)
+        return candidates or [fallback]
+
+    def _infer_linear_direct_project_hint_from_known_projects(
+        self,
+        text: str,
+        projects: list[dict[str, Any]],
+    ) -> str:
+        normalized_text = self._normalize_match_text(text)
+        matches: list[tuple[int, str]] = []
+        for project in projects:
+            name = str(project.get("name") or "").strip()
+            slug = str(project.get("slugId") or "").strip()
+            for value in (name, slug):
+                normalized_value = self._normalize_match_text(value)
+                if normalized_value and normalized_value in normalized_text:
+                    matches.append((len(normalized_value), name or slug))
+                    break
+        if not matches:
+            return ""
+        matches.sort(reverse=True)
+        return matches[0][1]
+
+    def _extract_linear_direct_issue_body(self, text: str, params: dict[str, Any]) -> str:
+        value = str(text or "").strip()
+        value = re.sub(r'<@[A-Z0-9]+>', ' ', value)
+        value = re.sub(r'\s+', ' ', value).strip()
+
+        assignment_pattern = (
+            r'\b(?:assign(?:ed)?(?:\s+(?:it|this|task|issue))?\s+to|assignee\s*:|owner\s*:)\b.*$'
+        )
+        without_assignment = re.sub(assignment_pattern, '', value, flags=re.IGNORECASE).strip(" ,.;:")
+
+        project_match = None
+        for pattern in self._linear_meeting_project_hint_patterns():
+            match = re.search(pattern, without_assignment, flags=re.IGNORECASE)
+            if match:
+                project_match = match
+                break
+
+        if project_match:
+            task_body = without_assignment[project_match.end():].strip()
+            if not task_body:
+                task_body = without_assignment[:project_match.start()].strip()
+        else:
+            task_body = without_assignment
+
+        project_hint = str(params.get("project_hint") or "").strip()
+        if project_hint:
+            hint_pattern = re.escape(project_hint)
+            direct_project_match = re.search(
+                rf'\b(?:in|into|to|under)\s+{hint_pattern}\b',
+                task_body,
+                flags=re.IGNORECASE,
+            )
+            if direct_project_match:
+                after_project = task_body[direct_project_match.end():].strip()
+                before_project = task_body[:direct_project_match.start()].strip()
+                task_body = after_project or before_project
+
+        task_body = re.sub(
+            r'^(?:please\s+)?(?:create|add|open|file|make)\s+(?:a|an|the)?\s*'
+            r'(?:linear\s+)?(?:(?:to\s*do|todo)\s+items?|tasks?|issues?|tickets?)\s*',
+            '',
+            task_body,
+            flags=re.IGNORECASE,
+        )
+        owner_hint = str(params.get("owner_hint") or params.get("owner") or "").strip()
+        if owner_hint:
+            task_body = re.sub(
+                rf'^\s*for\s+{re.escape(owner_hint)}\s*$',
+                '',
+                task_body,
+                flags=re.IGNORECASE,
+            )
+            task_body = re.sub(
+                rf'\s+\bfor\s+{re.escape(owner_hint)}\s*$',
+                '',
+                task_body,
+                flags=re.IGNORECASE,
+            )
+        task_body = re.sub(r'^(?:in|into|to|under|for|about|that|where|:|-)\s+', '', task_body, flags=re.IGNORECASE)
+        task_body = re.sub(r'\s+', ' ', task_body).strip(" ,.;:-")
+        return task_body
+
+    @staticmethod
+    def _linear_direct_issue_title_from_body(task_body: str) -> str:
+        title = str(task_body or "").strip()
+        title = re.sub(r'^(?:to\s+)+', '', title, flags=re.IGNORECASE).strip()
+        if not title:
+            return "Create Linear task"
+        return title[:1].upper() + title[1:]
 
     async def _extract_linear_meeting_candidates_from_sources(
         self,
@@ -2562,6 +2845,16 @@ Chunk {index} source: {label}
                 return {"user": user, "confidence": 0.98, "reason": "Matched owner by email"}
 
         normalized_hint = self._normalize_match_text(hint)
+        plain_matches = self._find_unique_linear_user_name_matches(hint, users)
+        if len(plain_matches) == 1:
+            return {
+                "user": plain_matches[0],
+                "confidence": 0.94,
+                "reason": "Matched owner by unique name",
+            }
+        if len(plain_matches) > 1:
+            return {"user": None, "confidence": 0.0, "reason": "Ambiguous owner hint"}
+
         best_user = None
         best_score = 0.0
         best_reason = "No user match"
@@ -2590,6 +2883,52 @@ Chunk {index} source: {label}
             return {"user": best_user, "confidence": min(best_score, 0.84), "reason": best_reason}
         return {"user": None, "confidence": 0.0, "reason": "No user match"}
 
+    def _find_unique_linear_user_name_matches(
+        self,
+        owner_hint: str,
+        users: list[dict[str, Any]],
+    ) -> list[dict[str, Any]]:
+        hint_tokens = self._linear_person_name_tokens(owner_hint)
+        if not hint_tokens:
+            return []
+        matches: list[dict[str, Any]] = []
+        for user in users:
+            user_tokens = self._linear_user_name_tokens(user)
+            if not user_tokens:
+                continue
+            if hint_tokens & user_tokens:
+                matches.append(user)
+        return self._dedupe_linear_users_by_id(matches)
+
+    def _linear_user_name_tokens(self, user: dict[str, Any]) -> set[str]:
+        values = [user.get("displayName"), user.get("name"), user.get("email")]
+        tokens: set[str] = set()
+        for value in values:
+            tokens.update(self._linear_person_name_tokens(str(value or "").split("@", 1)[0]))
+        return tokens
+
+    @staticmethod
+    def _linear_person_name_tokens(value: str) -> set[str]:
+        stop_words = {"assign", "assigned", "owner", "assignee", "to", "for", "it", "this", "task", "issue"}
+        tokens = {
+            token
+            for token in re.findall(r"[a-z0-9]+", str(value or "").lower())
+            if len(token) >= 3 and token not in stop_words
+        }
+        return tokens
+
+    @staticmethod
+    def _dedupe_linear_users_by_id(users: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        seen: set[str] = set()
+        deduped: list[dict[str, Any]] = []
+        for user in users:
+            key = str(user.get("id") or user.get("email") or user.get("name") or "").lower()
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            deduped.append(user)
+        return deduped
+
     def _match_linear_meeting_project(
         self,
         candidate: dict[str, Any],
@@ -2600,28 +2939,55 @@ Chunk {index} source: {label}
         hint = str(explicit_project_hint or candidate.get("project_hint") or "").strip()
         if hint:
             normalized_hint = self._normalize_match_text(hint)
-            best_project = None
-            best_score = 0.0
+            exact_name_matches: list[dict[str, Any]] = []
+            exact_value_matches: list[dict[str, Any]] = []
+            scored_matches: list[tuple[float, dict[str, Any]]] = []
             for project in projects:
-                names = [project.get("name"), project.get("slugId")]
-                for name in names:
-                    normalized_name = self._normalize_match_text(name)
-                    if not normalized_name:
+                project_name = project.get("name")
+                project_slug = project.get("slugId")
+                normalized_project_name = self._normalize_match_text(project_name)
+                if normalized_project_name and normalized_hint == normalized_project_name:
+                    exact_name_matches.append(project)
+                    continue
+                for value in (project_slug, project_name):
+                    normalized_value = self._normalize_match_text(value)
+                    if not normalized_value:
                         continue
-                    if normalized_hint == normalized_name:
-                        return {
-                            "project": project,
-                            "confidence": 0.96,
-                            "reason": "Matched project by exact hint",
-                        }
-                    if normalized_name in normalized_hint or normalized_hint in normalized_name:
+                    if normalized_hint == normalized_value:
+                        exact_value_matches.append(project)
+                        continue
+                    if normalized_value in normalized_hint or normalized_hint in normalized_value:
                         score = 0.88
                     else:
-                        score = SequenceMatcher(None, normalized_hint, normalized_name).ratio()
-                    if score > best_score:
-                        best_project = project
-                        best_score = score
-            if best_project and best_score >= 0.78:
+                        score = SequenceMatcher(None, normalized_hint, normalized_value).ratio()
+                    scored_matches.append((score, project))
+
+            exact_name_matches = self._dedupe_linear_projects_by_id(exact_name_matches)
+            if len(exact_name_matches) == 1:
+                return {
+                    "project": exact_name_matches[0],
+                    "confidence": 0.96,
+                    "reason": "Matched project by exact hint",
+                }
+            if len(exact_name_matches) > 1:
+                return {"project": None, "confidence": 0.0, "reason": "Ambiguous project hint"}
+
+            exact_value_matches = self._dedupe_linear_projects_by_id(exact_value_matches)
+            if len(exact_value_matches) == 1:
+                return {
+                    "project": exact_value_matches[0],
+                    "confidence": 0.94,
+                    "reason": "Matched project by exact slug",
+                }
+            if len(exact_value_matches) > 1:
+                return {"project": None, "confidence": 0.0, "reason": "Ambiguous project hint"}
+
+            scored_matches.sort(key=lambda item: item[0], reverse=True)
+            if scored_matches and scored_matches[0][0] >= 0.78:
+                best_score, best_project = scored_matches[0]
+                second_score = scored_matches[1][0] if len(scored_matches) > 1 else 0.0
+                if second_score >= 0.78 and best_score - second_score < 0.03:
+                    return {"project": None, "confidence": 0.0, "reason": "Ambiguous project hint"}
                 return {
                     "project": best_project,
                     "confidence": min(best_score, 0.86),
@@ -2650,6 +3016,18 @@ Chunk {index} source: {label}
                 "reason": "Only active project found for owner",
             }
         return {"project": None, "confidence": 0.0, "reason": "No project match"}
+
+    @staticmethod
+    def _dedupe_linear_projects_by_id(projects: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        seen: set[str] = set()
+        deduped: list[dict[str, Any]] = []
+        for project in projects:
+            key = str(project.get("id") or project.get("name") or project.get("slugId") or "").lower()
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            deduped.append(project)
+        return deduped
 
     def _match_linear_meeting_team(
         self,
@@ -2757,6 +3135,30 @@ Chunk {index} source: {label}
         if overall >= uncertain_threshold:
             return "review", overall
         return "skip", overall
+
+    def _linear_meeting_skip_reason(
+        self,
+        candidate: dict[str, Any],
+        owner_match: dict[str, Any],
+        project_match: dict[str, Any],
+        team_match: dict[str, Any],
+        uncertain_threshold: float,
+    ) -> str:
+        if float(candidate.get("confidence") or 0.0) < uncertain_threshold:
+            return "Candidate confidence too low"
+        if float(owner_match.get("confidence") or 0.0) < uncertain_threshold:
+            reason = str(owner_match.get("reason") or "")
+            if "ambiguous" in reason.lower():
+                return "Assignee unclear: multiple Linear users matched"
+            return "Assignee unclear"
+        if float(project_match.get("confidence") or 0.0) < uncertain_threshold:
+            reason = str(project_match.get("reason") or "")
+            if "ambiguous" in reason.lower():
+                return "Project unclear: multiple Linear projects matched"
+            return "Project unclear"
+        if float(team_match.get("confidence") or 0.0) < uncertain_threshold:
+            return "Team unclear"
+        return "Low confidence mapping"
 
     def _build_linear_meeting_issue_input(
         self,
@@ -2909,10 +3311,11 @@ Chunk {index} source: {label}
             lines.append(f"Skipped {len(skipped)} item{'s' if len(skipped) != 1 else ''}:")
             for item in skipped[:8]:
                 duplicate = item.get("duplicate") or {}
+                mapping = f"project: {item['project']}; assignee: {item['assignee']}"
                 if duplicate.get("url"):
-                    lines.append(f"- {item['title']} - {item['reason']} (<{duplicate['url']}|existing issue>)")
+                    lines.append(f"- {item['title']} - {item['reason']} ({mapping}; <{duplicate['url']}|existing issue>)")
                 else:
-                    lines.append(f"- {item['title']} - {item['reason']}")
+                    lines.append(f"- {item['title']} - {item['reason']} ({mapping})")
         return "\n".join(lines) if lines else "No Linear issues were created from those meeting notes."
 
     def _build_linear_meeting_review_blocks(

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -130,6 +130,9 @@ def test_linear_meeting_tasks_route_to_linear_meeting_actions():
         "create a project update from this PDF",
         "summarize this meeting as a Linear project update",
         "do a project update in Linear",
+        "create a to do item in the linear project 'venture studio' assign to Sonia",
+        "create an issue in Linear project Venture Studio assigned to <@U123>",
+        "add a Linear task to Venture Studio for Sonia",
     ]:
         skill = agent._select_skill_from_triggers(text)
         assert skill is not None

--- a/roo-standalone/roo/tests/test_linear_meeting_actions.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_actions.py
@@ -66,6 +66,36 @@ def test_linear_meeting_owner_matches_name_fallback():
     assert match["confidence"] >= 0.9
 
 
+def test_linear_meeting_owner_matches_unique_plain_first_name():
+    executor = SkillExecutor()
+
+    match = executor._match_linear_meeting_owner(
+        "Sonia",
+        [
+            {"id": "lin-user-1", "name": "Sonia Kaurah", "displayName": "sonia1", "email": "sonia@example.com"},
+            {"id": "lin-user-2", "name": "Sam Donegan", "displayName": "Sam", "email": "sam@example.com"},
+        ],
+    )
+
+    assert match["user"]["id"] == "lin-user-1"
+    assert match["confidence"] >= 0.9
+
+
+def test_linear_meeting_owner_reports_ambiguous_plain_name():
+    executor = SkillExecutor()
+
+    match = executor._match_linear_meeting_owner(
+        "Sonia",
+        [
+            {"id": "lin-user-1", "name": "Sonia Kaurah", "displayName": "sonia1", "email": "sonia@example.com"},
+            {"id": "lin-user-2", "name": "Sonia Lee", "displayName": "sonia2", "email": "sonia.lee@example.com"},
+        ],
+    )
+
+    assert match["user"] is None
+    assert "Ambiguous" in match["reason"]
+
+
 def test_linear_meeting_project_matches_explicit_hint():
     executor = SkillExecutor()
 
@@ -81,15 +111,66 @@ def test_linear_meeting_project_matches_explicit_hint():
     assert match["confidence"] >= 0.9
 
 
-def test_linear_meeting_project_hint_prepass_extracts_named_project():
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ('@Roo add this to the Linear project called “BITGET EVENT”', "BITGET EVENT"),
+        ("create a to do item in the linear project 'venture studio' assign to Sonia", "venture studio"),
+        ('create an issue in Linear project "Venture Studio" assigned to <@U123>', "Venture Studio"),
+        ("add a Linear task to Linear project Venture Studio for Sonia", "Venture Studio"),
+        ("sync this to project called BITGET EVENT please", "BITGET EVENT"),
+    ],
+)
+def test_linear_meeting_project_hint_prepass_extracts_project_forms(text, expected):
     executor = SkillExecutor()
 
-    params = executor._apply_linear_meeting_project_hint_prepass(
-        '@Roo add this to the Linear project called “BITGET EVENT”',
-        {},
+    params = executor._apply_linear_meeting_project_hint_prepass(text, {})
+
+    assert params["project_hint"] == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("create a Linear issue in project Alpha assign to Sonia", "Sonia"),
+        ("create a Linear issue in project Alpha assigned to Sonia Kaurah", "Sonia Kaurah"),
+        ("create an issue in Linear project Alpha assigned to <@U123>", "<@U123>"),
+        ("add a Linear task to project Alpha for Sonia", "Sonia"),
+    ],
+)
+def test_linear_meeting_owner_hint_prepass_extracts_assignment_forms(text, expected):
+    executor = SkillExecutor()
+
+    params = executor._apply_linear_meeting_owner_hint_prepass(text, {})
+
+    assert params["owner_hint"] == expected
+
+
+def test_linear_direct_issue_body_uses_command_work_not_linear_meta_instruction():
+    executor = SkillExecutor()
+
+    body = executor._extract_linear_direct_issue_body(
+        "create a to do item in the linear project 'venture studio' to rebrand and change the name of this project. assign to Sonia",
+        {"project_hint": "venture studio", "owner_hint": "Sonia"},
     )
 
-    assert params["project_hint"] == "BITGET EVENT"
+    assert body == "rebrand and change the name of this project"
+
+
+def test_linear_direct_issue_project_hint_can_be_inferred_from_known_project():
+    executor = SkillExecutor()
+
+    project_hint = executor._infer_linear_direct_project_hint_from_known_projects(
+        "add a Linear task to Venture Studio to rename it for Sonia",
+        [{"id": "project-1", "name": "Venture Studio", "slugId": "venture-studio"}],
+    )
+    body = executor._extract_linear_direct_issue_body(
+        "add a Linear task to Venture Studio to rename it for Sonia",
+        {"project_hint": project_hint, "owner_hint": "Sonia"},
+    )
+
+    assert project_hint == "Venture Studio"
+    assert body == "rename it"
 
 
 @pytest.mark.asyncio
@@ -627,6 +708,271 @@ async def test_linear_meeting_executor_creates_issue_from_parsed_file_source(mon
     assert created_inputs[0]["project_id"] == "project-1"
     assert created_inputs[0]["label_ids"] == ["label-1"]
     assert "meeting.pdf page 3" in created_inputs[0]["description"]
+
+
+@pytest.mark.asyncio
+async def test_linear_direct_issue_command_creates_immediately(monkeypatch):
+    executor = SkillExecutor()
+    created_inputs = []
+
+    async def fake_chat(messages, **kwargs):
+        prompt = messages[-1]["content"]
+        assert "directly asking Roo to create Linear issue" in prompt
+        return SimpleNamespace(
+            content=json.dumps(
+                {
+                    "issues": [
+                        {
+                            "title": "Rebrand and rename the Venture Studio project",
+                            "description": "Rebrand and rename the project because Venture Studio is confusing and does not describe the offering.",
+                            "owner_hint": "Sonia",
+                            "project_hint": "venture studio",
+                            "evidence": "rebrand and change the name",
+                            "source_label": "Slack command",
+                            "confidence": 0.96,
+                        }
+                    ]
+                }
+            )
+        )
+
+    async def fail_meeting_extraction(**kwargs):
+        raise AssertionError("direct issue commands should not use meeting transcript extraction")
+
+    team = {"id": "team-1", "key": "MLA", "name": "MLAI"}
+    user = {"id": "user-1", "name": "Sonia Kaurah", "displayName": "sonia1", "email": "sonia@example.com"}
+    project = {
+        "id": "project-1",
+        "name": "Venture Studio",
+        "slugId": "venture-studio",
+        "teams": {"nodes": [team]},
+        "members": {"nodes": [user]},
+    }
+
+    class FakeClient:
+        async def list_teams(self):
+            return [team]
+
+        async def list_users(self):
+            return [user]
+
+        async def list_active_projects(self):
+            return [project]
+
+        async def list_issue_labels(self):
+            return []
+
+        async def list_recent_open_issues(self):
+            return []
+
+        async def create_issue(self, **kwargs):
+            created_inputs.append(kwargs)
+            return {"identifier": "MLA-123", "title": kwargs["title"], "url": "https://linear.test/MLA-123"}
+
+    class FakeSkill:
+        def get_client_class(self, name):
+            assert name == "LinearMeetingActionsClient"
+            return FakeClient
+
+    monkeypatch.setattr(executor_module, "chat", fake_chat)
+    monkeypatch.setattr(executor, "_extract_linear_meeting_candidates_from_sources", fail_meeting_extraction)
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            OPENAI_API_KEY=None,
+            LINEAR_DEFAULT_TEAM=None,
+            LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE=0.85,
+            LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE=0.65,
+            LINEAR_MEETING_LLM_MODEL="gpt-5.5",
+            LINEAR_MEETING_LLM_REASONING_EFFORT="low",
+        ),
+    )
+
+    result = await executor._execute_linear_meeting_actions(
+        skill=FakeSkill(),
+        text=(
+            "create a to do item in the linear project 'venture studio' to rebrand and change "
+            "the name of this project as the name 'venture studio' is confusing and doesnt "
+            "describe the offering. assign to Sonia"
+        ),
+        params={},
+        user_id="U1",
+        channel_id="C1",
+        thread_ts="1.1",
+        thread_history=[],
+    )
+
+    assert result["data"]["created_count"] == 1
+    assert created_inputs[0]["title"] == "Rebrand and rename the Venture Studio project"
+    assert created_inputs[0]["assignee_id"] == "user-1"
+    assert created_inputs[0]["project_id"] == "project-1"
+    assert created_inputs[0]["team_id"] == "team-1"
+    assert "Slack command" in created_inputs[0]["description"]
+
+
+@pytest.mark.asyncio
+async def test_linear_direct_issue_command_reports_ambiguous_project(monkeypatch):
+    executor = SkillExecutor()
+    created_inputs = []
+
+    async def fake_chat(messages, **kwargs):
+        return SimpleNamespace(
+            content=json.dumps(
+                {
+                    "issues": [
+                        {
+                            "title": "Rename Venture Studio",
+                            "description": "Rename the Venture Studio project.",
+                            "owner_hint": "Sonia",
+                            "project_hint": "venture studio",
+                            "confidence": 0.96,
+                        }
+                    ]
+                }
+            )
+        )
+
+    team = {"id": "team-1", "key": "MLA", "name": "MLAI"}
+    user = {"id": "user-1", "name": "Sonia Kaurah", "displayName": "sonia1", "email": "sonia@example.com"}
+    projects = [
+        {"id": "project-1", "name": "Venture Studio", "slugId": "venture-studio-a", "teams": {"nodes": [team]}},
+        {"id": "project-2", "name": "Venture Studio", "slugId": "venture-studio-b", "teams": {"nodes": [team]}},
+    ]
+
+    class FakeClient:
+        async def list_teams(self):
+            return [team]
+
+        async def list_users(self):
+            return [user]
+
+        async def list_active_projects(self):
+            return projects
+
+        async def list_issue_labels(self):
+            return []
+
+        async def list_recent_open_issues(self):
+            return []
+
+        async def create_issue(self, **kwargs):
+            created_inputs.append(kwargs)
+            return {"identifier": "MLA-123"}
+
+    class FakeSkill:
+        def get_client_class(self, name):
+            return FakeClient
+
+    monkeypatch.setattr(executor_module, "chat", fake_chat)
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            OPENAI_API_KEY=None,
+            LINEAR_DEFAULT_TEAM=None,
+            LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE=0.85,
+            LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE=0.65,
+            LINEAR_MEETING_LLM_MODEL="gpt-5.5",
+            LINEAR_MEETING_LLM_REASONING_EFFORT="low",
+        ),
+    )
+
+    result = await executor._execute_linear_meeting_actions(
+        skill=FakeSkill(),
+        text="create a to do item in the linear project 'venture studio' to rename it. assign to Sonia",
+        params={},
+        user_id="U1",
+        channel_id="C1",
+        thread_ts="1.1",
+        thread_history=[],
+    )
+
+    assert created_inputs == []
+    assert "Project unclear: multiple Linear projects matched" in result["message"]
+    assert "project: Unresolved; assignee: sonia1" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_linear_direct_issue_command_reports_ambiguous_assignee(monkeypatch):
+    executor = SkillExecutor()
+    created_inputs = []
+
+    async def fake_chat(messages, **kwargs):
+        return SimpleNamespace(
+            content=json.dumps(
+                {
+                    "issues": [
+                        {
+                            "title": "Rename Venture Studio",
+                            "description": "Rename the Venture Studio project.",
+                            "owner_hint": "Sonia",
+                            "project_hint": "venture studio",
+                            "confidence": 0.96,
+                        }
+                    ]
+                }
+            )
+        )
+
+    team = {"id": "team-1", "key": "MLA", "name": "MLAI"}
+    users = [
+        {"id": "user-1", "name": "Sonia Kaurah", "displayName": "sonia1", "email": "sonia@example.com"},
+        {"id": "user-2", "name": "Sonia Lee", "displayName": "sonia2", "email": "sonia.lee@example.com"},
+    ]
+    project = {"id": "project-1", "name": "Venture Studio", "slugId": "venture-studio", "teams": {"nodes": [team]}}
+
+    class FakeClient:
+        async def list_teams(self):
+            return [team]
+
+        async def list_users(self):
+            return users
+
+        async def list_active_projects(self):
+            return [project]
+
+        async def list_issue_labels(self):
+            return []
+
+        async def list_recent_open_issues(self):
+            return []
+
+        async def create_issue(self, **kwargs):
+            created_inputs.append(kwargs)
+            return {"identifier": "MLA-123"}
+
+    class FakeSkill:
+        def get_client_class(self, name):
+            return FakeClient
+
+    monkeypatch.setattr(executor_module, "chat", fake_chat)
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            OPENAI_API_KEY=None,
+            LINEAR_DEFAULT_TEAM=None,
+            LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE=0.85,
+            LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE=0.65,
+            LINEAR_MEETING_LLM_MODEL="gpt-5.5",
+            LINEAR_MEETING_LLM_REASONING_EFFORT="low",
+        ),
+    )
+
+    result = await executor._execute_linear_meeting_actions(
+        skill=FakeSkill(),
+        text="create a to do item in the linear project 'venture studio' to rename it. assign to Sonia",
+        params={},
+        user_id="U1",
+        channel_id="C1",
+        thread_ts="1.1",
+        thread_history=[],
+    )
+
+    assert created_inputs == []
+    assert "Assignee unclear: multiple Linear users matched" in result["message"]
+    assert "project: Venture Studio; assignee: Unresolved" in result["message"]
 
 
 @pytest.mark.asyncio

--- a/roo-standalone/roo/tests/test_linear_meeting_routing.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_routing.py
@@ -60,6 +60,9 @@ def test_linear_meeting_file_prompts_route_to_linear_meeting_actions():
         "create a project update from this PDF",
         "summarize this meeting as a Linear project update",
         "do a project update in Linear",
+        "create a to do item in the linear project 'venture studio' assign to Sonia",
+        "create an issue in Linear project Venture Studio assigned to <@U123>",
+        "add a Linear task to Venture Studio for Sonia",
     ]:
         skill = agent._select_skill_from_triggers(text)
         assert skill is not None

--- a/roo-standalone/skills/linear_meeting_actions/SKILL.md
+++ b/roo-standalone/skills/linear_meeting_actions/SKILL.md
@@ -20,6 +20,7 @@ parameters:
   - action: One of extract, create, approve, or reject. Defaults to create for transcript-to-Linear requests.
   - transcript: Pasted meeting transcript, notes, or summary text. If omitted, use the current Slack thread history and supported attached files.
   - project_hint: Optional Linear project name or slug mentioned by the user.
+  - owner_hint: Optional Linear assignee name, email, or Slack mention.
   - team_hint: Optional Linear team name or key mentioned by the user.
   - confirm_create: Boolean flag used by Slack approval actions for uncertain items.
 ---
@@ -31,6 +32,7 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
 ## Capabilities
 
 - Parse Slack message/thread text and supported attached files for concrete to-do items.
+- Create a Linear issue directly from an explicit Slack command such as "create a to do item in Linear project X and assign to Y".
 - Draft a review-only Linear issue from a discussion thread when the user asks to add "this" or "the thread" to Linear.
 - Create a Linear project update when the request explicitly asks for a project update and Roo can confidently match the project.
 - Use the latest Linear project update and recent project issues as context for concise PDF/transcript-derived project updates.
@@ -46,6 +48,7 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
 - **action**: One of `extract`, `create`, `approve`, or `reject`. Defaults to `create`.
 - **transcript**: Pasted meeting transcript, notes, or summary text. If omitted, inspect the current Slack thread and attached files.
 - **project_hint**: Optional Linear project name or slug.
+- **owner_hint**: Optional Linear assignee name, email, or Slack mention.
 - **team_hint**: Optional Linear team name or key.
 - **confirm_create**: Internal boolean used for Slack approval actions.
 
@@ -59,14 +62,15 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
    - Latest project update for each active project when available
    - Issue labels
    - Recent open issues for duplicate detection
-3. Extract concrete action items into structured candidates with title, description, owner hint, project hint, due date, priority, evidence, source label, and confidence.
-4. If a project update was requested, summarize all parsed source chunks, compare against the latest project update context, and create a concise Linear project update for the matched project.
-5. If no concrete action item is found but the user asked to add the thread context to Linear, draft one contextual issue and require Slack approval before creation.
-6. Match owners by Slack mention/email first, then Linear user email, then display/name similarity.
-7. Match projects by explicit project hint, name/slug similarity, and project membership context.
-8. Create only high-confidence, non-duplicate concrete candidates.
-9. Present uncertain or contextual candidates in Slack with Approve and Reject buttons.
-10. Report created project updates, created issues, skipped duplicates, and unresolved items clearly.
+3. For explicit direct issue commands, parse the command itself as the issue source, including project and assignee hints.
+4. Otherwise, extract concrete action items into structured candidates with title, description, owner hint, project hint, due date, priority, evidence, source label, and confidence.
+5. If a project update was requested, summarize all parsed source chunks, compare against the latest project update context, and create a concise Linear project update for the matched project.
+6. If no concrete action item is found but the user asked to add the thread context to Linear, draft one contextual issue and require Slack approval before creation.
+7. Match owners by Slack mention/email first, then unique Linear name/email-prefix match, then display/name similarity.
+8. Match projects by explicit project hint, exact name/slug match, name/slug similarity, and project membership context.
+9. Create only high-confidence, non-duplicate concrete candidates.
+10. Present uncertain or contextual candidates in Slack with Approve and Reject buttons.
+11. Report created project updates, created issues, skipped duplicates, and unresolved items clearly.
 
 ## Creation Rules
 


### PR DESCRIPTION
## Summary
- route explicit Slack-to-Linear issue commands into the Linear meeting-actions skill
- parse direct project and assignee hints deterministically, including quoted Linear project names and plain-name assignees
- create direct Linear issues without treating the Slack command as a meeting transcript
- improve unresolved mapping feedback with specific project, assignee, team, and confidence causes

## Validation
- /tmp/roo-local-venv/bin/python -m pytest roo-standalone/roo/tests/test_linear_meeting_actions.py roo-standalone/roo/tests/test_linear_meeting_routing.py roo-standalone/roo/tests/test_agent_routing.py roo-standalone/roo/tests/test_linear_meeting_sources.py
- /tmp/roo-local-venv/bin/python -m pytest roo-standalone/roo/tests
  - 311 passed, 5 existing unrelated Content Factory Slack action failures
- /tmp/roo-local-venv/bin/python -m py_compile roo-standalone/roo/agent.py roo-standalone/roo/skills/executor.py roo-standalone/roo/tests/test_agent_routing.py roo-standalone/roo/tests/test_linear_meeting_actions.py roo-standalone/roo/tests/test_linear_meeting_routing.py
- git diff --check