### PR TITLE
Add committee meeting agenda skill

### DIFF
--- a/roo-standalone/.env.example
+++ b/roo-standalone/.env.example
@@ -47,3 +47,11 @@ JOBS_PER_KEYWORD_LIMIT=5
 JOBS_RETRY_ATTEMPTS=3
 JOBS_RETRY_DELAY_SECONDS=300
 JOBS_FAILURE_STOP_AFTER_DAYS=3
+
+# Committee meeting agenda
+# Set COMMITTEE_AGENDA_CHANNEL_ID to the Slack channel ID (e.g. C012ABCDEF) where
+# agenda submissions should be posted. If unset, Roo will resolve it from
+# COMMITTEE_AGENDA_CHANNEL_NAME at runtime (the bot must be a member).
+COMMITTEE_AGENDA_CHANNEL_ID=
+COMMITTEE_AGENDA_CHANNEL_NAME=committee-agenda
+COMMITTEE_AGENDA_SECOND_EMOJI=+1

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -75,6 +75,11 @@ class Settings(BaseSettings):
     JOBS_RETRY_DELAY_SECONDS: int = 300
     JOBS_FAILURE_STOP_AFTER_DAYS: int = 3
 
+    # Committee meeting agenda
+    COMMITTEE_AGENDA_CHANNEL_ID: Optional[str] = None
+    COMMITTEE_AGENDA_CHANNEL_NAME: str = "committee-agenda"
+    COMMITTEE_AGENDA_SECOND_EMOJI: str = "+1"
+
     @property
     def default_llm_provider(self) -> str:
         """Determine default LLM provider based on available keys."""

--- a/roo-standalone/roo/content_intent.py
+++ b/roo-standalone/roo/content_intent.py
@@ -55,6 +55,36 @@ WRITE_PATTERNS = (
 CONTENT_TARGET_PATTERN = re.compile(
     r"\b(?:repo(?:sitory)?|codebase|domain|site|website|project|app)\b"
 )
+AGENDA_ADD_PATTERNS = (
+    r"\badd\s+(?:this\s+|that\s+|it\s+)?(?:to\s+(?:the\s+)?(?:committee\s+|meeting\s+)?agenda)\b",
+    r"\bput\s+(?:this\s+|that\s+|it\s+)?on\s+(?:the\s+)?(?:committee\s+|meeting\s+)?agenda\b",
+    r"\b(?:committee|meeting)\s+agenda\b",
+    r"\bagenda\s+item\b",
+    r"\b(?:raise|bring|discuss)\b.*\b(?:at|in)\s+(?:the\s+)?(?:next\s+)?(?:committee\s+)?meeting\b",
+    r"\b(?:add|put|create)\b.*\bagenda\b",
+)
+AGENDA_COMPLETE_PATTERNS = (
+    r"\bagenda\s+(?:complete|completed|done|resolved|finished)\b",
+    r"\bmark\b.*\bagenda\b.*\b(?:complete|completed|done|resolved|finished)\b",
+    r"\b(?:complete|completed|done|resolved|finished)\b.*\bagenda\s+item\b",
+    r"\bclose\s+(?:this\s+|that\s+|the\s+)?agenda\s+item\b",
+    r"\bagenda\s+item\b.*\bclosed?\b",
+)
+AGENDA_REMOVE_PATTERNS = (
+    r"\bremove\s+(?:this\s+|that\s+|the\s+)?agenda\s+item\b",
+    r"\bdelete\s+(?:this\s+|that\s+|the\s+)?agenda\s+item\b",
+    r"\bdrop\s+(?:this\s+|that\s+|the\s+)?agenda\s+item\b",
+    r"\bagenda\s+item\b.*\bremoved?\b",
+)
+AGENDA_CLEANUP_PATTERNS = (
+    r"\bagenda\s+cleanup\b",
+    r"\bclean(?:\s+|-)?up\s+(?:the\s+)?(?:completed\s+)?agenda\b",
+    r"\bremove\s+(?:all\s+)?completed\s+agenda\s+items?\b",
+    r"\bclear\s+(?:out\s+)?(?:the\s+)?completed\s+agenda\s+items?\b",
+    r"\barchive\s+(?:the\s+)?completed\s+agenda\s+items?\b",
+    r"\bpurge\s+(?:the\s+)?completed\s+agenda\b",
+)
+
 GITHUB_AUTH_PATTERNS = (
     r"\bgithub\s+integration\b",
     r"\b(?:re-?connect|connect|authori[sz]e|link|install|fix)\b.*\bgithub\b",
@@ -184,6 +214,21 @@ def parse_routing_intent(
     )
     domain = explicit_domain or (thread_domain if references_thread_domain else None)
     action = detect_content_action(normalized)
+
+    if any(re.search(pattern, text_lower) for pattern in AGENDA_CLEANUP_PATTERNS):
+        return {"skill_name": "committee-agenda", "params": {"action": "cleanup"}}
+
+    if any(re.search(pattern, text_lower) for pattern in AGENDA_REMOVE_PATTERNS):
+        return {
+            "skill_name": "committee-agenda",
+            "params": {"action": "complete", "remove": True},
+        }
+
+    if any(re.search(pattern, text_lower) for pattern in AGENDA_COMPLETE_PATTERNS):
+        return {"skill_name": "committee-agenda", "params": {"action": "complete"}}
+
+    if any(re.search(pattern, text_lower) for pattern in AGENDA_ADD_PATTERNS):
+        return {"skill_name": "committee-agenda", "params": {"action": "add"}}
 
     if any(re.search(pattern, text_lower) for pattern in GITHUB_AUTH_PATTERNS):
         params: Dict[str, Any] = {}

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -170,6 +170,17 @@ class SkillExecutor:
                 result = await self._execute_medhack(skill, text, params, user_id, channel_id, thread_ts, thread_history)
             elif skill.name == "luma-events":
                 result = await self._execute_luma_events(skill, text, params, user_id, channel_id, thread_ts)
+            elif skill.name == "committee-agenda":
+                result = await self._execute_committee_agenda(
+                    skill,
+                    text,
+                    params,
+                    user_id,
+                    channel_id,
+                    thread_ts,
+                    thread_history,
+                    kwargs.get("current_message_ts"),
+                )
             else:
                 # Generic LLM-based execution
                 result = await self._execute_with_llm(skill, text, params, user_id, thread_history)
@@ -4400,6 +4411,194 @@ Chunk {index} source: {label}
             }
         ]
     
