### PR TITLE
Add MLAI Championships coworking leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,18 @@ For daily jobs, the recommended production setup is:
 - `mlai-backend` owns the 7am Melbourne scheduler and Slack posting
 - Roo keeps `JOBS_SCHEDULER_ENABLED=false`
 - Roo only needs `JOBS_API_URL` and `JOBS_TRIGGER_TOKEN` if you want it to trigger backend jobs manually in the future
+
+## MLAI Championships (coworking leaderboard) — admin setup
+
+The `coworking_leaderboard` action lets any member ask Roo for a ranked list of who's booked the coworking space the most ("MLAI championships", "leaderboard", "who came in the most this week", etc.). The Roo-side intent, formatter, and tests are in place — but the feature needs two things that have to happen outside this repo before it works end-to-end.
+
+**Slack admin (manual, one-time):**
+1. Create a Slack channel named `#mlai-championships` for testing the response in isolation before it goes general-availability.
+2. Invite the Roo bot user to that channel.
+3. Post in-channel with something like `@Roo MLAI championships this week` to smoke-test once steps 4–5 below are done.
+
+**mlai-backend owner:**
+4. Extend `GET /api/v1/points/coworking/report/` to accept `?include_users=true` and return a top-level `users` array sorted desc by booking count. Each entry should include at least `slack_user_id` and `booking_count`. Roo defensively re-sorts and handles a missing/empty `users` array with a friendly empty-state, so the feature degrades safely if the field isn't shipped yet.
+5. Confirm `slack_user_id` (not `user_id`) is the field name on the response.
+
+No new env vars are required for Roo. The leaderboard is public by design — every member can run it — so it does not gate on a points-admin role like the existing `coworking_report` command does.

--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -371,6 +371,12 @@ class RooAgent:
             r'\bcreate\s+(?:a\s+)?task\b',
             r'\btask\s+create\b',
             r'\bworth\s+\d+\s+points?\b',
+            r'\bmlai\s+championships?\b',
+            r'\bleaderboard\b',
+            r'\bwho\s+came\s+in\b',
+            r"\bwho(?:'s|s)?\s+been\s+in\b",
+            r'\btop\s+(?:\d{1,3}\s+)?members?\b',
+            r'\bmost\s+active\b',
         )
         return any(re.search(pattern, text) for pattern in patterns)
 

--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -1075,16 +1075,26 @@ class MLAIBackendClient:
         response.raise_for_status()
         return response.json()
 
-    async def get_coworking_report(self, slack_user_id: str, start_date: str, end_date: str) -> dict:
+    async def get_coworking_report(
+        self,
+        slack_user_id: str,
+        start_date: str,
+        end_date: str,
+        *,
+        include_users: bool = False,
+    ) -> dict:
         """Get active coworking booking report for an inclusive date range."""
