### PR TITLE
Add Watt The Hack announcement skill

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -2519,4 +2519,46 @@ class MLAIBackendClient:
             print(f"⚠️ MedHack create announcement error: {e}")
             return None
 
+    async def generic_hackathon_create_announcement(
+        self,
+        slug: str,
+        title: str,
+        body: str,
+        requester_slack_id: str,
+        author_slack_id: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Create an announcement on a generic hackathon website (e.g. Watt The Hack).
+
+        Args:
+            slug: Hackathon slug (e.g. "watt-the-hack")
+            title: Announcement title
+            body: Announcement body text
+            requester_slack_id: Slack ID of the human requesting the announcement.
+                The backend authorises this against Django superusers.
+            author_slack_id: Slack ID to attribute as the author (Roo's bot id).
+
+        Returns:
+            Response dict on success (201), an error dict with ``status_code`` on
+            a non-201 response, or None on a transport error.
+        """
+        try:
+            response = await self._request(
+                "POST",
+                f"/api/v1/hackathons/{slug}/app/announcements/",
+                json={
+                    "title": title,
+                    "body": body,
+                    "requester_slack_id": requester_slack_id,
+                    "slack_user_id": author_slack_id,
+                },
+                timeout=10.0,
+                circuit_breaker=True,
+            )
+            if response.status_code == 201:
+                return response.json()
+            return {"status_code": response.status_code, "detail": response.text}
+        except Exception as e:
+            print(f"⚠️ Generic hackathon create announcement error: {e}")
+            return None
+
     # End of MLAIBackendClient

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -168,6 +168,8 @@ class SkillExecutor:
                 result = await self._execute_tone_of_voice(skill, text, params, user_id)
             elif skill.name == "medhack":
                 result = await self._execute_medhack(skill, text, params, user_id, channel_id, thread_ts, thread_history)
+            elif skill.name == "watt-the-hack":
+                result = await self._execute_watt_the_hack(skill, text, params, user_id, channel_id, thread_ts, thread_history)
             elif skill.name == "luma-events":
                 result = await self._execute_luma_events(skill, text, params, user_id, channel_id, thread_ts)
             else:
@@ -882,6 +884,110 @@ Original text:
             # The MedHack client will handle missing users gracefully with local fallback
             print(f"⚠️ Failed to register user {user_id}: {e}")
             print(f"   MedHack will continue with local JSON fallback")
+
+    async def _execute_watt_the_hack(
+        self,
+        skill: Skill,
+        text: str,
+        params: dict,
+        user_id: str,
+        channel_id: Optional[str] = None,
+        thread_ts: Optional[str] = None,
+        thread_history: Optional[List[dict]] = None,
+    ) -> str:
+        """Execute the Watt The Hack skill: publish announcements to the site.
+
+        Authorisation is delegated to the backend — only Slack users who map to
+        an MLAI Django superuser may publish. Announcements are authored by Roo
+        (the bot identity), matching the MedHack behaviour.
+        """
+        import json
+        import re
+
+        # Channel restriction: this skill only operates in the Watt channel.
+        if skill.exclusive_channels and channel_id:
+            from ..slack_client import get_channel_name
+            channel_name = get_channel_name(channel_id)
+            if channel_name and channel_name not in skill.exclusive_channels:
+                channels_list = ", ".join(f"#*{ch}*" for ch in skill.exclusive_channels)
+                return f"The Watt The Hack skill is only available in {channels_list}."
+
+        text_lower = text.lower()
+        announce_keywords = ["announce", "announcement", "post announcement", "create announcement"]
+        is_announcement = any(k in text_lower for k in announce_keywords)
+
+        if not is_announcement:
+            # Not an announcement request — fall back to a general LLM answer.
+            return await self._execute_with_llm(skill, text, params, user_id, thread_history)
+
+        # Use an LLM to extract a clear title and body from the request.
+        extract_prompt = f"""Extract the announcement title and body from this message.
+The user wants to create an announcement for the Watt The Hack hackathon website.
+
+User message: "{text}"
+
+Return ONLY valid JSON with two keys: "title" and "body".
+If you cannot determine a clear title or body from the message, set the missing field to null.
+
+Example: {{"title": "Lunch is served", "body": "Pizza is in the atrium at 1pm."}}
+
+JSON:"""
+        openai_client = get_llm_client("openai")
+        extract_response = await openai_client.chat([
+            {"role": "system", "content": "You extract structured data from text. Return valid JSON only."},
+            {"role": "user", "content": extract_prompt}
+        ], model="gpt-4o-mini", max_tokens=1024)
+
+        try:
+            content = extract_response.content.strip()
+            if content.startswith("```"):
+                content = re.sub(r'^```\w*\n?', '', content)
+                content = re.sub(r'\n?```$', '', content)
+            extracted = json.loads(content)
+        except json.JSONDecodeError:
+            extracted = {}
+
+        ann_title = extracted.get("title")
+        ann_body = extracted.get("body")
+
+        if not ann_title or not ann_body:
+            return (
+                f"<@{user_id}> I need both a *title* and *body* for the announcement. "
+                f"Try something like:\n"
+                f"_\"Post an announcement titled 'Lunch is served' with body 'Pizza is in the atrium at 1pm.'\"_"
+            )
+
+        # Publish via the backend. The requesting human (user_id) is checked
+        # against Django superusers; authorship is attributed to Roo's bot id so
+        # the website shows Roo as the author.
+        from ..clients.mlai_backend import MLAIBackendClient
+        from ..slack_client import get_bot_user_id
+        backend = MLAIBackendClient()
+        bot_id = get_bot_user_id()
+        result = await backend.generic_hackathon_create_announcement(
+            slug="watt-the-hack",
+            title=ann_title,
+            body=ann_body,
+            requester_slack_id=user_id,
+            author_slack_id=bot_id,
+        )
+
+        if result is None:
+            return f"<@{user_id}> Something went wrong creating the announcement. Please try again later."
+
+        status_code = result.get("status_code")
+        if status_code == 400:
+            return f"<@{user_id}> The announcement couldn't be created — {result.get('detail', 'something is missing')}."
+        if status_code in (401, 403):
+            return (
+                f"<@{user_id}> Sorry, only MLAI superusers can post announcements "
+                f"to the Watt The Hack site."
+            )
+        if status_code is not None:
+            return f"<@{user_id}> Unexpected error (HTTP {status_code}): {result.get('detail', 'unknown')}"
+
+        # Success — the framework posts this confirmation back in-thread.
+        return f"Announcement *\"{ann_title}\"* has been posted to the Watt The Hack website."
 
     async def _execute_medhack(
         self,

--- a/roo-standalone/skills/watt-the-hack/SKILL.md
+++ b/roo-standalone/skills/watt-the-hack/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: watt-the-hack
+description: Post announcements to the Watt The Hack hackathon website and answer questions about the event. Use for any request to make, post, or create an announcement in the Watt The Hack channel.
+trigger_keywords:
+  - watt the hack
+  - watt
+  - announcement
+  - announce
+  - post announcement
+  - create announcement
+priority_channels:
+  - watt-the-hack
+exclusive_channels:
+  - watt-the-hack
+---
+
+# Watt The Hack Skill
+
+This skill lets organisers publish announcements to the Watt The Hack participant
+website straight from Slack. Published announcements appear in the Announcements
+panel on the participant dashboard.
+
+## Making an announcement
+
+When someone tags Roo in #watt-the-hack and asks to make / post / create an
+announcement, extract a clear **title** and a **body** from their message and
+publish it to the Watt The Hack site.
+
+- Only MLAI superusers can post announcements. Authorisation is verified by the
+  backend against the requester's account — if the person asking is not a
+  superuser, the backend refuses and Roo relays a polite "only MLAI superusers
+  can post announcements" message.
+- Once published, confirm back in the thread with the announcement title.
+- If the message is missing a clear title or body, ask the organiser to provide
+  both.
+
+Example: "@roo post an announcement titled 'Lunch is served' with body 'Pizza is
+in the atrium at 1pm.'"
+
+## Parameters
+
+- **query**: The organiser's announcement request, or a question about the Watt
+  The Hack event (required)


### PR DESCRIPTION
## What

Lets organisers publish announcements to the **Watt The Hack** participant website from Slack. Tag Roo in `#watt-the-hack` and ask it to make an announcement; Roo extracts a title/body and posts it to the backend, which renders it in the dashboard's Announcements panel.

Pairs with the backend endpoint in MLAI-AUS-Inc/mlai-backend#414.

## How

- **`skills/watt-the-hack/SKILL.md`** — new skill scoped to `#watt-the-hack` via `exclusive_channels`/`priority_channels`, with `announce`/`announcement` triggers.
- **`roo/skills/executor.py`** — `_execute_watt_the_hack` handler + a dispatch branch. Extracts title/body via the LLM, then calls the backend with the requesting human's Slack id (for the superuser check) and Roo's bot id (for authorship). A `401/403` from the backend becomes a polite "only MLAI superusers can post" reply.
- **`roo/clients/mlai_backend.py`** — `generic_hackathon_create_announcement(slug, title, body, requester_slack_id, author_slack_id)` → `POST /api/v1/hackathons/<slug>/app/announcements/`.

Authorisation lives entirely in the backend (Django superuser check) — there is no allow-list to maintain on the roo side.

## Notes

- Unlike the MedHack copy, the handler does **not** call `post_message` for its own confirmation (the framework already posts the returned message), so it posts once rather than twice.
- Verified: both edited modules compile; the new skill's frontmatter parses with the expected channel/keyword fields. Full runtime needs a live backend + Slack.

## Ops

- Invite Roo to `#watt-the-hack` and confirm the channel slug is `watt-the-hack`.
- Confirm `ROO_API_KEY` matches the backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)