+    async def _execute_committee_agenda(
+        self,
+        skill: Skill,
+        text: str,
+        params: dict,
+        user_id: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+        thread_history: Optional[List[dict]],
+        current_message_ts: Optional[str],
+    ) -> Any:
+        """Handle add / complete / cleanup actions for the agenda skill."""
+        client_class = skill.get_client_class("CommitteeAgendaClient")
+        if client_class is None:
+            return (
+                "The committee-agenda skill is missing its implementation. "
+                "Ask an admin to check `skills/committee_agenda/client.py`."
+            )
+        agenda_client = client_class()
+        action = str(params.get("action") or "add").strip().lower()
+
+        if action in {"complete", "remove"}:
+            return await self._execute_committee_agenda_complete(
+                agenda_client,
+                params,
+                user_id,
+                channel_id,
+                thread_ts,
+                remove=bool(params.get("remove")) or action == "remove",
+            )
+
+        if action == "cleanup":
+            return await self._execute_committee_agenda_cleanup(
+                agenda_client, params, user_id
+            )
+
+        title = str(params.get("title") or "").strip()
+        description = str(params.get("description") or "").strip()
+        if not title:
+            inferred_title, inferred_description = self._infer_agenda_fields(
+                text, thread_history, current_message_ts
+            )
+            title = title or inferred_title
+            if not description:
+                description = inferred_description
+
+        if not title:
+            return (
+                "I couldn't figure out a title for the agenda item. "
+                "Try `@Roo add to agenda: <short topic>` and I'll take it from there."
+            )
+
+        source_message_ts = current_message_ts or thread_ts
+        result = agenda_client.submit_item(
+            title=title,
+            description=description,
+            urgency=str(params.get("urgency") or "normal"),
+            proposer_user_id=user_id,
+            source_channel_id=channel_id,
+            source_message_ts=source_message_ts,
+        )
+        return result.message
+
+    async def _execute_committee_agenda_complete(
+        self,
+        agenda_client: Any,
+        params: dict,
+        user_id: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+        *,
+        remove: bool,
+    ) -> str:
+        denial = await self._committee_agenda_admin_denial(
+            user_id, "close or remove agenda items"
+        )
+        if denial:
+            return denial
+
+        if not thread_ts:
+            return (
+                "To close or remove an agenda item, reply in its thread in the "
+                "committee agenda channel and tag me with `@Roo agenda complete`."
+            )
+
+        result = agenda_client.complete_item(
+            item_channel_id=channel_id,
+            item_ts=thread_ts,
+            completed_by_user_id=user_id,
+            remove=remove,
+            reason=str(params.get("reason") or ""),
+        )
+        return result.message
+
+    async def _execute_committee_agenda_cleanup(
+        self,
+        agenda_client: Any,
+        params: dict,
+        user_id: str,
+    ) -> str:
+        denial = await self._committee_agenda_admin_denial(
+            user_id, "clean up completed agenda items"
+        )
+        if denial:
+            return denial
+
+        try:
+            limit = int(params.get("limit") or 200)
+        except (TypeError, ValueError):
+            limit = 200
+        result = agenda_client.cleanup_completed_items(
+            initiator_user_id=user_id,
+            limit=max(1, min(limit, 1000)),
+        )
+        return result.message
+
+    async def _committee_agenda_admin_denial(
+        self, user_id: str, action_label: str
+    ) -> Optional[str]:
+        """Return a denial string if user isn't a committee admin, else None."""
+        try:
+            from ..clients.mlai_backend import MLAIBackendClient
+
+            backend = MLAIBackendClient()
+            admin_details = await backend.get_admin_details(user_id)
+        except Exception as exc:
+            print(f"⚠️ Failed to resolve admin details for {user_id}: {exc}")
+            return (
+                "I couldn't verify your committee permissions just now. "
+                "Try again in a moment, or ping an admin."
+            )
+        if self._is_full_points_admin_details(admin_details):
+            return None
+        return (
+            f"Sorry mate, only committee admins can {action_label}. "
+            "If you reckon you should have access, have a chat with the committee. 🔒"
+        )
+
+    @staticmethod
+    def _infer_agenda_fields(
+        text: str,
+        thread_history: Optional[List[dict]],
+        current_message_ts: Optional[str],
+    ) -> tuple[str, str]:
+        """Pull a title (and optional description) from the user's text + thread."""
+        cleaned = re.sub(
+            r"^\s*(?:hey\s+)?(?:@?roo[,:\s]*)?",
+            "",
+            str(text or ""),
+            flags=re.IGNORECASE,
+        ).strip()
+        cleaned = re.sub(
+            r"^(?:please\s+)?(?:can\s+you\s+)?(?:also\s+)?",
+            "",
+            cleaned,
+            flags=re.IGNORECASE,
+        ).strip()
+        cleaned = re.sub(
+            r"^(?:add|put|create|raise|bring\s+up|discuss)\b\s*"
+            r"(?:this\s+|that\s+|it\s+)?"
+            r"(?:to\s+(?:the\s+)?(?:committee\s+|meeting\s+)?agenda|"
+            r"on\s+(?:the\s+)?(?:committee\s+|meeting\s+)?agenda|"
+            r"as\s+(?:an\s+)?agenda\s+item|"
+            r"at\s+(?:the\s+)?(?:next\s+)?(?:committee\s+)?meeting)\b\s*[:\-]?\s*",
+            "",
+            cleaned,
+            flags=re.IGNORECASE,
+        ).strip(" :;-")
+        cleaned = re.sub(r"\bagenda\s+item\b\s*[:\-]?\s*", "", cleaned, flags=re.IGNORECASE).strip()
+
+        title = cleaned
+        description = ""
+        if not title and thread_history:
+            current_ts = str(current_message_ts or "").strip()
+            for msg in thread_history:
+                if msg.get("is_bot") or msg.get("bot_id"):
+                    continue
+                if current_ts and str(msg.get("ts") or "").strip() == current_ts:
+                    continue
+                msg_text = str(msg.get("text") or "").strip()
+                if msg_text:
+                    title = msg_text
+                    break
+        if title and len(title) > 120:
+            description = title
+            title = title[:117].rstrip() + "…"
+        return title, description
+
     async def _execute_content_factory(
         self,
         skill: Skill,

--- a/roo-standalone/skills/committee_agenda/SKILL.md
+++ b/roo-standalone/skills/committee_agenda/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: committee-agenda
+description: Capture user requests to add items to the MLAI committee meeting agenda and post them to the dedicated agenda Slack channel.
+trigger_keywords:
+  - agenda
+  - add to agenda
+  - committee agenda
+  - meeting agenda
+  - next meeting
+  - bring up at the meeting
+  - raise at the meeting
+  - put on the agenda
+  - agenda item
+  - agenda complete
+  - agenda done
+  - mark agenda complete
+  - close agenda item
+  - remove agenda item
+  - delete agenda item
+  - agenda cleanup
+  - clean up completed agenda
+  - remove completed agenda items
+  - archive completed agenda items
+---
+
+# Committee Meeting Agenda Skill
+
+This skill lets any community member ask Roo to add an item to the next committee
+meeting agenda. Roo extracts a short title and description from the message
+(and surrounding thread if relevant), then posts a structured agenda card to
+the `#committee-agenda` channel where committee members triage it.
+
+Seconds are tallied directly from emoji reactions on the posted card; there is
+no separate database. Slack itself is the source of truth.
+
+## Capabilities
+
+- **Add** an agenda item from a natural-language request like
+  "@Roo add to agenda: discuss venue for next hackathon".
+- Pull the description from the thread the user is replying in, when the
+  request itself only gives a title.
+- Capture the proposer (the requesting Slack user) automatically.
+- Post a formatted card to the dedicated agenda channel with proposer mention,
+  timestamp, and a permalink back to the originating message when available.
+- Reply to the user with a confirmation and a link to the posted card.
+- **Complete** an agenda item when a committee member replies to its thread
+  with `@Roo agenda complete` (or "mark agenda complete", "agenda done",
+  "close agenda item"). Roo edits the card header to "✅ Completed agenda
+  item" and posts a completion note in-thread.
+- **Remove** an agenda item entirely with `@Roo remove agenda item` /
+  `@Roo delete agenda item` in the item's thread. Same gating as complete.
+- **Cleanup**: `@Roo agenda cleanup` or `@Roo remove completed agenda items`
+  scans the agenda channel and deletes every item already marked complete.
+  Admin-only.
+
+## Parameters
+
+- **action**: One of `add`, `complete`, `cleanup` (default: `add`). Set by
+  routing; rarely supplied by the user directly.
+- **title**: Short summary of the agenda item, used by `add` (max 120 chars).
+- **description**: Longer context for the committee, used by `add` (optional).
+- **urgency**: One of `low`, `normal`, `high` (default: `normal`), used by `add`.
+- **remove**: Boolean. If true with `action=complete`, deletes the agenda
+  message instead of marking it ✅ Completed. Set by routing when the user
+  says "remove/delete agenda item".
+- **reason**: Optional free-text reason the completer can supply, shown in
+  the completion note.
+
+## Workflow
+
+### Step 1: Extract the request
+From the user's message (and thread history if needed), build:
+- A concise `title` (imperative or topic-style, no leading "add to agenda:" filler)
+- A `description` capturing useful context — quote thread text if relevant
+- An `urgency` inferred only if the user explicitly signalled it
+
+### Step 2: Post to the agenda channel
+Call `CommitteeAgendaClient.submit_item(...)` with the extracted fields plus
+the requester's Slack user ID and (if available) a permalink back to the
+originating message. The client posts a Block Kit card to the configured
+agenda channel and returns the posted message's `ts` and a permalink.
+
+### Step 3: Confirm to the user
+Reply with a short confirmation including the agenda channel and a link to
+the posted item. Encourage other members to react with `:+1:` to second.
+
+## Response Style
+
+- Friendly and brief, Aussie flavour where it fits.
+- Always tell the user *where* the item went so they can follow up.
+- If the channel isn't configured, explain clearly what an admin needs to do
+  (set `COMMITTEE_AGENDA_CHANNEL_ID`) rather than failing silently.
+
+## Permissioning
+
+- `add` is open to any community member.
+- `complete` and `remove` (for an individual item) require the requester to
+  hold an MLAI Points admin role (`admin`, `committee`, or `portfolio_lead`).
+- `cleanup` requires the same admin role.
+
+If a non-admin asks for `complete` or `cleanup`, Roo explains they need
+committee permission rather than failing silently.
+
+## Examples
+
+> User: `@Roo add to agenda: budget for new whiteboards in the coworking space`
+>
+> Roo: `Done! I've added "Budget for new whiteboards in coworking space" to the committee agenda in <#C012ABCDEF|committee-agenda>. React with :+1: to second it. 👍`
+
+> Committee member (in agenda item thread): `@Roo agenda complete`
+>
+> Roo: `Agenda item marked complete by @alex.`
+
+> Committee member: `@Roo remove completed agenda items`
+>
+> Roo: `Removed 4 completed agenda items from <#C012ABCDEF>.`

--- a/roo-standalone/skills/committee_agenda/client.py
+++ b/roo-standalone/skills/committee_agenda/client.py
@@ -1,0 +1,566 @@
+"""Committee meeting agenda skill client.
+
+Posts agenda submissions to a dedicated Slack channel. Slack itself is the
+source of truth — seconds are tallied from emoji reactions on the posted card.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from roo.config import get_settings
+from roo.slack_client import (
+    get_channel_id,
+    get_display_name,
+    get_slack_client,
+    post_message,
+)
+
+
+VALID_URGENCIES = ("low", "normal", "high")
+URGENCY_LABEL = {"low": "Low", "normal": "Normal", "high": "High"}
+URGENCY_EMOJI = {"low": "🟢", "normal": "🟡", "high": "🔴"}
+MAX_TITLE_LEN = 120
+
+# Stable marker prefixes embedded in the message fallback text so cleanup can
+# find agenda items written by Roo without relying on per-item metadata.
+AGENDA_ITEM_MARKER = "[roo-agenda-item]"
+AGENDA_COMPLETED_MARKER = "[roo-agenda-item][completed]"
+AGENDA_CLEANUP_DEFAULT_LIMIT = 200
+
+
+@dataclass
+class AgendaSubmission:
+    ok: bool
+    message: str
+    channel_id: Optional[str] = None
+    channel_name: Optional[str] = None
+    posted_ts: Optional[str] = None
+    permalink: Optional[str] = None
+    error_code: Optional[str] = None
+
+
+@dataclass
+class AgendaCompletion:
+    ok: bool
+    message: str
+    item_ts: Optional[str] = None
+    removed: bool = False
+    error_code: Optional[str] = None
+
+
+@dataclass
+class AgendaCleanup:
+    ok: bool
+    message: str
+    removed_count: int = 0
+    error_code: Optional[str] = None
+
+
+class CommitteeAgendaClient:
+    """Slack-only persistence: each agenda item is a message in #committee-agenda."""
+
+    def __init__(self) -> None:
+        self._settings = get_settings()
+
+    def _resolve_channel_id(self) -> Optional[str]:
+        configured = (self._settings.COMMITTEE_AGENDA_CHANNEL_ID or "").strip()
+        if configured:
+            return configured
+        name = (self._settings.COMMITTEE_AGENDA_CHANNEL_NAME or "").strip()
+        if not name:
+            return None
+        return get_channel_id(name)
+
+    @staticmethod
+    def _normalize_urgency(value: Any) -> str:
+        text = str(value or "").strip().lower()
+        if text in VALID_URGENCIES:
+            return text
+        return "normal"
+
+    @staticmethod
+    def _normalize_title(value: Any) -> str:
+        text = " ".join(str(value or "").split())
+        if len(text) > MAX_TITLE_LEN:
+            text = text[: MAX_TITLE_LEN - 1].rstrip() + "…"
+        return text
+
+    @staticmethod
+    def _build_blocks(
+        *,
+        title: str,
+        description: str,
+        urgency: str,
+        proposer_user_id: str,
+        source_permalink: Optional[str],
+        second_emoji: str,
+    ) -> list[dict]:
+        urgency_text = f"{URGENCY_EMOJI.get(urgency, '🟡')} {URGENCY_LABEL.get(urgency, 'Normal')}"
+        proposer_mention = f"<@{proposer_user_id}>" if proposer_user_id else "_unknown_"
+        context_elements: list[dict] = [
+            {"type": "mrkdwn", "text": f"*Proposed by:* {proposer_mention}"},
+            {"type": "mrkdwn", "text": f"*Urgency:* {urgency_text}"},
+        ]
+        if source_permalink:
+            context_elements.append(
+                {"type": "mrkdwn", "text": f"<{source_permalink}|Source message>"}
+            )
+
+        blocks: list[dict] = [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": "📋 New agenda item", "emoji": True},
+            },
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"*{title}*"},
+            },
+        ]
+        if description:
+            blocks.append(
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": description},
+                }
+            )
+        blocks.append({"type": "context", "elements": context_elements})
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"React with :{second_emoji}: to second this item.",
+                    }
+                ],
+            }
+        )
+        return blocks
+
+    def _resolve_source_permalink(
+        self,
+        source_channel_id: Optional[str],
+        source_message_ts: Optional[str],
+    ) -> Optional[str]:
+        if not source_channel_id or not source_message_ts:
+            return None
+        try:
+            client = get_slack_client()
+            response = client.chat_getPermalink(
+                channel=source_channel_id,
+                message_ts=source_message_ts,
+            )
+            if response.get("ok"):
+                return response.get("permalink")
+        except Exception as exc:
+            print(f"⚠️ chat.getPermalink failed for {source_channel_id}/{source_message_ts}: {exc}")
+        return None
+
+    def _resolve_posted_permalink(
+        self, channel_id: str, posted_ts: str
+    ) -> Optional[str]:
+        try:
+            client = get_slack_client()
+            response = client.chat_getPermalink(channel=channel_id, message_ts=posted_ts)
+            if response.get("ok"):
+                return response.get("permalink")
+        except Exception as exc:
+            print(f"⚠️ chat.getPermalink failed for posted item {channel_id}/{posted_ts}: {exc}")
+        return None
+
+    def submit_item(
+        self,
+        *,
+        title: str,
+        description: str = "",
+        urgency: str = "normal",
+        proposer_user_id: str = "",
+        source_channel_id: Optional[str] = None,
+        source_message_ts: Optional[str] = None,
+    ) -> AgendaSubmission:
+        clean_title = self._normalize_title(title)
+        if not clean_title:
+            return AgendaSubmission(
+                ok=False,
+                message=(
+                    "I need a short title for the agenda item. "
+                    "Try something like `@Roo add to agenda: budget for new whiteboards`."
+                ),
+                error_code="missing_title",
+            )
+
+        channel_id = self._resolve_channel_id()
+        if not channel_id:
+            return AgendaSubmission(
+                ok=False,
+                message=(
+                    "The committee agenda channel isn't configured yet. "
+                    "An admin needs to set `COMMITTEE_AGENDA_CHANNEL_ID` (or make sure "
+                    f"I'm a member of `#{self._settings.COMMITTEE_AGENDA_CHANNEL_NAME}`)."
+                ),
+                error_code="channel_unconfigured",
+            )
+
+        clean_description = " ".join(str(description or "").split())
+        clean_urgency = self._normalize_urgency(urgency)
+        second_emoji = (self._settings.COMMITTEE_AGENDA_SECOND_EMOJI or "+1").strip(":") or "+1"
+        source_permalink = self._resolve_source_permalink(source_channel_id, source_message_ts)
+
+        blocks = self._build_blocks(
+            title=clean_title,
+            description=clean_description,
+            urgency=clean_urgency,
+            proposer_user_id=proposer_user_id,
+            source_permalink=source_permalink,
+            second_emoji=second_emoji,
+        )
+        proposer_label = get_display_name(proposer_user_id) if proposer_user_id else "a member"
+        fallback_text = (
+            f"{AGENDA_ITEM_MARKER} New agenda item from {proposer_label}: {clean_title}"
+        )
+
+        try:
+            response = post_message(channel_id, text=fallback_text, blocks=blocks)
+        except Exception as exc:
+            return AgendaSubmission(
+                ok=False,
+                message=(
+                    "Sorry, I couldn't post to the committee agenda channel. "
+                    "Double check that I'm a member and try again."
+                ),
+                error_code="post_failed",
+                channel_id=channel_id,
+            )
+
+        if not response.get("ok"):
+            slack_error = response.get("error") or "unknown_error"
+            print(f"❌ Failed to post agenda item: {slack_error}")
+            return AgendaSubmission(
+                ok=False,
+                message=(
+                    f"Slack rejected the agenda post (`{slack_error}`). "
+                    "Make sure I'm a member of the agenda channel and try again."
+                ),
+                error_code=slack_error,
+                channel_id=channel_id,
+            )
+
+        posted_ts = response.get("ts")
+        posted_channel = response.get("channel") or channel_id
+        permalink = self._resolve_posted_permalink(posted_channel, posted_ts) if posted_ts else None
+        channel_label = f"<#{posted_channel}>"
+        link_clause = f" → {permalink}" if permalink else ""
+
+        return AgendaSubmission(
+            ok=True,
+            message=(
+                f"Done! I've added *{clean_title}* to the committee agenda in {channel_label}."
+                f"{link_clause}\n"
+                f"React with :{second_emoji}: on that card to second it. 👍"
+            ),
+            channel_id=posted_channel,
+            channel_name=self._settings.COMMITTEE_AGENDA_CHANNEL_NAME,
+            posted_ts=posted_ts,
+            permalink=permalink,
+        )
+
+    def submit_from_params(
+        self,
+        params: Dict[str, Any],
+        *,
+        proposer_user_id: str,
+        source_channel_id: Optional[str],
+        source_message_ts: Optional[str],
+    ) -> AgendaSubmission:
+        return self.submit_item(
+            title=params.get("title", ""),
+            description=params.get("description", ""),
+            urgency=params.get("urgency", "normal"),
+            proposer_user_id=proposer_user_id,
+            source_channel_id=source_channel_id,
+            source_message_ts=source_message_ts,
+        )
+
+    # ------------------------------------------------------------------
+    # Completion + cleanup
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_agenda_item_message(message: Dict[str, Any]) -> bool:
+        text = str(message.get("text") or "")
+        return AGENDA_ITEM_MARKER in text
+
+    @staticmethod
+    def _is_completed_agenda_item(message: Dict[str, Any]) -> bool:
+        text = str(message.get("text") or "")
+        return AGENDA_COMPLETED_MARKER in text
+
+    def _agenda_channel_or_error(self) -> tuple[Optional[str], Optional[AgendaCompletion]]:
+        channel_id = self._resolve_channel_id()
+        if channel_id:
+            return channel_id, None
+        return None, AgendaCompletion(
+            ok=False,
+            message=(
+                "The committee agenda channel isn't configured. "
+                "Ask an admin to set `COMMITTEE_AGENDA_CHANNEL_ID`."
+            ),
+            error_code="channel_unconfigured",
+        )
+
+    def _fetch_agenda_item(
+        self, channel_id: str, item_ts: str
+    ) -> Optional[Dict[str, Any]]:
+        from roo.slack_client import get_message  # local import to avoid cycle
+
+        return get_message(channel_id, item_ts)
+
+    def complete_item(
+        self,
+        *,
+        item_channel_id: Optional[str],
+        item_ts: Optional[str],
+        completed_by_user_id: str = "",
+        remove: bool = False,
+        reason: str = "",
+    ) -> AgendaCompletion:
+        agenda_channel_id, error = self._agenda_channel_or_error()
+        if error:
+            return error
+        if not item_channel_id or item_channel_id != agenda_channel_id or not item_ts:
+            return AgendaCompletion(
+                ok=False,
+                message=(
+                    "Reply in the thread of the agenda item in "
+                    f"<#{agenda_channel_id}> and say something like "
+                    "`@Roo agenda complete` so I know which item to close."
+                ),
+                error_code="not_in_agenda_thread",
+            )
+
+        message = self._fetch_agenda_item(agenda_channel_id, item_ts)
+        if not message:
+            return AgendaCompletion(
+                ok=False,
+                message="I couldn't find that agenda item to mark complete.",
+                error_code="item_not_found",
+            )
+        if not self._is_agenda_item_message(message):
+            return AgendaCompletion(
+                ok=False,
+                message=(
+                    "That message doesn't look like an agenda item I posted. "
+                    "Reply in the thread of an agenda card instead."
+                ),
+                error_code="not_agenda_item",
+            )
+
+        client = get_slack_client()
+        completer_mention = (
+            f"<@{completed_by_user_id}>" if completed_by_user_id else "a committee member"
+        )
+        reason_clause = f" — {reason.strip()}" if reason and reason.strip() else ""
+
+        if remove:
+            try:
+                response = client.chat_delete(channel=agenda_channel_id, ts=item_ts)
+            except Exception as exc:
+                return AgendaCompletion(
+                    ok=False,
+                    message=f"Couldn't delete that agenda item: {exc}",
+                    error_code="delete_failed",
+                )
+            if not response.get("ok"):
+                slack_error = response.get("error") or "unknown_error"
+                return AgendaCompletion(
+                    ok=False,
+                    message=(
+                        f"Slack rejected the delete (`{slack_error}`). "
+                        "Roo can only delete its own messages, so make sure the "
+                        "item was posted by me."
+                    ),
+                    error_code=slack_error,
+                )
+            return AgendaCompletion(
+                ok=True,
+                message=f"Agenda item removed by {completer_mention}.{reason_clause}",
+                item_ts=item_ts,
+                removed=True,
+            )
+
+        existing_text = str(message.get("text") or "")
+        existing_blocks = message.get("blocks") or []
+        if self._is_completed_agenda_item(message):
+            return AgendaCompletion(
+                ok=True,
+                message="That agenda item is already marked complete.",
+                item_ts=item_ts,
+            )
+
+        updated_text = existing_text.replace(
+            AGENDA_ITEM_MARKER, AGENDA_COMPLETED_MARKER, 1
+        )
+        if AGENDA_COMPLETED_MARKER not in updated_text:
+            updated_text = f"{AGENDA_COMPLETED_MARKER} {existing_text}"
+        if not updated_text.startswith("✅ Completed"):
+            updated_text = f"✅ Completed — {updated_text}"
+
+        updated_blocks = self._mark_blocks_completed(existing_blocks, completer_mention, reason_clause)
+
+        try:
+            response = client.chat_update(
+                channel=agenda_channel_id,
+                ts=item_ts,
+                text=updated_text,
+                blocks=updated_blocks if updated_blocks else None,
+            )
+        except Exception as exc:
+            return AgendaCompletion(
+                ok=False,
+                message=f"Couldn't update that agenda item: {exc}",
+                error_code="update_failed",
+            )
+        if not response.get("ok"):
+            slack_error = response.get("error") or "unknown_error"
+            return AgendaCompletion(
+                ok=False,
+                message=(
+                    f"Slack rejected the update (`{slack_error}`). "
+                    "Roo can only edit its own messages."
+                ),
+                error_code=slack_error,
+            )
+
+        try:
+            post_message(
+                agenda_channel_id,
+                text=f"✅ Marked complete by {completer_mention}.{reason_clause}",
+                thread_ts=item_ts,
+            )
+        except Exception as exc:
+            print(f"⚠️ Failed to post completion thread reply: {exc}")
+
+        return AgendaCompletion(
+            ok=True,
+            message=f"Agenda item marked complete by {completer_mention}.{reason_clause}",
+            item_ts=item_ts,
+        )
+
+    @staticmethod
+    def _mark_blocks_completed(
+        blocks: list,
+        completer_mention: str,
+        reason_clause: str,
+    ) -> list:
+        if not isinstance(blocks, list) or not blocks:
+            return []
+        out: list = []
+        replaced_header = False
+        for block in blocks:
+            if not isinstance(block, dict):
+                continue
+            cloned = dict(block)
+            if not replaced_header and cloned.get("type") == "header":
+                cloned = {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "✅ Completed agenda item",
+                        "emoji": True,
+                    },
+                }
+                replaced_header = True
+            out.append(cloned)
+        out.append(
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"✅ Marked complete by {completer_mention}.{reason_clause}",
+                    }
+                ],
+            }
+        )
+        return out
+
+    def cleanup_completed_items(
+        self,
+        *,
+        initiator_user_id: str = "",
+        limit: int = AGENDA_CLEANUP_DEFAULT_LIMIT,
+    ) -> AgendaCleanup:
+        channel_id = self._resolve_channel_id()
+        if not channel_id:
+            return AgendaCleanup(
+                ok=False,
+                message=(
+                    "The committee agenda channel isn't configured. "
+                    "Ask an admin to set `COMMITTEE_AGENDA_CHANNEL_ID`."
+                ),
+                error_code="channel_unconfigured",
+            )
+
+        client = get_slack_client()
+        removed = 0
+        scanned = 0
+        cursor: Optional[str] = None
+        try:
+            while scanned < limit:
+                page = client.conversations_history(
+                    channel=channel_id,
+                    limit=min(100, limit - scanned),
+                    cursor=cursor,
+                )
+                if not page.get("ok"):
+                    slack_error = page.get("error") or "unknown_error"
+                    return AgendaCleanup(
+                        ok=False,
+                        message=(
+                            f"Couldn't read the agenda channel (`{slack_error}`). "
+                            "Make sure Roo is a member."
+                        ),
+                        error_code=slack_error,
+                    )
+                for msg in page.get("messages", []):
+                    scanned += 1
+                    if not self._is_completed_agenda_item(msg):
+                        continue
+                    ts = msg.get("ts")
+                    if not ts:
+                        continue
+                    delete_resp = client.chat_delete(channel=channel_id, ts=ts)
+                    if delete_resp.get("ok"):
+                        removed += 1
+                    else:
+                        print(
+                            f"⚠️ Failed to delete completed agenda item ts={ts}: "
+                            f"{delete_resp.get('error')}"
+                        )
+                cursor = (page.get("response_metadata") or {}).get("next_cursor") or None
+                if not cursor:
+                    break
+        except Exception as exc:
+            return AgendaCleanup(
+                ok=False,
+                message=f"Cleanup failed: {exc}",
+                error_code="cleanup_failed",
+            )
+
+        initiator_clause = (
+            f" (initiated by <@{initiator_user_id}>)" if initiator_user_id else ""
+        )
+        if removed == 0:
+            return AgendaCleanup(
+                ok=True,
+                message=f"No completed agenda items found to remove{initiator_clause}.",
+            )
+        return AgendaCleanup(
+            ok=True,
+            message=(
+                f"Removed {removed} completed agenda item"
+                f"{'s' if removed != 1 else ''} from <#{channel_id}>{initiator_clause}."
+            ),
+            removed_count=removed,
+        )


