### PR TITLE
Fix linear-meeting-actions ignoring attached meeting notes

### DIFF
--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -1638,6 +1638,7 @@ Keep the response concise but informative."""
         settings = get_settings()
         params = self._apply_linear_meeting_project_hint_prepass(text, params)
         params = self._apply_linear_meeting_owner_hint_prepass(text, params)
+        params = self._apply_linear_meeting_default_assignee_prepass(text, params)
         direct_issue_request = self._is_linear_direct_issue_request(text, params)
         thread_reference_request = self._is_linear_thread_reference_request(text, params)
         source_result = await self._build_linear_meeting_source_result(
@@ -1650,7 +1651,14 @@ Keep the response concise but informative."""
             exclude_current_message=thread_reference_request,
         )
         transcript = source_result.combined_text()
-        if len(transcript.split()) < 8 and not direct_issue_request:
+        # When meeting-note files (PDF/DOCX/text/image) were parsed, always extract
+        # action items from those sources. Only treat the message as a one-off "direct
+        # issue" command when no document was attached — otherwise a phrase like
+        # "add these to linear as tasks" hijacks the command path and the attached file
+        # is parsed but never used.
+        has_document_sources = source_result.files_parsed > 0
+        use_direct_issue_path = direct_issue_request and not has_document_sources
+        if len(transcript.split()) < 8 and not use_direct_issue_path:
             warning_suffix = self._format_linear_meeting_source_warnings(source_result.warnings)
             return {
                 "message": (
@@ -1678,7 +1686,7 @@ Keep the response concise but informative."""
                 "message": f"I couldn't read Linear context yet: {detail}"
             }
 
-        if direct_issue_request:
+        if use_direct_issue_path:
             candidates = await self._extract_linear_direct_issue_candidates(
                 text=text,
                 params=params,
@@ -1723,6 +1731,16 @@ Keep the response concise but informative."""
             for label in labels
             if self._normalize_match_text(label.get("name")) == "meetingaction"
         ]
+
+        # Resolve the optional fallback assignee once ("if unsure, assign to X").
+        # Used to rescue candidates whose own owner can't be confidently matched so
+        # they remain assignable instead of being dropped.
+        default_assignee_match: Optional[dict[str, Any]] = None
+        default_assignee_hint = str(params.get("default_assignee_hint") or "").strip()
+        if default_assignee_hint:
+            resolved_default = self._match_linear_meeting_owner(default_assignee_hint, users)
+            if resolved_default.get("user"):
+                default_assignee_match = resolved_default
 
         created: list[dict[str, Any]] = []
         review_needed: list[dict[str, Any]] = []
@@ -1769,6 +1787,16 @@ Keep the response concise but informative."""
                 continue
 
             owner_match = self._match_linear_meeting_owner(candidate.get("owner_hint"), users)
+            if (
+                float(owner_match.get("confidence") or 0.0) < uncertain_threshold
+                and default_assignee_match
+                and default_assignee_match.get("user")
+            ):
+                owner_match = {
+                    "user": default_assignee_match["user"],
+                    "confidence": float(default_assignee_match.get("confidence") or 0.9),
+                    "reason": "Fallback assignee",
+                }
             project_match = self._match_linear_meeting_project(
                 candidate,
                 projects,
@@ -1797,6 +1825,15 @@ Keep the response concise but informative."""
             )
             if candidate.get("contextual_review_only") and decision == "create":
                 decision = "review"
