### PR TITLE
Double Roo Points per top-up pack (same prices)

### DIFF
--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -57,20 +57,23 @@ POINTS_SUPER_ADMIN_SLACK_ID = "U05QPB483K9"
 FULL_POINTS_ADMIN_ROLES = {"admin", "committee", "portfolio_lead"}
 COWORKING_REPORT_ROLES = {*FULL_POINTS_ADMIN_ROLES, "partner"}
 LINEAR_MEETING_PENDING_ACTIONS: dict[str, dict[str, Any]] = {}
+# Pack ids are opaque and kept stable; the id number no longer matches the
+# points it grants (points were doubled for the same price). Must stay in sync
+# with mlai-backend roo/services.py ROO_TOPUP_PACKS.
 ROO_TOPUP_PACKS = {
     "topup_5": {
-        "points": 5,
-        "label": "5 Top-up Roo Points",
+        "points": 10,
+        "label": "10 Top-up Roo Points",
         "price": "A$19.99",
     },
     "topup_10": {
-        "points": 10,
-        "label": "10 Top-up Roo Points",
+        "points": 20,
+        "label": "20 Top-up Roo Points",
         "price": "A$36.99",
     },
     "topup_25": {
-        "points": 25,
-        "label": "25 Top-up Roo Points",
+        "points": 50,
+        "label": "50 Top-up Roo Points",
         "price": "A$63.99",
     },
 }
@@ -6656,7 +6659,7 @@ Chunk {index} source: {label}
             return ROO_TOPUP_PACK_BY_POINTS.get(amount), amount
 
         text_lower = self._normalize_points_routing_text(text)
-        exact_pack = re.search(r"\btopup[_\s-]*(5|10|25)\b", text_lower)
+        exact_pack = re.search(r"\btopup[_\s-]*(10|20|50)\b", text_lower)
         if exact_pack:
             amount = int(exact_pack.group(1))
             return ROO_TOPUP_PACK_BY_POINTS[amount], None
@@ -8134,7 +8137,7 @@ Chunk {index} source: {label}
             if not pack_id:
                 if unsupported_amount is None:
                     return self._topup_pack_list_message()
-                return "I can only help with these fixed top-up packs right now: 5, 10, or 25 Top-up Roo Points."
+                return "I can only help with these fixed top-up packs right now: 10, 20, or 50 Top-up Roo Points."
 
             purchase_from = {"source": "slack"}
             if channel_id:

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -688,9 +688,9 @@ async def test_topup_points_missing_pack_lists_fixed_packs(monkeypatch):
     )
 
     assert "Available Top-up Roo Points packs" in result
-    assert "5 Top-up Roo Points - A$19.99" in result
-    assert "10 Top-up Roo Points - A$36.99" in result
-    assert "25 Top-up Roo Points - A$63.99" in result
+    assert "10 Top-up Roo Points - A$19.99" in result
+    assert "20 Top-up Roo Points - A$36.99" in result
+    assert "50 Top-up Roo Points - A$63.99" in result
     assert "price per point" not in result.lower()
 
 
@@ -715,7 +715,7 @@ async def test_topup_points_unsupported_pack_is_rejected(monkeypatch):
         skill=SimpleNamespace(name="mlai-points"),
     )
 
-    assert "5, 10, or 25 Top-up Roo Points" in result
+    assert "10, 20, or 50 Top-up Roo Points" in result
 
 
 @pytest.mark.asyncio
@@ -746,7 +746,7 @@ async def test_topup_points_valid_pack_creates_purchase(monkeypatch):
     assert "do not count toward lifetime earned contribution" in result
     assert client.created == {
         "slack_user_id": "U123",
-        "pack_id": "topup_10",
+        "pack_id": "topup_5",
         "points_amount": None,
         "purchase_from": {
             "source": "slack",
@@ -794,8 +794,8 @@ async def test_topup_points_balance_cap_message_is_clear(monkeypatch):
     result = await executor._handle_points_action(
         client=BalanceCapTopupPurchaseClient(),
         action="topup_points",
-        params={"points": 5},
-        text="topup 5 points",
+        params={"points": 10},
+        text="topup 10 points",
         user_id="U123",
         channel_id="C123",
         thread_ts="111.222",


### PR DESCRIPTION
Syncs the Slack bot's `ROO_TOPUP_PACKS` mirror with mlai-backend (#471): each pack grants 2x points for the same price — 10/20/50 points for A$19.99 / A$36.99 / A$63.99.

Also updates:
- the `topup N` resolver regex (valid amounts are now 10/20/50)
- the "I can only help with these fixed packs" message ("10, 20, or 50")

So `@Roo topup 10` now buys the A$19.99 pack; `topup 5`/`topup 25` get the friendly "valid packs" reply. Pack ids unchanged.

**96 tests pass** (`test_points_requests.py` + `test_mlai_backend_client.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)