### PR TITLE
Prefer raw text for Roo data queries

### DIFF
--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -6192,14 +6192,21 @@ Chunk {index} source: {label}
             return detail or "The data query failed. Please try again in a moment."
 
     def _data_query_catalog_requested(self, text: str, params: dict) -> bool:
-        action = str(params.get("action") or "").lower().strip()
-        if action in {"catalog", "list_resources", "schema"}:
-            return True
         text_lower = str(text or "").lower()
-        return bool(
+        raw_catalog_request = bool(
             re.search(r'\b(?:data|database|db)\s+(?:catalog|resources?|tables?|schema)\b', text_lower)
             or re.search(r'\b(?:what|which|show|list)\b.*\b(?:tables?|resources?)\b.*\b(?:query|available|access)\b', text_lower)
         )
+        if raw_catalog_request:
+            return True
+
+        action = str(params.get("action") or "").lower().strip()
+        if action not in {"catalog", "list_resources", "schema"}:
+            return False
+
+        # The generic LLM extractor can mistake "how many X do we have?" for a
+        # catalog request. If the raw text points at a known resource, query it.
+        return not bool(self._infer_data_query_resource(text_lower, params))
 
     def _build_data_query_payload(self, text: str, params: dict, user_id: str) -> dict:
         text_lower = str(text or "").lower()
@@ -6242,20 +6249,19 @@ Chunk {index} source: {label}
         return payload
 
     def _infer_data_query_operation(self, text_lower: str, params: dict) -> str:
-        operation = str(params.get("operation") or "").lower().strip()
-        if operation in {"list", "count", "aggregate"}:
-            return operation
         if re.search(r'\b(?:how\s+many|count|number\s+of|total\s+number)\b', text_lower):
             return "count"
         if re.search(r'\b(?:group\s+by|break\s+down|breakdown|by\s+status|by\s+state|by\s+month)\b', text_lower):
             return "aggregate"
+        if re.search(r'\b(?:show|list|which|what|query|find|search|give\s+me|display|report)\b', text_lower):
+            return "list"
+
+        operation = str(params.get("operation") or "").lower().strip()
+        if operation in {"list", "count", "aggregate"}:
+            return operation
         return "list"
 
     def _infer_data_query_resource(self, text_lower: str, params: dict) -> str:
-        explicit = str(params.get("resource") or params.get("table") or "").strip().lower()
-        if explicit:
-            return re.sub(r'[^a-z0-9_]+', '_', explicit).strip("_")
-
         resource_patterns = (
             ("vibe_raising_companies", (r'\bvibe\s*raising\b.*\bcompan', r'\bcompan(?:y|ies)\b.*\bvibe\s*raising\b')),
             ("vibe_raising_profiles", (r'\bvibe\s*raising\b.*\bprofiles?\b', r'\bfounder\s+profiles?\b')),
@@ -6288,6 +6294,10 @@ Chunk {index} source: {label}
         for resource, patterns in resource_patterns:
             if any(re.search(pattern, text_lower) for pattern in patterns):
                 return resource
+
+        explicit = str(params.get("resource") or params.get("table") or "").strip().lower()
+        if explicit:
+            return re.sub(r'[^a-z0-9_]+', '_', explicit).strip("_")
         return ""
 
     def _infer_data_query_filters(self, text_lower: str, resource: str) -> list[dict]:

--- a/roo-standalone/roo/tests/test_mlai_data_query.py
+++ b/roo-standalone/roo/tests/test_mlai_data_query.py
@@ -120,6 +120,32 @@ async def test_data_query_vibe_raising_count_payload(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_data_query_specific_count_beats_bad_catalog_param(monkeypatch):
+    _reset_fake_client()
+    executor = SkillExecutor()
+    monkeypatch.setattr(executor_module, "get_settings", lambda: _settings())
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeDataBackendClient)
+
+    result = await executor._execute_mlai_data_query(
+        skill=SimpleNamespace(name="mlai-data-query"),
+        text="how many Vibe Raising companies do we have?",
+        params={"action": "catalog"},
+        user_id="U123",
+    )
+
+    assert FakeDataBackendClient.catalog_calls == 0
+    assert FakeDataBackendClient.queries == [
+        {
+            "requester_slack_id": "U123",
+            "resource": "vibe_raising_companies",
+            "operation": "count",
+            "offset": 0,
+        }
+    ]
+    assert "`vibe_raising_companies` count: 3" in result["message"]
+
+
+@pytest.mark.asyncio
 async def test_data_query_content_factory_failed_jobs_payload(monkeypatch):
     _reset_fake_client()
     FakeDataBackendClient.query_response = {
@@ -170,6 +196,45 @@ async def test_data_query_content_factory_failed_jobs_payload(monkeypatch):
     assert payload["limit"] == 20
     assert "job-1" in result["message"]
     assert "generation failed" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_data_query_raw_text_beats_bad_resource_and_operation_params(monkeypatch):
+    _reset_fake_client()
+    FakeDataBackendClient.query_response = {
+        "resource": "content_factory_jobs",
+        "rows": [
+            {
+                "job_id": "job-1",
+                "domain": "mlai.au",
+                "status": "error",
+                "selected_keyword": "ai grants",
+                "article_url": "",
+                "pr_url": "",
+                "error_message": "generation failed",
+                "created_at": "2026-06-10T01:00:00Z",
+            }
+        ],
+        "returned_count": 1,
+        "limit": 20,
+        "offset": 0,
+        "has_more": False,
+    }
+    executor = SkillExecutor()
+    monkeypatch.setattr(executor_module, "get_settings", lambda: _settings())
+    monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeDataBackendClient)
+
+    await executor._execute_mlai_data_query(
+        skill=SimpleNamespace(name="mlai-data-query"),
+        text="which content factory jobs failed last week?",
+        params={"resource": "gmail_messages", "operation": "count"},
+        user_id="UADMIN",
+    )
+
+    payload = FakeDataBackendClient.queries[0]
+    assert payload["resource"] == "content_factory_jobs"
+    assert payload["operation"] == "list"
+    assert payload["filters"] == [{"field": "status", "operator": "eq", "value": "error"}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes Roo data-query planning so normal questions are not overridden by generic LLM-extracted params. Catalog is now returned only when the raw Slack text asks for catalog/resources/tables, and clear raw-text operation/resource matches beat extracted hints. Tests: /tmp/roo-venv/bin/python -m pytest roo/tests/test_mlai_data_query.py roo/tests/test_agent_routing.py