+            # Extraction path is "review first": never auto-create. Surface every
+            # creatable candidate for Slack Approve/Reject; only drop duplicates and
+            # items we couldn't resolve enough to create on approval (no team, or no
+            # assignee even after the fallback).
+            if not use_direct_issue_path and decision != "duplicate":
+                if owner_match.get("user") and team_match.get("team"):
+                    decision = "review"
+                else:
+                    decision = "skip"
 
             issue_input = self._build_linear_meeting_issue_input(
                 candidate=candidate,
@@ -1981,6 +2018,34 @@ Keep the response concise but informative."""
         if not owner_hint:
             return params
         return {**params, "owner_hint": owner_hint}
+
+    def _apply_linear_meeting_default_assignee_prepass(
+        self,
+        text: str,
+        params: dict,
+    ) -> dict:
+        if params.get("default_assignee_hint"):
+            return params
+        default_assignee = self._extract_linear_meeting_default_assignee_from_text(text)
+        if not default_assignee:
+            return params
+        return {**params, "default_assignee_hint": default_assignee}
+
+    def _extract_linear_meeting_default_assignee_from_text(self, text: str) -> Optional[str]:
+        """Parse a fallback assignee like "if you're not sure who to assign to, assign to X"."""
+        value = str(text or "").strip()
+        person = r'(<@[A-Z0-9]+>|@?[A-Z][\w.\-]*(?:\s+[A-Z][\w.\-]*){0,3})'
+        patterns = (
+            rf'\bif\s+(?:you(?:\'re|\s+are)?\s+)?(?:not\s+sure|unsure|in\s+doubt|you\s+don\'?t\s+know)\b[^.!?]*?\bassign(?:ed)?\b[^.!?]*?\bto\s+{person}',
+            rf'\bif\s+(?:it\'?s\s+)?(?:unclear|unknown|ambiguous)\b[^.!?]*?\bassign(?:ed)?\b[^.!?]*?\bto\s+{person}',
+            rf'\b(?:otherwise|by\s+default|as\s+a\s+fallback|default(?:ing)?)\b[^.!?]*?\bassign(?:ed)?\b[^.!?]*?\bto\s+{person}',
+            rf'\b(?:default|fallback)\s+assignee\s*[:\-]?\s*{person}',
+        )
+        for pattern in patterns:
+            match = re.search(pattern, value, flags=re.IGNORECASE)
+            if match:
+                return self._clean_linear_meeting_owner_hint(match.group(1))
+        return None
 
     def _extract_linear_meeting_project_hint_from_text(self, text: str) -> Optional[str]:
         value = str(text or "").strip()
@@ -2412,6 +2477,7 @@ Current date: {get_current_date().isoformat()}
 Source label: {source_label or "Slack thread"}
 Project hint: {params.get("project_hint") or "none"}
 Team hint: {params.get("team_hint") or "none"}
+Default assignee if the owner is unclear: {params.get("default_assignee_hint") or "none"}
 
 Known Linear projects: {project_names or "none loaded"}
 Known Linear users: {user_names or "none loaded"}
@@ -2437,7 +2503,8 @@ Return JSON only with this shape:
   ]
 }}
 
-Only include actionable work someone agreed to do. Do not include decisions, FYIs, vague follow-ups, or the user's instruction to create Linear tasks/project updates."""
+Only include actionable work someone agreed to do. Do not include decisions, FYIs, vague follow-ups, or the user's instruction to create Linear tasks/project updates.
+If an action item has no clear owner and a default assignee is given above, set its owner_hint to that default assignee."""
         settings = get_settings()
         response = await chat(
             [
@@ -3412,7 +3479,7 @@ Chunk {index} source: {label}
             if lines:
                 lines.append("")
             lines.append(f"{len(review_needed)} action item{'s' if len(review_needed) != 1 else ''} need approval:")
-            for item in review_needed[:10]:
+            for item in review_needed[:20]:
                 lines.append(
                     f"- {item['title']} -> {item['project']} / {item['assignee']} "
                     f"({item['confidence']:.0%}, {item.get('source', 'Slack thread')})"
@@ -3439,7 +3506,7 @@ Chunk {index} source: {label}
         blocks: list[dict[str, Any]] = [
             {"type": "section", "text": {"type": "mrkdwn", "text": message[:3000]}}
         ]
-        for item in review_needed[:8]:
+        for item in review_needed[:20]:
             pending_id = item["pending_id"]
             summary = (
                 f"*{item['title']}*\n"

--- a/roo-standalone/roo/tests/test_linear_meeting_actions.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_actions.py
@@ -603,8 +603,9 @@ async def test_linear_meeting_candidate_extraction_chunks_sources(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_linear_meeting_executor_creates_issue_from_parsed_file_source(monkeypatch):
+async def test_linear_meeting_executor_queues_review_from_parsed_file_source(monkeypatch):
     executor = SkillExecutor()
+    executor_module.LINEAR_MEETING_PENDING_ACTIONS.clear()
     created_inputs = []
 
     async def fake_source_result(**kwargs):
@@ -615,7 +616,9 @@ async def test_linear_meeting_executor_creates_issue_from_parsed_file_source(mon
                     text="Sam will update onboarding docs in Alpha.",
                     kind="pdf",
                 )
-            ]
+            ],
+            files_seen=1,
+            files_parsed=1,
         )
 
     async def fake_candidates_from_sources(**kwargs):
@@ -701,13 +704,21 @@ async def test_linear_meeting_executor_creates_issue_from_parsed_file_source(mon
         event_files=[{"id": "F1", "name": "meeting.pdf"}],
     )
 
+    # Extraction path is "review first": nothing is auto-created; the fully-resolved
+    # issue is stashed for Slack Approve/Reject instead.
     assert "data" in result, result
-    assert result["data"]["created_count"] == 1
-    assert created_inputs[0]["title"] == "Update onboarding docs"
-    assert created_inputs[0]["assignee_id"] == "user-1"
-    assert created_inputs[0]["project_id"] == "project-1"
-    assert created_inputs[0]["label_ids"] == ["label-1"]
-    assert "meeting.pdf page 3" in created_inputs[0]["description"]
+    assert result["data"]["created_count"] == 0
+    assert result["data"]["review_count"] == 1
+    assert created_inputs == []
+
+    pending = list(executor_module.LINEAR_MEETING_PENDING_ACTIONS.values())
+    assert len(pending) == 1
+    issue_input = pending[0]["issue_input"]
+    assert issue_input["title"] == "Update onboarding docs"
+    assert issue_input["assignee_id"] == "user-1"
+    assert issue_input["project_id"] == "project-1"
+    assert issue_input["label_ids"] == ["label-1"]
+    assert "meeting.pdf page 3" in issue_input["description"]
 
 
 @pytest.mark.asyncio
@@ -978,6 +989,7 @@ async def test_linear_direct_issue_command_reports_ambiguous_assignee(monkeypatc
 @pytest.mark.asyncio
 async def test_linear_meeting_executor_creates_project_update_when_requested(monkeypatch):
     executor = SkillExecutor()
+    executor_module.LINEAR_MEETING_PENDING_ACTIONS.clear()
     created_updates = []
     created_issues = []
 
@@ -1088,7 +1100,12 @@ async def test_linear_meeting_executor_creates_project_update_when_requested(mon
     )
 
     assert created_updates == [{"project_id": "project-1", "body": "Meeting update", "health": "onTrack"}]
-    assert created_issues[0]["title"] == "Validate the bounty model with VCs"
+    # Project updates are still posted immediately when explicitly requested, but the
+    # extracted action item is queued for review rather than auto-created.
+    assert created_issues == []
+    assert result["data"]["review_count"] == 1
+    pending = list(executor_module.LINEAR_MEETING_PENDING_ACTIONS.values())
+    assert any(p["issue_input"]["title"] == "Validate the bounty model with VCs" for p in pending)
     assert "Created Linear project update" in result["message"]
 
 
@@ -1546,3 +1563,211 @@ async def test_linear_meeting_slack_reject_clears_contextual_issue(monkeypatch):
     assert response.status_code == 200
     assert pending_id not in live_executor_module.LINEAR_MEETING_PENDING_ACTIONS
     assert posted_messages[0]["text"] == "Skipped Linear issue creation for: Decide event positioning"
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("if you're not sure who to assign to, assign to Dr Sam Donegan", "Dr Sam Donegan"),
+        ("extract tasks and add to linear; if unsure, assign to Jane Doe", "Jane Doe"),
+        ("turn these notes into tasks. Default assignee: Sam Donegan", "Sam Donegan"),
+        ("add these to linear and assign to the correct people", None),
+    ],
+)
+def test_linear_meeting_default_assignee_prepass_extracts_fallback(text, expected):
+    executor = SkillExecutor()
+    params = executor._apply_linear_meeting_default_assignee_prepass(text, {})
+    assert params.get("default_assignee_hint") == expected
+
+
+@pytest.mark.asyncio
+async def test_linear_meeting_command_with_file_uses_extraction_not_direct_path(monkeypatch):
+    """Regression for the "one task about assigning the tasks" bug.
+
+    A direct-looking command ("add ... tasks ... linear") with an attached file must
+    extract action items from the file (not parse the command into a single issue), map
+    every task to the explicitly named project, fall back to the named assignee when an
+    owner is unclear, and queue everything for review.
+    """
+    executor = SkillExecutor()
+    executor_module.LINEAR_MEETING_PENDING_ACTIONS.clear()
+    created_inputs = []
+
+    async def fake_source_result(**kwargs):
+        return SourceParseResult(
+            sources=[
+                ParsedSource(
+                    label="MLAI Committee Meeting.pdf",
+                    text="Committee discussed the venue, sponsors, and the budget.",
+                    kind="pdf",
+                )
+            ],
+            files_seen=1,
+            files_parsed=1,
+        )
+
+    async def fake_candidates_from_sources(**kwargs):
+        assert kwargs["sources"][0].label == "MLAI Committee Meeting.pdf"
+        return [
+            {"title": "Confirm the venue booking", "owner_hint": "Sonia", "confidence": 0.9,
+             "source_label": "MLAI Committee Meeting.pdf"},
+            {"title": "Draft the sponsorship deck", "owner_hint": "the team", "confidence": 0.9,
+             "source_label": "MLAI Committee Meeting.pdf"},
+        ]
+
+    async def fail_direct(**kwargs):
+        raise AssertionError("direct-issue path must not run when a file was parsed")
+
+    team = {"id": "team-1", "key": "MLA", "name": "MLAI"}
+    sonia = {"id": "user-sonia", "name": "Sonia", "displayName": "Sonia", "email": "sonia@example.com"}
+    sam = {"id": "user-sam", "name": "Sam Donegan", "displayName": "Dr Sam Donegan", "email": "sam@example.com"}
+    project = {
+        "id": "project-mlai",
+        "name": "MLAI Core",
+        "teams": {"nodes": [team]},
+        "members": {"nodes": [sonia, sam]},
+    }
+
+    class FakeClient:
+        async def list_teams(self):
+            return [team]
+
+        async def list_users(self):
+            return [sonia, sam]
+
+        async def list_active_projects(self):
+            return [project]
+
+        async def list_issue_labels(self):
+            return []
+
+        async def list_recent_open_issues(self):
+            return []
+
+        async def create_issue(self, **kwargs):
+            created_inputs.append(kwargs)
+            return {"identifier": "MLA-1", "title": kwargs["title"]}
+
+    class FakeSkill:
+        def get_client_class(self, name):
+            return FakeClient
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            LINEAR_DEFAULT_TEAM=None,
+            LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE=0.85,
+            LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE=0.65,
+        ),
+    )
+    monkeypatch.setattr(executor, "_build_linear_meeting_source_result", fake_source_result)
+    monkeypatch.setattr(executor, "_extract_linear_meeting_candidates_from_sources", fake_candidates_from_sources)
+    monkeypatch.setattr(executor, "_extract_linear_direct_issue_candidates", fail_direct)
+
+    result = await executor._execute_linear_meeting_actions(
+        skill=FakeSkill(),
+        text=(
+            "here's the committee meeting notes, please add them to the linear project "
+            "called 'MLAI Core' and assign the tasks to the correct people. if you're not "
+            "sure who to assign to, assign to Dr Sam Donegan"
+        ),
+        params={},
+        user_id="U1",
+        channel_id="C1",
+        thread_ts="1.1",
+        thread_history=[],
+        event_files=[{"id": "F1", "name": "MLAI Committee Meeting.pdf"}],
+    )
+
+    # Nothing auto-created; both extracted tasks are queued for review.
+    assert result["data"]["created_count"] == 0
+    assert result["data"]["review_count"] == 2
+    assert created_inputs == []
+
+    pending = {
+        p["issue_input"]["title"]: p["issue_input"]
+        for p in executor_module.LINEAR_MEETING_PENDING_ACTIONS.values()
+    }
+    assert set(pending) == {"Confirm the venue booking", "Draft the sponsorship deck"}
+    # Every task mapped to the explicitly named project and its team.
+    for issue_input in pending.values():
+        assert issue_input["project_id"] == "project-mlai"
+        assert issue_input["team_id"] == "team-1"
+    # Clear owner kept; vague owner fell back to the named default assignee.
+    assert pending["Confirm the venue booking"]["assignee_id"] == "user-sonia"
+    assert pending["Draft the sponsorship deck"]["assignee_id"] == "user-sam"
+
+
+@pytest.mark.asyncio
+async def test_linear_meeting_unmatched_owner_skipped_without_fallback(monkeypatch):
+    """Without a fallback assignee, a task whose owner can't be resolved is skipped
+    (not reviewed). The fallback is what rescues it (see the test above)."""
+    executor = SkillExecutor()
+    executor_module.LINEAR_MEETING_PENDING_ACTIONS.clear()
+    created_inputs = []
+
+    async def fake_source_result(**kwargs):
+        return SourceParseResult(
+            sources=[ParsedSource(label="notes.pdf", text="The team will sort it out.", kind="pdf")],
+            files_seen=1,
+            files_parsed=1,
+        )
+
+    async def fake_candidates_from_sources(**kwargs):
+        return [{"title": "Sort out logistics", "owner_hint": "the team", "confidence": 0.9}]
+
+    team = {"id": "team-1", "key": "MLA", "name": "MLAI"}
+    project = {"id": "project-mlai", "name": "MLAI Core", "teams": {"nodes": [team]}, "members": {"nodes": []}}
+
+    class FakeClient:
+        async def list_teams(self):
+            return [team]
+
+        async def list_users(self):
+            return [{"id": "user-sonia", "name": "Sonia", "displayName": "Sonia", "email": "sonia@example.com"}]
+
+        async def list_active_projects(self):
+            return [project]
+
+        async def list_issue_labels(self):
+            return []
+
+        async def list_recent_open_issues(self):
+            return []
+
+        async def create_issue(self, **kwargs):
+            created_inputs.append(kwargs)
+            return {"identifier": "MLA-1", "title": kwargs["title"]}
+
+    class FakeSkill:
+        def get_client_class(self, name):
+            return FakeClient
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            LINEAR_DEFAULT_TEAM=None,
+            LINEAR_MEETING_AUTO_CREATE_MIN_CONFIDENCE=0.85,
+            LINEAR_MEETING_UNCERTAIN_MIN_CONFIDENCE=0.65,
+        ),
+    )
+    monkeypatch.setattr(executor, "_build_linear_meeting_source_result", fake_source_result)
+    monkeypatch.setattr(executor, "_extract_linear_meeting_candidates_from_sources", fake_candidates_from_sources)
+
+    result = await executor._execute_linear_meeting_actions(
+        skill=FakeSkill(),
+        text="add these notes to the linear project 'MLAI Core' as tasks",
+        params={},
+        user_id="U1",
+        channel_id="C1",
+        thread_ts="1.1",
+        thread_history=[],
+        event_files=[{"id": "F1", "name": "notes.pdf"}],
+    )
+
+    assert result["data"]["created_count"] == 0
+    assert result["data"]["review_count"] == 0
+    assert result["data"]["skipped_count"] == 1
+    assert created_inputs == []


### PR DESCRIPTION
## Problem

A request like *"add these committee meeting notes to the Linear project 'MLAI Core' and assign the tasks to the correct people; if unsure, assign to Dr Sam Donegan"* with a PDF attached produced **one** bogus issue — "Assign committee meeting tasks to the correct people" — instead of extracting the actual tasks from the notes.

**Root cause:** the message matched `_is_linear_direct_issue_request` ("linear" + "add" + "tasks"), routing it to the direct-command path, which parses the *instruction text* into a single issue and never reads the parsed PDF. The file was downloaded and parsed, then discarded.

## Changes

- **Route to extraction when a document was parsed** (`files_parsed > 0`) so attached PDF/DOCX/text/image notes are actually used; short file-less commands still take the direct path.
- **Fallback assignee**: parse "if unsure, assign to X" / "default assignee: X" and assign tasks with an unresolvable owner to that person, instead of silently skipping them (previously unmatched owners scored 0 and dropped below the skip floor).
- **Review-first for extracted tasks**: every extracted task is queued for Slack Approve/Reject rather than auto-created; review-card cap raised 8 → 20. Project updates still post immediately; the direct single-command path still creates immediately.

## Tests

- 44/44 in `test_linear_meeting_actions.py` pass.
- Updated two tests that asserted auto-creation from a file source to expect review-queueing.
- Added: fallback-assignee parser test, full file-attached regression of the reported scenario, and an unmatched-owner-skipped-without-fallback test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)