### PR TITLE
Add Roo data query skill

### DIFF
--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -364,6 +364,8 @@ class RooAgent:
             r'\btop-up\b',
             r'\bbalance\b',
             r'\bcoworking\b',
+            r'\boffice\b.*\b(?:attendance|attended|usage|used|report|summary)\b',
+            r'\b(?:attendance|attended|usage|used)\b.*\boffice\b',
             r'\bbook\s+me\s+in\b',
             r'\bcheck\b.*<@[a-z0-9]+>.*\bin\b',
             r'\brewards?\b',
@@ -486,6 +488,37 @@ class RooAgent:
         )
         return has_creation_intent and has_issue_noun and has_linear_project
 
+    def _looks_like_data_query_request(self, text: str) -> bool:
+        if re.search(r'\b(?:data|database|db)\s+(?:catalog|resources?|tables?|schema)\b', text):
+            return True
+        if re.search(r'\b(?:what|which|show|list)\b.*\b(?:tables?|resources?)\b.*\b(?:query|available|access)\b', text):
+            return True
+
+        has_query_intent = bool(
+            re.search(
+                r'\b(?:how\s+many|count|show|list|which|what|query|find|search|give\s+me|display|report)\b',
+                text,
+            )
+        )
+        if not has_query_intent:
+            return False
+
+        data_subject_patterns = (
+            r'\bvibe\s*raising\b',
+            r'\bstartup\s+(?:updates?|drafts?|profiles?|bindings?|metrics?|events?)\b',
+            r'\bmonthly\s+update\s+drafts?\b',
+            r'\bupdates?\s+drafts?\b',
+            r'\bcontent\s+factory\s+(?:jobs?|runs?|steps?|attempts?|articles?)\b',
+            r'\blinear\s+(?:issues?|projects?|project\s+updates?)\b',
+            r'\bgmail\s+(?:messages?|threads?|attachments?)\b',
+            r'\bslack\s+(?:messages?|threads?|channel\s+selections?)\b',
+            r'\bgithub\s+integrations?\b',
+            r'\bfinancial\s+(?:records?|accounts?)\b',
+            r'\borganizations?\b',
+            r'\bstartup\s+data\b',
+        )
+        return any(re.search(pattern, text) for pattern in data_subject_patterns)
+
     def _looks_like_content_follow_up(self, text: str) -> bool:
         patterns = (
             r'\bwrite\b',
@@ -525,6 +558,7 @@ class RooAgent:
         luma_skill = self._get_skill_by_name("luma-events")
         points_skill = self._get_skill_by_name("mlai-points")
         linear_meeting_skill = self._get_skill_by_name("linear-meeting-actions")
+        data_query_skill = self._get_skill_by_name("mlai-data-query")
 
         if luma_skill and self._looks_like_luma_request(text_lower):
             return luma_skill
@@ -541,6 +575,9 @@ class RooAgent:
             has_thread_context,
         ):
             return linear_meeting_skill
+
+        if data_query_skill and self._looks_like_data_query_request(text_lower):
+            return data_query_skill
 
         if (
             thread_context

--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -47,6 +47,7 @@ class MLAIBackendClient:
         )
         self.base_url = self.base_url.rstrip('/') if self.base_url else ""
         self._points_base = "/api/v1/points"
+        self._data_base = "/api/v1/data"
         self._admin_cache: Dict[str, bool] = {}
 
     def _backend_key(self) -> str:
@@ -1117,6 +1118,33 @@ class MLAIBackendClient:
             "/api/v1/integrations/luma/attendee-report",
             params=params,
             timeout=30.0,