+        params = {
+            "slack_user_id": self._clean_slack_id(slack_user_id),
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+        if include_users:
+            params["include_users"] = "true"
         response = await self._request(
             "GET",
             f"{self._points_base}/coworking/report/",
-            params={
-                "slack_user_id": self._clean_slack_id(slack_user_id),
-                "start_date": start_date,
-                "end_date": end_date,
-            },
+            params=params,
             timeout=15.0,
             transport_retries=1,
             retry_backoff_seconds=0.25,

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -6123,6 +6123,20 @@ Chunk {index} source: {label}
             return "request_points"
 
         if action in [
+            "coworking_leaderboard",
+            "leaderboard",
+            "coworking_championship",
+            "coworking_championships",
+            "championship",
+            "championships",
+            "coworking_ranking",
+            "ranking",
+        ]:
+            return "coworking_leaderboard"
+        if self._is_coworking_leaderboard_request(text, params):
+            return "coworking_leaderboard"
+
+        if action in [
             "coworking_report",
             "report_coworking",
             "coworking_summary",
@@ -7496,6 +7510,143 @@ Chunk {index} source: {label}
         context = self._build_coworking_analysis_context("coworking report", report, None, None)
         return self._format_coworking_analysis_fallback(context)
 
+    def _is_coworking_leaderboard_request(self, text: str, params: dict) -> bool:
+        """Detect public coworking leaderboard / MLAI Championships requests."""
+        text_lower = self._normalize_points_routing_text(text)
+
+        if re.search(r"\bmlai\s+championships?\b", text_lower):
+            return True
+        if re.search(r"\bchampionships?\b", text_lower) and "coworking" in text_lower:
+            return True
+        if re.search(r"\bleaderboard\b", text_lower) and "coworking" in text_lower:
+            return True
+        if re.search(
+            r"\bwho(?:'s|s|\s+is|\s+has|'s\s+been|s\s+been|\s+been|\s+came|\s+came\s+in|\s+came\s+in\s+the|\s+coming\s+in)\b.*\b(?:most|the\s+most)\b",
+            text_lower,
+        ):
+            return True
+        if re.search(r"\bwho\s+came\s+in\b", text_lower):
+            return True
+        if re.search(r"\bwho(?:'s|s|\s+is|\s+has|'s\s+been|s\s+been)\s+(?:been\s+)?coming\s+in\b", text_lower):
+            return True
+        if re.search(r"\bmost\s+active\b", text_lower) and "coworking" in text_lower:
+            return True
+        if re.search(r"\btop\s+(?:\d{1,3}\s+)?members?\b", text_lower) and any(
+            word in text_lower for word in ("coworking", "week", "month")
+        ):
+            return True
+        return False
+
+    def _parse_leaderboard_limit(self, text: str, params: dict, *, default: int = 5, cap: int = 25) -> int:
+        """Parse leaderboard size from params or text (clamps to 1..cap)."""
+        raw_limit = params.get("limit") or params.get("top")
+        if raw_limit is not None:
+            try:
+                limit = int(raw_limit)
+                return max(1, min(cap, limit))
+            except (TypeError, ValueError):
+                pass
+
+        match = re.search(r"\btop\s+(\d{1,3})\b", str(text or "").lower())
+        if match:
+            limit = int(match.group(1))
+            return max(1, min(cap, limit))
+        return default
+
+    def _coworking_leaderboard_label(self, text: str, start_date: str, end_date: str) -> str:
+        """Friendly label for the leaderboard range header."""
+        text_lower = text.lower()
+        if re.search(r"\blast\s+week\b", text_lower):
+            return "last week"
+        if re.search(r"\bthis\s+week\b", text_lower):
+            return "this week"
+        if re.search(r"\blast\s+month\b", text_lower):
+            return "last month"
+        if re.search(r"\blast\s+3\s+months?\b", text_lower):
+            return "last 3 months"
+        if re.search(r"\blast\s+6\s+months?\b", text_lower):
+            return "last 6 months"
+        if re.search(r"\b(?:last|past)\s+(?:1\s+)?years?\b", text_lower) or re.search(
+            r"\blast\s+12\s+months?\b",
+            text_lower,
+        ):
+            return "last year"
+        if re.search(r"\blast\s+7\s+days?\b", text_lower):
+            return "last 7 days"
+        return f"{start_date} → {end_date}"
+
+    def _format_coworking_leaderboard(self, report: dict, range_label: str, limit: int) -> str:
+        """Render the MLAI Championships coworking leaderboard for Slack.
+
+        Uses standard competition ranking: ties share the lower index's rank/medal,
+        and the next rank is skipped accordingly (e.g., 5, 4, 4, 4 -> 🥇, 🥈, 🥈, 4.).
+        """
+        report_range = report.get("range") or {}
+        totals = report.get("totals") or {}
+        start_date = report_range.get("start_date") or ""
+        end_date = report_range.get("end_date") or ""
+
+        users = list(report.get("users") or [])
+        header = f"🏆 MLAI Championships — {range_label}"
+        range_line = f"Range: {start_date} to {end_date}"
+
+        if not users:
+            return (
+                f"{header}\n"
+                f"{range_line}\n\n"
+                "No coworking bookings in that range yet — be the first to claim the title! 🏆"
+            )
+
+        cleaned = []
+        for entry in users:
+            slack_id = str(entry.get("slack_user_id") or entry.get("user_id") or "").strip()
+            if not slack_id:
+                continue
+            slack_id = re.sub(r"[<@>]", "", slack_id)
+            try:
+                count = int(entry.get("booking_count", 0) or 0)
+            except (TypeError, ValueError):
+                count = 0
+            cleaned.append((slack_id, count))
+
+        if not cleaned:
+            return (
+                f"{header}\n"
+                f"{range_line}\n\n"
+                "No coworking bookings in that range yet — be the first to claim the title! 🏆"
+            )
+
+        cleaned.sort(key=lambda item: (-item[1], item[0]))
+        capped_limit = max(1, min(25, int(limit or 5)))
+        shown = cleaned[:capped_limit]
+
+        medals = {1: "🥇", 2: "🥈", 3: "🥉"}
+        rows: list[str] = []
+        rank = 0
+        previous_count: Optional[int] = None
+        for index, (slack_id, count) in enumerate(shown, start=1):
+            if previous_count is None or count != previous_count:
+                rank = index
+            previous_count = count
+            day_word = "day" if count == 1 else "days"
+            if rank in medals:
+                rows.append(f"{medals[rank]} <@{slack_id}>  {count} {day_word}")
+            else:
+                rows.append(f"{rank:>2}. <@{slack_id}>  {count} {day_word}")
+
+        unique_users = int(totals.get("unique_users", len(cleaned)) or 0)
+        booked_user_days = int(
+            totals.get("booked_user_days", sum(count for _, count in cleaned)) or 0
+        )
+        member_word = "member" if unique_users == 1 else "members"
+        day_word = "user-day" if booked_user_days == 1 else "user-days"
+        footer = (
+            f"🎉 {unique_users} {member_word} showed up across "
+            f"{booked_user_days} {day_word} — keep it up!"
+        )
+
+        return "\n".join([header, range_line, "", *rows, "", footer])
+
     def _resolve_coworking_booking_date(
         self,
         params: dict,
@@ -8057,6 +8208,34 @@ Chunk {index} source: {label}
                 comparison_range,
             )
             return await self._format_coworking_analysis_response(context)
+
+        elif action == "coworking_leaderboard":
+            from ..clients.mlai_backend import MLAIBackendUnavailableError
+
+            start_date, end_date, error = self._resolve_coworking_report_range(text, params)
+            if error:
+                from ..utils import get_current_date
+
+                today = get_current_date()
+                start_date = (today - timedelta(days=6)).isoformat()
+                end_date = today.isoformat()
+
+            try:
+                report = await client.get_coworking_report(
+                    user_id,
+                    start_date,
+                    end_date,
+                    include_users=True,
+                )
+            except MLAIBackendUnavailableError:
+                return (
+                    "The MLAI Championships leaderboard isn't available right now — "
+                    "the points backend is taking a quick breather. Try again in a moment."
+                )
+
+            range_label = self._coworking_leaderboard_label(text, start_date, end_date)
+            limit = self._parse_leaderboard_limit(text, params)
+            return self._format_coworking_leaderboard(report, range_label, limit)
 
         elif action == "admin_checkin_coworking":
             from ..slack_client import get_bot_user_id

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -227,6 +227,25 @@ def test_luma_attendee_csv_phrase_routes_to_luma_events():
         assert skill.name == "luma-events"
 
 
+def test_coworking_leaderboard_phrases_route_to_points():
+    agent = _make_agent()
+
+    for text in [
+        "MLAI championships this week",
+        "mlai championship last week",
+        "coworking leaderboard",
+        "leaderboard for coworking",
+        "who came in the most last week",
+        "who's been in the most this month",
+        "top 10 members this month",
+        "top members this week",
+        "most active coworking this week",
+    ]:
+        skill = agent._select_skill_from_triggers(text)
+        assert skill is not None, f"no skill matched for: {text!r}"
+        assert skill.name == "mlai-points", f"wrong skill for {text!r}: {skill.name}"
+
+
 def test_coworking_report_wording_routes_to_points():
     agent = _make_agent()
 

--- a/roo-standalone/roo/tests/test_coworking_leaderboard.py
+++ b/roo-standalone/roo/tests/test_coworking_leaderboard.py
@@ -1,0 +1,265 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("frontmatter", SimpleNamespace(load=lambda *args, **kwargs: None))
+sys.modules.pop("roo.skills.executor", None)
+
+executor_module = importlib.import_module("roo.skills.executor")
+SkillExecutor = executor_module.SkillExecutor
+
+
+def test_resolve_points_action_detects_leaderboard_phrases():
+    executor = SkillExecutor()
+
+    for text in [
+        "MLAI championships this week",
+        "mlai championship last week",
+        "coworking leaderboard",
+        "leaderboard for coworking",
+        "who came in the most last week",
+        "who's been in the most this month",
+        "who's coming in the most",
+        "top 10 members this month",
+        "top members last week",
+        "most active coworking this week",
+    ]:
+        assert (
+            executor._resolve_points_action({}, text) == "coworking_leaderboard"
+        ), f"expected leaderboard routing for: {text!r}"
+
+
+def test_resolve_points_action_leaderboard_action_aliases():
+    executor = SkillExecutor()
+
+    for action in [
+        "coworking_leaderboard",
+        "leaderboard",
+        "championship",
+        "championships",
+        "coworking_championship",
+        "coworking_championships",
+        "ranking",
+        "coworking_ranking",
+    ]:
+        assert (
+            executor._resolve_points_action({"action": action}, "")
+            == "coworking_leaderboard"
+        ), f"expected leaderboard routing for action: {action!r}"
+
+
+def test_leaderboard_check_runs_before_report():
+    executor = SkillExecutor()
+
+    # "leaderboard coworking" should NOT get swallowed by the coworking_report path.
+    assert (
+        executor._resolve_points_action({}, "leaderboard coworking last week")
+        == "coworking_leaderboard"
+    )
+
+
+def test_parse_leaderboard_limit_defaults_and_clamps():
+    executor = SkillExecutor()
+
+    assert executor._parse_leaderboard_limit("MLAI championships this week", {}) == 5
+    assert executor._parse_leaderboard_limit("top 10 members this month", {}) == 10
+    assert executor._parse_leaderboard_limit("top 3 coworking", {}) == 3
+    assert executor._parse_leaderboard_limit("top 100 coworking", {}) == 25
+    assert executor._parse_leaderboard_limit("top 0 coworking", {}) == 1
+    assert executor._parse_leaderboard_limit("anything", {"limit": "8"}) == 8
+    assert executor._parse_leaderboard_limit("anything", {"limit": 50}) == 25
+
+
+def _sample_report_users(users):
+    return {
+        "range": {"start_date": "2026-05-18", "end_date": "2026-05-25"},
+        "totals": {"unique_users": 34, "booked_user_days": 67},
+        "users": users,
+    }
+
+
+def test_format_coworking_leaderboard_renders_medals_ties_and_footer():
+    """
+    Standard competition ranking ties: two on 4 days both show 🥈,
+    the next row is rank 4 (not 3).
+    """
+    executor = SkillExecutor()
+
+    report = _sample_report_users(
+        [
+            {"slack_user_id": "U123", "booking_count": 5},
+            {"slack_user_id": "U456", "booking_count": 4},
+            {"slack_user_id": "U789", "booking_count": 4},
+            {"slack_user_id": "U234", "booking_count": 3},
+            {"slack_user_id": "U567", "booking_count": 3},
+        ]
+    )
+
+    output = executor._format_coworking_leaderboard(report, "last week", 5)
+
+    assert "🏆 MLAI Championships — last week" in output
+    assert "Range: 2026-05-18 to 2026-05-25" in output
+    assert "🥇 <@U123>  5 days" in output
+    assert "🥈 <@U456>  4 days" in output
+    assert "🥈 <@U789>  4 days" in output
+    # Tied 🥈 means next rank skips 🥉 and becomes 4.
+    assert "🥉" not in output
+    # Two tied at 3 days also share rank 4 under competition ranking.
+    rank_four_lines = [line for line in output.splitlines() if line.startswith(" 4.")]
+    assert len(rank_four_lines) == 2
+    assert " 4. <@U234>  3 days" in output
+    assert " 4. <@U567>  3 days" in output
+    assert "34 members showed up across 67 user-days" in output
+
+
+def test_format_coworking_leaderboard_three_distinct_counts_uses_all_medals():
+    executor = SkillExecutor()
+
+    report = _sample_report_users(
+        [
+            {"slack_user_id": "U1", "booking_count": 5},
+            {"slack_user_id": "U2", "booking_count": 4},
+            {"slack_user_id": "U3", "booking_count": 3},
+            {"slack_user_id": "U4", "booking_count": 2},
+        ]
+    )
+
+    output = executor._format_coworking_leaderboard(report, "last week", 5)
+
+    assert "🥇 <@U1>  5 days" in output
+    assert "🥈 <@U2>  4 days" in output
+    assert "🥉 <@U3>  3 days" in output
+    assert " 4. <@U4>  2 days" in output
+
+
+def test_format_coworking_leaderboard_with_two_users_drops_bronze():
+    executor = SkillExecutor()
+
+    report = {
+        "range": {"start_date": "2026-05-18", "end_date": "2026-05-25"},
+        "totals": {"unique_users": 2, "booked_user_days": 5},
+        "users": [
+            {"slack_user_id": "U1", "booking_count": 3},
+            {"slack_user_id": "U2", "booking_count": 2},
+        ],
+    }
+
+    output = executor._format_coworking_leaderboard(report, "last week", 5)
+
+    assert "🥇 <@U1>  3 days" in output
+    assert "🥈 <@U2>  2 days" in output
+    assert "🥉" not in output
+    # Only two member rows, no padding entries.
+    lines = [line for line in output.splitlines() if "<@" in line]
+    assert len(lines) == 2
+
+
+def test_format_coworking_leaderboard_empty_users_friendly_message():
+    executor = SkillExecutor()
+
+    report = {
+        "range": {"start_date": "2026-05-18", "end_date": "2026-05-25"},
+        "totals": {"unique_users": 0, "booked_user_days": 0},
+        "users": [],
+    }
+
+    output = executor._format_coworking_leaderboard(report, "last week", 5)
+
+    assert "🏆 MLAI Championships — last week" in output
+    assert "Range: 2026-05-18 to 2026-05-25" in output
+    assert "be the first to claim the title" in output
+    assert "<@" not in output
+
+
+def test_format_coworking_leaderboard_missing_users_key_treated_as_empty():
+    executor = SkillExecutor()
+
+    report = {
+        "range": {"start_date": "2026-05-18", "end_date": "2026-05-25"},
+        "totals": {"unique_users": 0, "booked_user_days": 0},
+    }
+
+    output = executor._format_coworking_leaderboard(report, "last week", 5)
+
+    assert "be the first to claim the title" in output
+
+
+def test_format_coworking_leaderboard_caps_at_25_and_singular_day():
+    executor = SkillExecutor()
+
+    users = [
+        {"slack_user_id": f"U{i:03d}", "booking_count": (30 - i)}
+        for i in range(30)
+    ]
+    report = {
+        "range": {"start_date": "2026-05-01", "end_date": "2026-05-25"},
+        "totals": {"unique_users": 30, "booked_user_days": sum(u["booking_count"] for u in users)},
+        "users": users,
+    }
+
+    output = executor._format_coworking_leaderboard(report, "last month", 100)
+    # Cap at 25 rows.
+    member_rows = [line for line in output.splitlines() if "<@" in line]
+    assert len(member_rows) == 25
+
+
+def test_format_coworking_leaderboard_singular_day_word():
+    executor = SkillExecutor()
+
+    report = {
+        "range": {"start_date": "2026-05-18", "end_date": "2026-05-25"},
+        "totals": {"unique_users": 1, "booked_user_days": 1},
+        "users": [{"slack_user_id": "U1", "booking_count": 1}],
+    }
+
+    output = executor._format_coworking_leaderboard(report, "last week", 5)
+
+    assert "🥇 <@U1>  1 day" in output
+    assert "1 member showed up across 1 user-day" in output
+
+
+def test_leaderboard_label_picks_friendly_keyword_or_iso_range():
+    executor = SkillExecutor()
+
+    assert executor._coworking_leaderboard_label("last week vibes", "2026-05-18", "2026-05-25") == "last week"
+    assert executor._coworking_leaderboard_label("this week", "2026-05-18", "2026-05-25") == "this week"
+    assert executor._coworking_leaderboard_label("last month please", "2026-04-01", "2026-04-30") == "last month"
+    assert (
+        executor._coworking_leaderboard_label("from 2026-05-01 to 2026-05-25", "2026-05-01", "2026-05-25")
+        == "2026-05-01 → 2026-05-25"
+    )
+
+
+def test_is_coworking_leaderboard_request_matches_brief_phrases():
+    executor = SkillExecutor()
+
+    for text in [
+        "MLAI championships",
+        "mlai championship this week",
+        "coworking leaderboard",
+        "leaderboard for coworking last week",
+        "who came in the most last week",
+        "who's been in the most",
+        "who's coming in the most",
+        "top members this week",
+        "top 10 members this month",
+        "most active coworking this week",
+    ]:
+        assert executor._is_coworking_leaderboard_request(text, {}), f"missed: {text!r}"
+
+
+def test_is_coworking_leaderboard_request_skips_unrelated_phrases():
+    executor = SkillExecutor()
+
+    for text in [
+        "coworking report last week",
+        "coworking summary last 6 months",
+        "how many points do I have",
+        "book me in tomorrow",
+        "balance",
+    ]:
+        assert not executor._is_coworking_leaderboard_request(text, {}), f"matched but shouldn't: {text!r}"

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -167,6 +167,73 @@ async def test_get_coworking_report_uses_canonical_endpoint(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_coworking_report_include_users_sets_query_flag(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["params"] = kwargs["params"]
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(
+            200,
+            request=request,
+            json={
+                "totals": {"booked_user_days": 3, "unique_users": 2},
+                "users": [
+                    {"slack_user_id": "U123", "booking_count": 2},
+                    {"slack_user_id": "U456", "booking_count": 1},
+                ],
+            },
+        )
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.get_coworking_report(
+        "<@U123>",
+        "2026-01-01",
+        "2026-01-31",
+        include_users=True,
+    )
+
+    assert captured["method"] == "GET"
+    assert captured["endpoint"] == "/api/v1/points/coworking/report/"
+    assert captured["params"] == {
+        "slack_user_id": "U123",
+        "start_date": "2026-01-01",
+        "end_date": "2026-01-31",
+        "include_users": "true",
+    }
+    assert result["users"][0]["slack_user_id"] == "U123"
+
+
+@pytest.mark.asyncio
+async def test_get_coworking_report_omits_include_users_flag_by_default(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured["params"] = kwargs["params"]
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(200, request=request, json={"totals": {}})
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    await client.get_coworking_report("U123", "2026-01-01", "2026-01-31")
+
+    assert "include_users" not in captured["params"]
+
+
+@pytest.mark.asyncio
 async def test_create_points_purchase_sends_slack_origin(monkeypatch):
     captured = {}
 

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -20,6 +20,10 @@ trigger_keywords:
   - pay for points
   - add points
   - add roo points
+  - leaderboard
+  - championship
+  - championships
+  - mlai championships
 ---
 
 # MLAI Points System Skill


### PR DESCRIPTION
## Summary
- New public `coworking_leaderboard` Roo intent — triggered by phrases like "MLAI championships", "leaderboard", "who came in the most this week" — that ranks members by coworking bookings over a window (default last 7 days) and renders a celebratory Slack message with medals 🥇🥈🥉 and `<@user>` mentions.
- Backend client (`get_coworking_report`) extended with `include_users=True` kwarg; if `mlai-backend` doesn't (yet) ship a `users` array, Roo degrades to a friendly empty-state rather than crashing.
- Public by design — no points-admin gate. Yana's ask in the committee thread was a community shout-out, not an admin report.

## Context
Yana asked in Slack whether Roo could "extract specific users from the data… 'MLAI championships - who's come in the most in the last week / month'… and just highlight the community". This implements the Roo-side intent + formatter; the backend change to populate per-user data is tracked separately (see README admin setup section).

## What's in the PR
- `roo/clients/mlai_backend.py` — `include_users` kwarg on `get_coworking_report`
- `roo/skills/executor.py` — intent routing, handler, helpers (`_is_coworking_leaderboard_request`, `_parse_leaderboard_limit`, `_coworking_leaderboard_label`, `_format_coworking_leaderboard`)
- `roo/agent.py` + `skills/mlai_points/SKILL.md` — fast-path trigger phrases
- New `roo/tests/test_coworking_leaderboard.py` (14 tests) + extensions to `test_mlai_backend_client.py` and `test_agent_routing.py` — 67 tests passing
- `README.md` — admin setup section documenting the manual Slack-channel + `mlai-backend` endpoint steps that have to happen outside this repo

## Test plan
- [ ] Backend owner adds `?include_users=true` support to `/api/v1/points/coworking/report/`
- [ ] Slack admin creates `#mlai-championships` and invites Roo
- [ ] In `#mlai-championships`, run `@Roo MLAI championships this week` and confirm the medals/mentions/footer render correctly
- [ ] Try `@Roo top 10 members last month` — confirm range parsing + limit override
- [ ] With backend `users` missing, confirm empty-state copy renders instead of an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)