### PR DESCRIPTION
## Summary
- New `committee-agenda` skill lets community members request agenda items via natural language (`@Roo add to agenda: <topic>`); Roo posts a structured Block Kit card to a dedicated `#committee-agenda` Slack channel.
- Slack is the source of truth — seconds are tallied via emoji reactions on the posted card.
- Committee admins (`admin`/`committee`/`portfolio_lead` roles) can close items with `@Roo agenda complete` in the item's thread, delete with `@Roo remove agenda item`, or bulk-clear completed items with `@Roo agenda cleanup` / `@Roo remove completed agenda items`.
- Deterministic routing patterns in `content_intent.py` mean these phrases match before the LLM fallback. 42/42 existing routing tests still pass.

## Configuration
Add to `.env`:
- `COMMITTEE_AGENDA_CHANNEL_ID` — Slack channel ID for agenda posts (preferred), or
- `COMMITTEE_AGENDA_CHANNEL_NAME` — defaults to `committee-agenda`; resolved at runtime if the bot is a member.
- `COMMITTEE_AGENDA_SECOND_EMOJI` — defaults to `+1`.

The Slack bot needs `channels:history`, `chat:write`, and (if using channel-name resolution) membership in the agenda channel. Edits/deletes only work on messages Roo posted.

## Test plan
- [ ] Set `COMMITTEE_AGENDA_CHANNEL_ID` and restart Roo.
- [ ] In any channel: `@Roo add to agenda: budget for new whiteboards` → card appears in `#committee-agenda`, confirmation reply links back.
- [ ] React `:+1:` on the card — confirm it counts as a second visually.
- [ ] As a committee admin, in the card's thread: `@Roo agenda complete` → header flips to "✅ Completed agenda item", thread reply confirms.
- [ ] As a committee admin, in the card's thread: `@Roo remove agenda item` → card deleted.
- [ ] As a committee admin: `@Roo remove completed agenda items` → all `✅ Completed` cards in the channel are deleted, summary returned.
- [ ] As a non-admin: `@Roo agenda complete` → denial message, no state change.
- [ ] Confirm no regression in existing routing (content-factory, github-integration, linear-meeting-actions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)