+            transport_retries=1,
+            retry_backoff_seconds=0.25,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def get_data_catalog(self) -> dict:
+        """Get Roo's curated read-only data resource catalog."""
+        response = await self._request(
+            "GET",
+            f"{self._data_base}/catalog/",
+            timeout=15.0,
+            transport_retries=1,
+            retry_backoff_seconds=0.25,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def query_data(self, payload: dict) -> dict:
+        """Query a curated read-only data resource through mlai-backend."""
+        response = await self._request(
+            "POST",
+            f"{self._data_base}/query/",
+            json=payload,
+            timeout=35.0,
             transport_retries=1,
             retry_backoff_seconds=0.25,
             circuit_breaker=True,

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -150,6 +150,8 @@ class SkillExecutor:
                 result = await self._execute_connect_users(skill, text, params, user_id)
             elif skill.name == "mlai-points":
                 result = await self._execute_mlai_points(skill, text, params, user_id, channel_id, thread_ts)
+            elif skill.name == "mlai-data-query":
+                result = await self._execute_mlai_data_query(skill, text, params, user_id)
             elif skill.name == "github-integration":
                 result = await self._execute_github_integration(skill, text, params, user_id, channel_id, thread_ts)
             elif skill.name == "linear-meeting-actions":
@@ -6134,6 +6136,341 @@ Chunk {index} source: {label}
         if match:
             return match.group(1).strip()
         return None
+
+    async def _execute_mlai_data_query(
+        self,
+        skill: Skill,
+        text: str,
+        params: dict,
+        user_id: str,
+    ) -> Any:
+        """Execute curated read-only data queries through mlai-backend."""
+        from roo.clients import mlai_backend as backend_module
+
+        settings = get_settings()
+        if not settings.MLAI_BACKEND_URL:
+            return "Sorry mate, the data query API isn't configured. Ask the team to set MLAI_BACKEND_URL."
+
+        client = backend_module.MLAIBackendClient(
+            base_url=settings.MLAI_BACKEND_URL,
+            api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY,
+            internal_api_key=settings.INTERNAL_API_KEY or settings.ROO_API_KEY or settings.MLAI_API_KEY,
+        )
+
+        try:
+            if self._data_query_catalog_requested(text, params):
+                catalog = await client.get_data_catalog()
+                return {
+                    "message": self._format_data_catalog(catalog),
+                    "data": {"action": "data_catalog", "catalog": catalog},
+                }
+
+            payload = self._build_data_query_payload(text, params, user_id)
+            if not payload.get("resource"):
+                return (
+                    "I can query the curated data resources, but I need a more specific dataset. "
+                    "Ask for the data catalog to see what is available."
+                )
+
+            result = await client.query_data(payload)
+            return {
+                "message": self._format_data_query_result(payload, result),
+                "data": {
+                    "action": "data_query",
+                    "payload": payload,
+                    "result": result,
+                },
+            }
+        except backend_module.MLAIBackendUnavailableError:
+            return "MLAI backend is temporarily unavailable. Please try again in a moment."
+        except httpx.HTTPStatusError as exc:
+            detail = self._extract_http_error_detail(exc)
+            if exc.response.status_code == 403:
+                return detail or "You do not have access to that data resource."
+            if exc.response.status_code == 400:
+                return f"The data query was rejected: {detail or 'invalid query'}"
+            return detail or "The data query failed. Please try again in a moment."
+
+    def _data_query_catalog_requested(self, text: str, params: dict) -> bool:
+        action = str(params.get("action") or "").lower().strip()
+        if action in {"catalog", "list_resources", "schema"}:
+            return True
+        text_lower = str(text or "").lower()
+        return bool(
+            re.search(r'\b(?:data|database|db)\s+(?:catalog|resources?|tables?|schema)\b', text_lower)
+            or re.search(r'\b(?:what|which|show|list)\b.*\b(?:tables?|resources?)\b.*\b(?:query|available|access)\b', text_lower)
+        )
+
+    def _build_data_query_payload(self, text: str, params: dict, user_id: str) -> dict:
+        text_lower = str(text or "").lower()
+        operation = self._infer_data_query_operation(text_lower, params)
+        resource = self._infer_data_query_resource(text_lower, params)
+        payload: dict[str, Any] = {
+            "requester_slack_id": user_id,
+            "resource": resource,
+            "operation": operation,
+            "offset": self._coerce_data_query_offset(params.get("offset")),
+        }
+
+        filters = self._extract_data_query_filters(params)
+        filters.extend(self._infer_data_query_filters(text_lower, resource))
+        if filters:
+            payload["filters"] = filters
+
+        if operation == "aggregate":
+            group_by = self._extract_string_list(params.get("group_by"))
+            if group_by:
+                payload["group_by"] = group_by
+            limit = self._coerce_data_query_limit(params.get("limit"), default=20)
+            payload["limit"] = limit
+            order_by = self._extract_data_query_order_by(params.get("order_by"))
+            if order_by:
+                payload["order_by"] = order_by
+            return payload
+
+        if operation == "count":
+            return payload
+
+        fields = self._extract_string_list(params.get("fields")) or self._default_data_query_fields(resource)
+        if fields:
+            payload["fields"] = fields
+        limit = self._coerce_data_query_limit(params.get("limit"), default=20)
+        payload["limit"] = limit
+        order_by = self._extract_data_query_order_by(params.get("order_by"))
+        if order_by:
+            payload["order_by"] = order_by
+        return payload
+
+    def _infer_data_query_operation(self, text_lower: str, params: dict) -> str:
+        operation = str(params.get("operation") or "").lower().strip()
+        if operation in {"list", "count", "aggregate"}:
+            return operation
+        if re.search(r'\b(?:how\s+many|count|number\s+of|total\s+number)\b', text_lower):
+            return "count"
+        if re.search(r'\b(?:group\s+by|break\s+down|breakdown|by\s+status|by\s+state|by\s+month)\b', text_lower):
+            return "aggregate"
+        return "list"
+
+    def _infer_data_query_resource(self, text_lower: str, params: dict) -> str:
+        explicit = str(params.get("resource") or params.get("table") or "").strip().lower()
+        if explicit:
+            return re.sub(r'[^a-z0-9_]+', '_', explicit).strip("_")
+
+        resource_patterns = (
+            ("vibe_raising_companies", (r'\bvibe\s*raising\b.*\bcompan', r'\bcompan(?:y|ies)\b.*\bvibe\s*raising\b')),
+            ("vibe_raising_profiles", (r'\bvibe\s*raising\b.*\bprofiles?\b', r'\bfounder\s+profiles?\b')),
+            ("monthly_update_drafts", (r'\bmonthly\s+update\s+drafts?\b', r'\bupdate\s+drafts?\b', r'\bdrafts?\s+for\s+my\s+company\b')),
+            ("startup_metrics", (r'\bstartup\s+metrics?\b', r'\bmetrics?\b.*\bstartup\b')),
+            ("startup_events", (r'\bstartup\s+events?\b', r'\btimeline\s+events?\b')),
+            ("startup_profiles", (r'\bstartup\s+profiles?\b', r'\bcompany\s+profile\b')),
+            ("startup_bindings", (r'\bstartup\s+bindings?\b', r'\buser\s+startup\s+bindings?\b')),
+            ("content_factory_run_step_attempts", (r'\bcontent\s+factory\b.*\bstep\s+attempts?\b',)),
+            ("content_factory_run_steps", (r'\bcontent\s+factory\b.*\brun\s+steps?\b', r'\bcontent\s+factory\b.*\bsteps?\b')),
+            ("content_factory_runs", (r'\bcontent\s+factory\b.*\bruns?\b',)),
+            ("content_factory_jobs", (r'\bcontent\s+factory\b.*\bjobs?\b', r'\barticle\s+jobs?\b')),
+            ("written_articles", (r'\bwritten\s+articles?\b', r'\bpublished\s+articles?\b')),
+            ("researched_keywords", (r'\bresearched\s+keywords?\b', r'\bseo\s+keywords?\b')),
+            ("linear_project_updates", (r'\blinear\b.*\bproject\s+updates?\b',)),
+            ("linear_projects", (r'\blinear\b.*\bprojects?\b',)),
+            ("linear_issues", (r'\blinear\b.*\b(?:issues?|tickets?|tasks?)\b',)),
+            ("gmail_attachments", (r'\bgmail\b.*\battachments?\b',)),
+            ("gmail_threads", (r'\bgmail\b.*\bthreads?\b',)),
+            ("gmail_messages", (r'\bgmail\b.*\bmessages?\b', r'\bemails?\b')),
+            ("slack_channel_selections", (r'\bslack\b.*\bchannel\s+selections?\b',)),
+            ("slack_threads", (r'\bslack\b.*\bthreads?\b',)),
+            ("slack_messages", (r'\bslack\b.*\bmessages?\b',)),
+            ("github_integrations", (r'\bgithub\s+integrations?\b', r'\bconnected\s+github\b')),
+            ("financial_accounts", (r'\bfinancial\s+accounts?\b', r'\bbank\s+accounts?\b')),
+            ("financial_records", (r'\bfinancial\s+records?\b', r'\btransactions?\b')),
+            ("organizations", (r'\borganizations?\b', r'\bcompanies?\b')),
+            ("coworking_bookings", (r'\bcoworking\b.*\bbookings?\b',)),
+        )
+        for resource, patterns in resource_patterns:
+            if any(re.search(pattern, text_lower) for pattern in patterns):
+                return resource
+        return ""
+
+    def _infer_data_query_filters(self, text_lower: str, resource: str) -> list[dict]:
+        filters: list[dict] = []
+        if resource in {"content_factory_jobs", "content_factory_runs", "content_factory_run_steps", "content_factory_run_step_attempts"}:
+            if re.search(r'\b(?:failed|failure|errored|errors?)\b', text_lower):
+                value = "error" if resource == "content_factory_jobs" else "failed"
+                field = "status"
+                operator = "eq"
+                filters.append({"field": field, "operator": operator, "value": value})
+            elif re.search(r'\b(?:queued|running|completed|cancelled|canceled)\b', text_lower):
+                status_match = re.search(r'\b(queued|running|completed|cancelled|canceled)\b', text_lower)
+                if status_match:
+                    value = "cancelled" if status_match.group(1) == "canceled" else status_match.group(1)
+                    filters.append({"field": "status", "operator": "eq", "value": value})
+        if resource == "monthly_update_drafts":
+            status_match = re.search(r'\b(draft|generated|sent|approved|failed|error)\b', text_lower)
+            if status_match:
+                value = "error" if status_match.group(1) in {"failed", "error"} else status_match.group(1)
+                filters.append({"field": "status", "operator": "eq", "value": value})
+        if resource == "vibe_raising_companies" and re.search(r'\bregistered\b', text_lower):
+            filters.append({"field": "registered", "operator": "eq", "value": True})
+        return filters
+
+    def _default_data_query_fields(self, resource: str) -> list[str]:
+        defaults = {
+            "vibe_raising_companies": ["name", "domain", "organization_domain", "registered", "created_at"],
+            "vibe_raising_profiles": ["user_email", "user_slack_id", "role", "organization_name", "updated_at"],
+            "monthly_update_drafts": ["organization_id", "month", "status", "title", "groundedness_status", "updated_at"],
+            "startup_profiles": ["organization_id", "stage", "organization_kind", "short_description", "updated_at"],
+            "startup_bindings": ["user_email", "organization_domain", "role", "is_default_for_gmail", "updated_at"],
+            "startup_metrics": ["metric_name", "value_text", "value_number", "unit", "period_month", "confidence"],
+            "startup_events": ["event_type", "title", "event_date", "sentiment", "investor_importance", "confidence"],
+            "content_factory_jobs": ["job_id", "domain", "status", "selected_keyword", "article_url", "pr_url", "error_message", "created_at"],
+            "content_factory_runs": ["run_id", "workflow", "domain", "status", "current_step", "approval_state", "error", "updated_at"],
+            "content_factory_run_steps": ["run_key", "domain", "step_key", "status", "attempts", "message", "error"],
+            "content_factory_run_step_attempts": ["run_key", "domain", "attempt", "status", "message", "error", "created_at"],
+            "written_articles": ["title", "slug", "category", "article_url", "primary_keyword", "published_at"],
+            "researched_keywords": ["keyword", "volume", "difficulty", "intent", "tier", "opportunity_index", "status"],
+            "linear_issues": ["identifier", "title", "state_name", "priority_label", "assignee_name", "team_key", "url", "updated_at_linear"],
+            "linear_projects": ["name", "status_name", "health", "progress", "priority", "lead_name", "target_date", "url"],
+            "linear_project_updates": ["health", "author_name", "url", "created_at_linear", "updated_at_linear"],
+            "gmail_messages": ["internal_date", "subject", "from_address", "snippet", "relevance_label", "relevance_score"],
+            "gmail_threads": ["gmail_thread_id", "source_message_count", "hydration_status", "extraction_status", "latest_message_internal_date"],
+            "gmail_attachments": ["filename", "mime_type", "size_bytes", "extraction_status", "created_at"],
+            "slack_messages": ["channel_name", "author_name", "posted_at", "thread_ts", "created_at"],
+            "slack_threads": ["channel_name", "thread_ts", "source_message_count", "latest_message_at", "relevance_label"],
+            "slack_channel_selections": ["channel_name", "selected", "last_synced_at", "updated_at"],
+            "github_integrations": ["slack_user_id", "github_user_name", "github_repo", "project_scanned", "last_scanned_at", "updated_at"],
+            "financial_accounts": ["provider", "account_label", "institution_name", "account_type", "status", "currency", "balance", "last_synced_at"],
+            "financial_records": ["provider", "record_type", "amount", "direction", "status", "transaction_date", "description", "merchant_name"],
+            "organizations": ["id", "name", "domain", "created_at"],
+            "coworking_bookings": ["user_email", "user_slack_id", "date", "status", "points_cost"],
+        }
+        return list(defaults.get(resource, []))
+
+    def _extract_string_list(self, value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return []
+        result = []
+        for item in value:
+            if isinstance(item, str) and item.strip():
+                result.append(item.strip())
+        return result
+
+    def _extract_data_query_filters(self, value: Any) -> list[dict]:
+        if not isinstance(value, list):
+            return []
+        filters = []
+        for item in value:
+            if not isinstance(item, dict):
+                continue
+            field = str(item.get("field") or "").strip()
+            operator = str(item.get("operator") or "").strip()
+            if not field or not operator:
+                continue
+            filters.append({"field": field, "operator": operator, "value": item.get("value")})
+        return filters
+
+    def _extract_data_query_order_by(self, value: Any) -> list[dict]:
+        if not isinstance(value, list):
+            return []
+        order_by = []
+        for item in value:
+            if not isinstance(item, dict):
+                continue
+            field = str(item.get("field") or "").strip()
+            direction = str(item.get("direction") or "asc").strip().lower()
+            if field and direction in {"asc", "desc"}:
+                order_by.append({"field": field, "direction": direction})
+        return order_by
+
+    def _coerce_data_query_limit(self, value: Any, *, default: int) -> int:
+        try:
+            limit = int(value)
+        except (TypeError, ValueError):
+            return default
+        return max(1, min(limit, 100))
+
+    def _coerce_data_query_offset(self, value: Any) -> int:
+        try:
+            offset = int(value)
+        except (TypeError, ValueError):
+            return 0
+        return max(0, offset)
+
+    def _format_data_catalog(self, catalog: dict) -> str:
+        resources = catalog.get("resources") or []
+        if not resources:
+            return "No data resources are currently registered."
+
+        lines = ["Available data resources:"]
+        for resource in resources[:30]:
+            key = resource.get("key") or "unknown"
+            operations = ", ".join(resource.get("operations") or [])
+            fields = ", ".join((resource.get("fields") or [])[:8])
+            lines.append(f"- `{key}` ({operations}): {fields}")
+        if len(resources) > 30:
+            lines.append(f"...and {len(resources) - 30} more.")
+        return "\n".join(lines)
+
+    def _format_data_query_result(self, payload: dict, result: dict) -> str:
+        if result.get("message"):
+            return str(result["message"])
+
+        resource = result.get("resource") or payload.get("resource") or "resource"
+        rows = result.get("rows") or []
+        operation = payload.get("operation") or "list"
+
+        if operation == "count":
+            count_value = rows[0].get("count") if rows else 0
+            return f"`{resource}` count: {count_value}"
+
+        if not rows:
+            return f"No matching records found for `{resource}`."
+
+        display_rows = rows[:10]
+        fields = list(display_rows[0].keys())
+        table_rows = [[self._stringify_data_cell(row.get(field)) for field in fields] for row in display_rows]
+        message = [
+            f"`{resource}` results",
+            self._data_query_table(fields, table_rows),
+        ]
+        returned_count = result.get("returned_count", len(rows))
+        limit = result.get("limit", payload.get("limit"))
+        offset = result.get("offset", payload.get("offset", 0))
+        if result.get("has_more"):
+            message.append(f"Showing {returned_count} rows from offset {offset}. More rows are available with a higher offset.")
+        else:
+            message.append(f"Showing {returned_count} row{'s' if returned_count != 1 else ''}.")
+        if len(rows) > len(display_rows):
+            message.append(f"Displayed first {len(display_rows)} of {len(rows)} returned rows.")
+        if limit:
+            message.append(f"Limit: {limit}.")
+        return "\n".join(message)
+
+    def _stringify_data_cell(self, value: Any) -> str:
+        if value is None:
+            return ""
+        if isinstance(value, (dict, list)):
+            rendered = json.dumps(value, default=str)
+        else:
+            rendered = str(value)
+        rendered = rendered.replace("\n", " ").strip()
+        if len(rendered) > 80:
+            return rendered[:77] + "..."
+        return rendered
+
+    def _data_query_table(self, headers: list[str], rows: list[list[str]]) -> str:
+        widths = [min(max(len(header), 3), 28) for header in headers]
+        for row in rows:
+            for index, cell in enumerate(row):
+                widths[index] = min(max(widths[index], len(cell)), 28)
+
+        def fit(value: str, width: int) -> str:
+            if len(value) > width:
+                return value[: max(0, width - 3)] + "..."
+            return value.ljust(width)
+
+        lines = [" ".join(fit(header, widths[index]) for index, header in enumerate(headers))]
+        for row in rows:
+            lines.append(" ".join(fit(cell, widths[index]) for index, cell in enumerate(row)))
+        return "```\n" + "\n".join(lines) + "\n```"
     
     async def _execute_mlai_points(
         self,
@@ -6307,7 +6644,7 @@ Chunk {index} source: {label}
             return "unclaim_task"
         if "submit" in text_lower:
             return "submit_task"
-        if "coworking" in text_lower and any(
+        if ("coworking" in text_lower or "office" in text_lower) and any(
             w in text_lower
             for w in [
                 "report",
@@ -6316,6 +6653,8 @@ Chunk {index} source: {label}
                 "how many users",
                 "how many people",
                 "used the coworking",
+                "used the office",
+                "attended",
                 "attendance",
                 "usage",
                 "compare",

--- a/roo-standalone/roo/tests/test_agent_routing.py
+++ b/roo-standalone/roo/tests/test_agent_routing.py
@@ -92,6 +92,19 @@ def _make_agent() -> RooAgent:
                 "mlai events",
             ],
         ),
+        _make_skill(
+            "mlai-data-query",
+            [
+                "data catalog",
+                "database catalog",
+                "query data",
+                "vibe raising companies",
+                "startup update drafts",
+                "content factory jobs",
+                "linear issues",
+                "gmail messages",
+            ],
+        ),
     ]
     agent.skill_executor = SimpleNamespace()
     agent._thread_skill_context = {}
@@ -235,6 +248,7 @@ def test_coworking_report_wording_routes_to_points():
         "coworking summary last 6 months",
         "coworking overview from 2026-01-01 to 2026-03-31",
         "how many people used the coworking space this week",
+        "how many people attended the office this week",
         "give me a report for how many people used the coworking space last week",
         "Roo how many peopel used the coworkign space last week and how does that usage compare to the week prior?",
         "which day was busiest for coworking last month",
@@ -244,6 +258,51 @@ def test_coworking_report_wording_routes_to_points():
         skill = agent._select_skill_from_triggers(text)
         assert skill is not None
         assert skill.name == "mlai-points"
+
+
+def test_data_catalog_request_routes_to_data_query():
+    agent = _make_agent()
+
+    skill = agent._select_skill_from_triggers("what data resources can Roo query?")
+
+    assert skill is not None
+    assert skill.name == "mlai-data-query"
+
+
+def test_vibe_raising_data_request_routes_to_data_query():
+    agent = _make_agent()
+
+    skill = agent._select_skill_from_triggers("how many Vibe Raising companies do we have?")
+
+    assert skill is not None
+    assert skill.name == "mlai-data-query"
+
+
+def test_content_factory_job_state_request_routes_to_data_query():
+    agent = _make_agent()
+
+    skill = agent._select_skill_from_triggers("which content factory jobs failed last week?")
+
+    assert skill is not None
+    assert skill.name == "mlai-data-query"
+
+
+def test_startup_update_drafts_request_routes_to_data_query():
+    agent = _make_agent()
+
+    skill = agent._select_skill_from_triggers("show startup update drafts for my company")
+
+    assert skill is not None
+    assert skill.name == "mlai-data-query"
+
+
+def test_synced_linear_issue_read_request_routes_to_data_query():
+    agent = _make_agent()
+
+    skill = agent._select_skill_from_triggers("show Linear issues synced for this startup")
+
+    assert skill is not None
+    assert skill.name == "mlai-data-query"
 
 
 def test_promote_points_admin_phrase_routes_to_points():

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -167,6 +167,61 @@ async def test_get_coworking_report_uses_canonical_endpoint(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_data_catalog_uses_canonical_endpoint(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(200, request=request, json={"resources": [{"key": "vibe_raising_companies"}]})
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.get_data_catalog()
+
+    assert result == {"resources": [{"key": "vibe_raising_companies"}]}
+    assert captured["method"] == "GET"
+    assert captured["endpoint"] == "/api/v1/data/catalog/"
+
+
+@pytest.mark.asyncio
+async def test_query_data_uses_canonical_endpoint_and_payload(monkeypatch):
+    captured = {}
+    payload = {
+        "requester_slack_id": "U123",
+        "resource": "content_factory_jobs",
+        "operation": "count",
+    }
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = kwargs["json"]
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(200, request=request, json={"resource": "content_factory_jobs", "rows": [{"count": 2}]})
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.query_data(payload)
+
+    assert result == {"resource": "content_factory_jobs", "rows": [{"count": 2}]}
+    assert captured["method"] == "POST"
+    assert captured["endpoint"] == "/api/v1/data/query/"
+    assert captured["json"] == payload
+
+
+@pytest.mark.asyncio
 async def test_create_points_purchase_sends_slack_origin(monkeypatch):
     captured = {}
 

--- a/roo-standalone/roo/tests/test_mlai_data_query.py
+++ b/roo-standalone/roo/tests/test_mlai_data_query.py
@@ -1,0 +1,211 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("frontmatter", SimpleNamespace(load=lambda *args, **kwargs: None))
+sys.modules.pop("roo.skills.executor", None)
+
+executor_module = importlib.import_module("roo.skills.executor")
+backend_module = importlib.import_module("roo.clients.mlai_backend")
+SkillExecutor = executor_module.SkillExecutor
+
+
+def _settings(**overrides):
+    values = {
+        "MLAI_BACKEND_URL": "https://backend.test",
+        "MLAI_API_KEY": "api-key",
+        "ROO_API_KEY": "roo-api-key",
+        "INTERNAL_API_KEY": "internal-key",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class FakeDataBackendClient:
+    catalog = {"resources": [{"key": "vibe_raising_companies", "operations": ["list", "count"], "fields": ["name", "domain"]}]}
+    query_response = {
+        "resource": "vibe_raising_companies",
+        "rows": [{"count": 3}],
+        "returned_count": 1,
+        "limit": 1,
+        "offset": 0,
+        "has_more": False,
+    }
+    catalog_calls = 0
+    queries = []
+    last_init = None
+
+    def __init__(self, *args, **kwargs):
+        self.__class__.last_init = {"args": args, "kwargs": kwargs}
+
+    async def get_data_catalog(self):
+        self.__class__.catalog_calls += 1
+        return self.catalog
+
+    async def query_data(self, payload):
+        self.__class__.queries.append(payload)
+        return self.query_response
+
+
+def _reset_fake_client():
+    FakeDataBackendClient.catalog = {
+        "resources": [
+            {
+                "key": "vibe_raising_companies",
+                "operations": ["list", "count"],
+                "fields": ["name", "domain"],
+            }
+        ]
+    }
+    FakeDataBackendClient.query_response = {
+        "resource": "vibe_raising_companies",
+        "rows": [{"count": 3}],
+        "returned_count": 1,
+        "limit": 1,
+        "offset": 0,
+        "has_more": False,
+    }
+    FakeDataBackendClient.catalog_calls = 0
+    FakeDataBackendClient.queries = []
+    FakeDataBackendClient.last_init = None
+
+
+@pytest.mark.asyncio
+async def test_data_query_catalog_calls_backend_catalog(monkeypatch):
+    _reset_fake_client()
+    executor = SkillExecutor()
+    monkeypatch.setattr(executor_module, "get_settings", lambda: _settings())
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeDataBackendClient)
+
+    result = await executor._execute_mlai_data_query(
+        skill=SimpleNamespace(name="mlai-data-query"),
+        text="what data resources can Roo query?",
+        params={},
+        user_id="U123",
+    )
+
+    assert FakeDataBackendClient.catalog_calls == 1
+    assert FakeDataBackendClient.queries == []
+    assert "Available data resources" in result["message"]
+    assert "`vibe_raising_companies`" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_data_query_vibe_raising_count_payload(monkeypatch):
+    _reset_fake_client()
+    executor = SkillExecutor()
+    monkeypatch.setattr(executor_module, "get_settings", lambda: _settings())
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeDataBackendClient)
+
+    result = await executor._execute_mlai_data_query(
+        skill=SimpleNamespace(name="mlai-data-query"),
+        text="how many Vibe Raising companies do we have?",
+        params={},
+        user_id="U123",
+    )
+
+    assert FakeDataBackendClient.queries == [
+        {
+            "requester_slack_id": "U123",
+            "resource": "vibe_raising_companies",
+            "operation": "count",
+            "offset": 0,
+        }
+    ]
+    assert "`vibe_raising_companies` count: 3" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_data_query_content_factory_failed_jobs_payload(monkeypatch):
+    _reset_fake_client()
+    FakeDataBackendClient.query_response = {
+        "resource": "content_factory_jobs",
+        "rows": [
+            {
+                "job_id": "job-1",
+                "domain": "mlai.au",
+                "status": "error",
+                "selected_keyword": "ai grants",
+                "article_url": "",
+                "pr_url": "",
+                "error_message": "generation failed",
+                "created_at": "2026-06-10T01:00:00Z",
+            }
+        ],
+        "returned_count": 1,
+        "limit": 20,
+        "offset": 0,
+        "has_more": False,
+    }
+    executor = SkillExecutor()
+    monkeypatch.setattr(executor_module, "get_settings", lambda: _settings())
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeDataBackendClient)
+
+    result = await executor._execute_mlai_data_query(
+        skill=SimpleNamespace(name="mlai-data-query"),
+        text="which content factory jobs failed last week?",
+        params={},
+        user_id="UADMIN",
+    )
+
+    payload = FakeDataBackendClient.queries[0]
+    assert payload["requester_slack_id"] == "UADMIN"
+    assert payload["resource"] == "content_factory_jobs"
+    assert payload["operation"] == "list"
+    assert payload["filters"] == [{"field": "status", "operator": "eq", "value": "error"}]
+    assert payload["fields"] == [
+        "job_id",
+        "domain",
+        "status",
+        "selected_keyword",
+        "article_url",
+        "pr_url",
+        "error_message",
+        "created_at",
+    ]
+    assert payload["limit"] == 20
+    assert "job-1" in result["message"]
+    assert "generation failed" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_data_query_uses_explicit_resource_params(monkeypatch):
+    _reset_fake_client()
+    FakeDataBackendClient.query_response = {
+        "resource": "linear_issues",
+        "rows": [{"identifier": "MLAI-1", "title": "Fix sync", "state_name": "Todo"}],
+        "returned_count": 1,
+        "limit": 5,
+        "offset": 10,
+        "has_more": False,
+    }
+    executor = SkillExecutor()
+    monkeypatch.setattr(executor_module, "get_settings", lambda: _settings())
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeDataBackendClient)
+
+    await executor._execute_mlai_data_query(
+        skill=SimpleNamespace(name="mlai-data-query"),
+        text="show synced linear issues",
+        params={
+            "resource": "linear_issues",
+            "fields": ["identifier", "title", "state_name"],
+            "limit": 5,
+            "offset": 10,
+        },
+        user_id="U123",
+    )
+
+    assert FakeDataBackendClient.queries == [
+        {
+            "requester_slack_id": "U123",
+            "resource": "linear_issues",
+            "operation": "list",
+            "offset": 10,
+            "fields": ["identifier", "title", "state_name"],
+            "limit": 5,
+        }
+    ]

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -3220,6 +3220,13 @@ def test_resolve_points_action_detects_coworking_report_wording():
     assert (
         executor._resolve_points_action(
             {},
+            "how many people attended the office this week",
+        )
+        == "coworking_report"
+    )
+    assert (
+        executor._resolve_points_action(
+            {},
             "give me a report for how many people used the coworking space last week",
         )
         == "coworking_report"

--- a/roo-standalone/skills/mlai_data_query/SKILL.md
+++ b/roo-standalone/skills/mlai_data_query/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: mlai-data-query
+description: Query curated read-only MLAI backend data resources through the permissioned data access API
+trigger_keywords:
+  - data catalog
+  - database catalog
+  - query data
+  - data resource
+  - data resources
+  - vibe raising companies
+  - startup update drafts
+  - monthly update drafts
+  - content factory jobs
+  - content factory runs
+  - linear issues
+  - gmail messages
+  - slack messages
+  - github integrations
+  - financial records
+requires_auth: true
+---
+
+# MLAI Data Query Skill
+
+Use this skill when a Slack user asks Roo to read curated backend data across the MLAI app, especially Vibe Raising, startup update artifacts, Content Factory state, Linear/Gmail/Slack sync metadata, GitHub integration status, financial metadata, organizations, and coworking booking records.
+
+Roo must not write data and must not send SQL. It calls the backend's read-only data access API:
+
+- `GET /api/v1/data/catalog/`
+- `POST /api/v1/data/query/`
+
+The backend registry is the security contract. Each resource has explicit allow-listed fields, supported operations, filters, ordering, pagination limits, and role-scoped policies. There is no "admin bypass all" mode.
+
+## Parameters
+
+- **action**: Optional action. Use `catalog` when the user asks what data/tables/resources are available.
+- **resource**: Optional exact resource key, such as `vibe_raising_companies`, `monthly_update_drafts`, `content_factory_jobs`, or `linear_issues`.
+- **operation**: Optional operation. One of `list`, `count`, or `aggregate`.
+- **fields**: Optional list of allow-listed field names to return.
+- **filters**: Optional list of filters. Each filter must use `{ "field": "...", "operator": "...", "value": ... }`.
+- **group_by**: Optional list of fields for aggregate queries.
+- **order_by**: Optional list of `{ "field": "...", "direction": "asc|desc" }`.
+- **limit**: Optional positive integer. Roo caps default requests before the backend resource max.
+- **offset**: Optional non-negative integer for pagination.
+
+## Query Rules
+
+- The only supported filter operators are `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, and `icontains`.
+- `icontains` means case-insensitive substring search and only works on backend fields marked searchable.
+- Paginated list responses use `returned_count`, `limit`, `offset`, and `has_more`.
+- `count` is only the count returned by an explicit count operation. List responses do not include total matching rows.
+- Tokens, secrets, credentials, raw payloads, raw attachment data, storage paths, and sync cursors are never exposed.
+
+## Examples
+
+- "How many Vibe Raising companies do we have?"
+- "Show startup update drafts for my company."
+- "Which Content Factory jobs failed?"
+- "Show Linear issues synced for this startup."
+- "What data resources can Roo query?"


### PR DESCRIPTION
Adds Roo's mlai-data-query skill, backend client methods, routing, result formatting, docs, and regression tests. Keeps coworking/office attendance questions routed to mlai-points. Tests: focused Roo data-query/routing/client suite passed. Broader Roo suite has five known pre-existing Content Factory confirmation failures.