### PR TITLE
Slack cross-org channel bridge (MLAI <-> Stone & Chalk)

### DIFF
--- a/SLACK_BRIDGE_PLAN.md
+++ b/SLACK_BRIDGE_PLAN.md
@@ -1,0 +1,205 @@
+# Slack Cross-Org Channel Bridge — Implementation Plan
+
+> **Status (2026-06-21):** Building as a **dedicated "Bridge" Slack app installed in both workspaces** — the symmetric two-bot design (a.k.a. Path A). S&C turned out to allow app installs, so the session-token (Path S), reuse-Roo, and asymmetric-Path-B approaches discussed below are **superseded** and kept only for context. Final shape: one bot token per side, both channels polled, `chat:write.customize` in both directions so every author shows their real name + avatar. Roo is untouched. Code lives in `roo-standalone/bridge/`.
+
+**Goal:** Bidirectional sync between one channel in the MLAI Slack workspace (where Roo lives) and one channel in the Stone & Chalk (S&C) Slack workspace, relayed by the existing DigitalOcean droplet. Members of each org read and write entirely from their own workspace.
+
+**Asymmetry that shapes everything:** Sam is an admin/owner in MLAI but an ordinary member in S&C. MLAI-side capabilities are unlimited (bots, custom apps, eventually puppet accounts). S&C-side capabilities depend on that workspace's app-installation policy and otherwise fall back to Sam's personal user token.
+
+---
+
+## Step 0 — Preflight (do before writing any code)
+
+1. **Discover S&C's app policy.** Create the bridge app at api.slack.com, then attempt to install/authorize it against the S&C workspace. Three outcomes:
+   - **Path A — app installs cleanly (bot allowed):** symmetric bridge, best fidelity. Build this.
+   - **Path B — bot install blocked, but user OAuth allowed:** asymmetric bridge through Sam's user token. Workable.
+   - **Path C — all app authorization requires admin approval:** either ask the S&C community manager to approve the app (show them this doc), **or** use **Path S (session-token client, below)** which needs no app at all. Path S is the recommended default for S&C precisely because it doesn't depend on this policy — but it's a Slack ToS grey area on an org Sam doesn't own, so the consent conversation (0.2) is required, not optional.
+2. **Get S&C's blessing regardless of path.** Mirroring members' messages into another org is a consent issue before it's a technical one. Tell the community manager what the bridge does; put a permanent note in both channel topics: "⛓ This channel is bridged with <other org> #channel — messages are mirrored both ways."
+3. **Pick channels.** MLAI: create `#stone-and-chalk` (or reuse). S&C: create `#mlai` or whichever channel Sam can socially own. Record both channel IDs.
+4. **Record identities** needed for loop prevention and self-puppeting: Sam's MLAI user ID, Sam's S&C user ID, both app IDs, both bot user IDs (Path A).
+5. **Confirm plan tiers** (free vs paid) for both workspaces — only matters for the later puppet upgrade (free = puppets cost nothing in MLAI).
+
+---
+
+## Architecture
+
+```
+MLAI  #stone-and-chalk                          S&C  #mlai
+  │        ▲                                     │        ▲
+events     │ post via bot                     events      │ Path A: post via bot
+(bridge    │ (chat:write.customize:           (bot events │   (spoofed name/avatar)
+ bot)      │  S&C author's name+avatar)        or Sam's   │ Path B: post via Sam's
+  │        │                                   user-scope │   user token, prefixed
+  ▼        │                                   events)    │   "*Alice:* …"
+ ┌─────────┴─────────────────────────────────────┴────────┐
+ │              bridge service on DO droplet               │
+ │  tokens: MLAI bot, S&C bot (Path A) or Sam xoxp (B),   │
+ │          Sam's MLAI xoxp (self-puppet, optional)        │
+ │  SQLite: message ts-map, posted-message registry        │
+ │  logic: loop filter → attribution → translate → post    │
+ └──────────────────────────────────────────────────────────┘
+```
+
+### Path A (S&C allows bot install) — symmetric spoofing bridge
+Both sides run the same design: a bot app per workspace ingests channel messages via Events API and posts into the opposite channel with `chat:write.customize` (author's real name + avatar, small APP badge). This is the Option-3 design from the original plan, instantiated twice.
+
+### Path B (user-token only in S&C) — asymmetric bridge
+- **S&C → MLAI:** ingest via *user-scoped* event subscriptions on Sam's S&C token; post into MLAI via the MLAI bridge bot with spoofed name/avatar. Full fidelity on the MLAI side.
+- **MLAI → S&C:** post via Sam's S&C user token. Messages appear *from Sam*, with the real author as a bold prefix: `*Alice:* message text` (use a Block Kit context line if nicer). Lower fidelity, zero admin cooperation needed.
+- Note: user-scoped `message.channels` events fire for **every** public channel Sam is in at S&C. The relay must filter to the bridged channel ID as the very first check and drop everything else unprocessed and unlogged.
+
+### Path S (RECOMMENDED for S&C) — session-token client, "Beeper-style"
+This is how Beeper/mautrix-slack connect to Slack with **no app installed in the workspace at all**, which sidesteps S&C's app policy (Path C dissolves). Instead of an app, the bridge reuses Sam's existing logged-in Slack web session:
+- **Credentials:** the `xoxc-…` client token (from browser `localStorage` → `localConfig_v2`) plus the `d` cookie value `xoxd-…`. Together these are exactly what the Slack web client sends; with them the bridge calls Slack's *internal* client API as Sam, with all his normal permissions. No OAuth, no admin approval, no app review.
+- **Real-time ingest:** rather than an Events API webhook (which needs an app + public request URL), the bridge opens the **same WebSocket the web client uses** (`client.userBoot` → WS gateway) and receives channel messages live. So the S&C side needs *no* inbound endpoint at all.
+- **Egress:** posting with the session client makes messages come from Sam's real S&C account natively — no APP badge, no app at all.
+
+**What it changes vs Path B:** strictly simpler and more capable on the S&C side — removes the app/OAuth dependency entirely and makes S&C ingest a persistent outbound WebSocket instead of an inbound webhook. Everything downstream of ingest (relay logic, MLAI side) is unchanged.
+
+**What it does NOT change:** the *into-S&C* direction is still "as Sam," because Sam's session is the only S&C identity the bridge controls. MLAI authors posting into S&C still appear as `*Alice:* …` under Sam's account. Making MLAI users appear as *themselves in S&C* still requires real puppet accounts in S&C (the double-puppeting upgrade), which Beeper's mechanism does **not** provide — see "Critical distinction" below.
+
+**Critical distinction — Beeper is a single-user aggregator, not a multi-user bridge.** Beeper authenticates *one* account (yours) and renders everyone else as read-only "ghosts" for you to read; when you send, it sends as you. It never makes other people appear back inside Slack. Our goal (every member of each org sees the conversation in their own workspace) is a *bridge*, which is more than Beeper does. The session-token mechanism is the reusable insight; it powers the S&C ingest/egress-as-Sam leg, but the cross-org fan-out is still our own relay.
+
+**Trade-offs / risks of session tokens (be honest about these):**
+- **Slack ToS grey area.** Non-official-client automation is against Slack's ToS. Beeper operates in this space openly for personal use, but S&C is an org Sam doesn't own — the Step 0.2 consent conversation matters *more* here, not less. This only ever touches Sam's own account and the one agreed channel.
+- **Fragile credentials.** `xoxc`/`xoxd` are tied to the browser session: invalidated by logout, password change, or admin session revocation. The cookie TTL itself is long (>1 year as of late 2025), so the practical failure mode is *session invalidation*, not expiry.
+- **Anti-abuse heuristics.** Slack invalidates these tokens when behavior looks non-human — e.g. bulk-caching all users tripped it in the slack-mcp-server case (Aug 2025). Mitigation: behave like a real client — lazy per-id `users.info` with caching, respect rate limits, no bulk scraping.
+- **Not production-grade.** Expect occasional manual re-auth (re-extract token+cookie). Build a clean `tokens_revoked`/401 → DM-Sam-to-re-auth path; treat S&C connectivity as best-effort.
+- **xoxp alternative:** a user-OAuth token (`xoxp`) avoids the caching-invalidation problem but requires creating an app + OAuth in S&C — the exact dependency Path S exists to avoid. Only worth it if S&C turns out to permit user-OAuth apps (Path B).
+
+### Self-puppeting (both paths, optional layer)
+Sam is the one human with real accounts in both orgs. With his user tokens on both sides, his messages bridge as *his real account* — no spoofing, no prefix. This is puppet-zero of the full double-puppeting design and exercises the per-user token routing machinery. Under Path S the S&C "token" is the session client; under Path B it's his `xoxp`.
+
+---
+
+## Slack app configuration
+
+| | App 1: "Bridge" (MLAI) | App 2: "Bridge" (S&C) |
+|---|---|---|
+| Install type | Bot (Sam is admin) | Path A: bot · Path B: Sam's user OAuth only |
+| Bot scopes | `channels:history`, `chat:write`, `chat:write.customize`, `users:read`, `files:read`, `files:write` | Path A: same list |
+| User scopes (Sam) | `chat:write` (self-puppet, optional) | Path B: `channels:history`, `chat:write`, `users:read`, `files:read`, `files:write` |
+| Event subscriptions | Bot events: `message.channels` | Path A: bot events `message.channels` · Path B: same as *user* events |
+| Request URL | `https://<droplet>/bridge/events/mlai` | `https://<droplet>/bridge/events/snc` |
+
+Separate request-URL paths per app so each endpoint verifies with its own signing secret. Handle Slack's `url_verification` challenge on both. If the channels are private, swap in `groups:history` / `groups:read`.
+
+---
+
+## Relay service design
+
+### Where it lives
+New package `roo-standalone/bridge/` — its own FastAPI app, port, and systemd unit (`slack-bridge.service`), proxied by the existing nginx. Deliberately **not** inside Roo's app: independent deploys, and a Roo crash shouldn't take the bridge down. Copy Roo's signature-verification and `slack_sdk` client patterns ([main.py](roo-standalone/roo/main.py), [slack_client.py](roo-standalone/roo/slack_client.py)).
+
+```
+roo-standalone/bridge/
+  __init__.py
+  main.py          # FastAPI app: /events/mlai, /events/snc, /healthz
+  config.py        # env-driven settings
+  relay.py         # core pipeline: filter → attribute → translate → post
+  identity.py      # author resolution, name/avatar cache, self-puppet routing
+  store.py         # SQLite: ts-map, posted-registry, profile cache
+  slack.py         # thin clients: per-token WebClient factory
+  snc_session.py   # Path S: session-token client + WebSocket ingest worker
+  tests/
+```
+
+**Ingest differs by path.** MLAI always ingests via the `/events/mlai` HTTP endpoint (proper bot). For S&C: Path A/B use the `/events/snc` HTTP endpoint; **Path S has no inbound endpoint** — `snc_session.py` runs a long-lived background task that authenticates with the `xoxc`/`xoxd` session creds, opens the web-client WebSocket, and feeds received messages into the same `relay.py` pipeline. So in Path S the bridge needs only *one* public request URL (MLAI's), which is one less thing to expose.
+
+### Config (env)
+```
+MLAI_BOT_TOKEN / MLAI_SIGNING_SECRET / MLAI_CHANNEL_ID
+SNC_CHANNEL_ID
+SNC_SIGNING_SECRET       # Path A/B only (HTTP ingest)
+SNC_BOT_TOKEN            # Path A
+SNC_SAM_USER_TOKEN       # Path B (and self-puppet)
+SNC_SESSION_XOXC / SNC_SESSION_XOXD   # Path S (session client; encrypt at rest)
+MLAI_SAM_USER_TOKEN      # self-puppet, optional
+SAM_MLAI_USER_ID / SAM_SNC_USER_ID
+MLAI_APP_ID / SNC_APP_ID / bot user IDs
+BRIDGE_DB_PATH=/var/lib/slack-bridge/bridge.db
+```
+
+### SQLite schema
+```sql
+-- thread/edit/delete correlation, bidirectional lookups
+CREATE TABLE message_map (
+  src_team TEXT, src_channel TEXT, src_ts TEXT,
+  dst_team TEXT, dst_channel TEXT, dst_ts TEXT,
+  PRIMARY KEY (src_team, src_channel, src_ts)
+);
+CREATE INDEX idx_map_dst ON message_map (dst_team, dst_channel, dst_ts);
+
+-- loop prevention: every message the bridge itself posted
+CREATE TABLE posted_registry (
+  team TEXT, channel TEXT, ts TEXT, posted_at REAL,
+  PRIMARY KEY (team, channel, ts)
+);
+
+-- event dedupe (Slack retries up to 3x)
+CREATE TABLE seen_events (event_id TEXT PRIMARY KEY, seen_at REAL);
+```
+
+### Pipeline (per event)
+1. **Verify signature** (per-app secret), ack `200` immediately, process async — same 3-second-ack pattern Roo uses.
+2. **Dedupe** on `event_id`.
+3. **Channel filter:** drop anything not from the two bridged channel IDs (critical in Path B — Sam's user events cover all his S&C channels).
+4. **Loop filter** (order matters):
+   a. Author is own bridge bot/app on that side → drop.
+   b. `(channel, ts)` in `posted_registry` → drop.
+   c. Path B subtlety: Sam's S&C account is both a real participant *and* the relay identity. His organic messages must bridge; bridge-posted ones must not. The registry handles this, but there's a race — the message event can arrive before the `chat.postMessage` response is recorded. Fix: insert a registry *intent* row before calling postMessage and reconcile ts after; belt-and-braces, organic client messages carry `client_msg_id` while API-posted ones don't.
+5. **Subtype routing:** plain message → relay; `message_changed` → `chat.update` on mapped ts; `message_deleted` → `chat.delete`; `bot_message` from other bots (e.g. Roo) → relay via spoof path; file shares → file pipeline; everything else (joins, pins) → drop.
+6. **Attribution:** resolve author via `users.info` (cached in SQLite with TTL). Choose egress identity:
+   - Author is Sam (either side) and self-puppet enabled → post with his opposite-side user token, no prefix.
+   - Path A or into-MLAI → bot post with `username` + `icon_url`.
+   - Path B into-S&C → Sam's user token with `*Name:* ` prefix.
+7. **Translate:** rewrite `<@U…>` mentions to plain `@Display Name` (no cross-org pings until puppets exist); leave `:emoji:` as text; map `thread_ts` through `message_map` for replies.
+8. **Post, then record** mapping + registry. On `429`, honor `Retry-After` (volume makes this rare).
+
+### Files
+`url_private` is workspace-internal — always re-upload: download with the source-side token, `files.uploadV2` with the egress identity's token to the destination channel (threaded if applicable).
+
+### Reactions
+Skip in v1. Bot-mirrored reactions collapse attribution (everything from one identity, one per emoji), and in Path B they'd all appear as Sam. Revisit with puppets.
+
+### Ops
+- `tokens_revoked` / auth failures → DM Sam via Roo's existing `send_dm` and disable that direction cleanly (don't crash-loop).
+- systemd unit + `/healthz`; logs to journald. Nightly `seen_events`/`posted_registry` pruning (>7 days).
+- Tokens in env via systemd `EnvironmentFile` (root-read-only, like Roo's).
+
+---
+
+## Phases
+
+| Phase | Scope | Estimate |
+|---|---|---|
+| 0 | Preflight: S&C policy discovery, consent, channels, IDs | ½ day (mostly waiting on S&C) |
+| 1 | Apps + tokens + endpoint skeleton with verified signatures on both event URLs | ½ day |
+| 2 | **MVP:** text both directions, threads, loop prevention, ts-map, deploy on droplet | 1 day |
+| 3 | Fidelity: edits, deletes, files, mention translation, self-puppet for Sam | 1 day |
+| 4 | Hardening: revocation alerts, retries, pruning, channel-topic notices, README | ½ day |
+
+**Total: ~3.5 days** to a polished v1.
+
+## Risks
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| S&C blocks all app auth (Path C) | Project blocked | Ask S&C admin early (Step 0.1); nothing else is sanctioned |
+| S&C revokes Sam's token / membership lapses | S&C direction halts | `tokens_revoked` handler + DM alert; re-auth runbook |
+| Path S session token invalidated (logout / password change / anti-abuse heuristic) | S&C leg stops until re-auth | Behave like a real client (no bulk scraping, cache `users.info`, respect rate limits); 401 → DM Sam to re-extract token+cookie; treat S&C as best-effort |
+| Loop bug floods both channels | Embarrassing, noisy | Registry + author filters + a circuit breaker: >N bridge posts in 60s → pause + alert |
+| Consent/optics in S&C | Trust damage | Step 0.2 blessing + permanent channel-topic disclosure |
+| Path B: every S&C message Sam can see hits the endpoint | Privacy/log hygiene | Channel filter first, before any logging |
+
+## Future upgrades (when wanted)
+
+1. **Puppets in MLAI for S&C regulars** — Sam is MLAI admin, so the full double-puppeting plan applies one-directionally: catch-all email domain, invite + OAuth each puppet, S&C folks appear as real MLAI accounts with working mentions. The fallback-first design means this layers on without rearchitecting.
+2. **S&C bot via admin approval** — converts Path B to Path A; delete the prefix code path.
+3. **More channels** — schema already keys on channel; add a channel-pair table instead of env vars.
+
+## Open questions
+
+1. Which S&C channel — existing one, or a new `#mlai` Sam creates?
+2. Is the MLAI workspace on a free or paid plan? (Only matters for the puppet upgrade.)
+3. Should other bots' messages (Roo's posts in the MLAI channel) bridge into S&C, or stay internal? Default plan: bridge them.

--- a/roo-standalone/Dockerfile
+++ b/roo-standalone/Dockerfile
@@ -17,6 +17,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY roo/ ./roo/
 COPY skills/ ./skills/
 COPY ops/ ./ops/
+COPY bridge/ ./bridge/
 
 EXPOSE 8000
 

--- a/roo-standalone/bridge/.env.example
+++ b/roo-standalone/bridge/.env.example
@@ -1,0 +1,24 @@
+# --- Slack cross-org bridge config ---
+# A dedicated "Bridge" Slack app is installed in BOTH workspaces; this service
+# holds both bot tokens and polls both channels. Roo is not involved.
+# The bridge reads roo-standalone/.env. Both sides poll — no webhooks, no secret.
+
+# MLAI side — the Bridge app's MLAI install bot token.
+MLAI_BOT_TOKEN=xoxb-...
+MLAI_CHANNEL_ID=C0XXXXXXX
+# MLAI_POLL_SECONDS=5.0
+
+# Stone & Chalk side — the Bridge app's S&C install bot token.
+SNC_BOT_TOKEN=xoxb-...
+SNC_CHANNEL_ID=C0YYYYYYY
+# SNC_POLL_SECONDS=5.0
+
+# Behaviour (defaults shown)
+# BRIDGE_DB_PATH=data/slack_bridge.db
+# BRIDGE_RELAY_BOT_MESSAGES=true      # bridge other bots' posts (e.g. Roo) too
+# BRIDGE_RELAY_FILES=true
+# BRIDGE_MAX_POSTS_PER_MIN=30         # circuit breaker
+# BRIDGE_DELIVERY_POLL_SECONDS=2.0    # how often the delivery worker drains the queue
+# BRIDGE_MAX_DELIVERY_ATTEMPTS=5      # retries before a message is marked failed
+# BRIDGE_ALERT_DM_USER_ID=U0XXXXXXX   # DM you (MLAI id) on errors
+# BRIDGE_PRUNE_AFTER_DAYS=7

--- a/roo-standalone/bridge/.env.example
+++ b/roo-standalone/bridge/.env.example
@@ -1,24 +1,24 @@
 # --- Slack cross-org bridge config ---
-# A dedicated "Bridge" Slack app is installed in BOTH workspaces; this service
-# holds both bot tokens and polls both channels. Roo is not involved.
+# MLAI is the hub. A dedicated "Bridge" Slack app is installed in MLAI and in
+# each partner workspace; this service holds the tokens and polls each channel.
 # The bridge reads roo-standalone/.env. Both sides poll — no webhooks, no secret.
+# THESE ARE SECRETS — .env is gitignored; never commit real tokens.
 
-# MLAI side — the Bridge app's MLAI install bot token.
+# Hub: the Bridge app's MLAI install bot token.
 MLAI_BOT_TOKEN=xoxb-...
-MLAI_CHANNEL_ID=C0XXXXXXX
-# MLAI_POLL_SECONDS=5.0
 
-# Stone & Chalk side — the Bridge app's S&C install bot token.
-SNC_BOT_TOKEN=xoxb-...
-SNC_CHANNEL_ID=C0YYYYYYY
-# SNC_POLL_SECONDS=5.0
+# One JSON object per mirrored channel (single line). `mlai_channel` and
+# `remote_channel` may be a channel name (resolved at startup) or an ID.
+# `remote_token` is that partner workspace's Bridge bot token. Add a workspace
+# by appending another object.
+BRIDGE_PAIRS=[{"label":"hex","mlai_channel":"exp-victor-ai","remote_token":"xoxb-...","remote_channel":"exp-victor-ai"}]
 
 # Behaviour (defaults shown)
+# POLL_SECONDS=5.0
+# BRIDGE_DELIVERY_POLL_SECONDS=2.0
+# BRIDGE_MAX_DELIVERY_ATTEMPTS=5
 # BRIDGE_DB_PATH=data/slack_bridge.db
 # BRIDGE_RELAY_BOT_MESSAGES=true      # bridge other bots' posts (e.g. Roo) too
 # BRIDGE_RELAY_FILES=true
 # BRIDGE_MAX_POSTS_PER_MIN=30         # circuit breaker
-# BRIDGE_DELIVERY_POLL_SECONDS=2.0    # how often the delivery worker drains the queue
-# BRIDGE_MAX_DELIVERY_ATTEMPTS=5      # retries before a message is marked failed
-# BRIDGE_ALERT_DM_USER_ID=U0XXXXXXX   # DM you (MLAI id) on errors
-# BRIDGE_PRUNE_AFTER_DAYS=7
+# BRIDGE_ALERT_DM_USER_ID=U...        # DM you (MLAI id) on errors

--- a/roo-standalone/bridge/.gitignore
+++ b/roo-standalone/bridge/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/roo-standalone/bridge/README.md
+++ b/roo-standalone/bridge/README.md
@@ -50,8 +50,24 @@ cd roo-standalone
 cp bridge/.env.example .env   # then fill it in (or merge into your existing .env)
 uvicorn bridge.main:app --host 0.0.0.0 --port 8100
 ```
-Health: `GET /healthz`. On the droplet, run it as its own systemd unit
-(`slack-bridge.service`) behind nginx, separate from Roo.
+Health: `GET /healthz`. No public port is needed — the bridge only makes
+outbound calls (both sides poll), so there are no inbound webhooks to expose.
+
+### 3. Deploy on the droplet (Docker)
+Roo runs via Docker Compose, so the bridge ships the same way — its own
+container in its own Compose project, independent of Roo's deploy:
+```bash
+cd roo-standalone
+docker compose -f docker-compose.bridge.yml up -d --build
+```
+To have systemd supervise it (mirroring `ops/docker-health-watchdog.service.example`):
+```bash
+sudo cp ops/slack-bridge.service.example /etc/systemd/system/slack-bridge.service
+# edit WorkingDirectory if your deploy dir differs from /root/roo/roo-standalone
+sudo systemctl daemon-reload && sudo systemctl enable --now slack-bridge
+```
+Because it's a separate Compose project (`name: slack-bridge`), Roo's regular
+`docker compose up -d --remove-orphans` deploy never starts or removes it.
 
 ## v1 scope and limitations
 - **Both sides poll**, not real-time. Expect a few seconds of latency

--- a/roo-standalone/bridge/README.md
+++ b/roo-standalone/bridge/README.md
@@ -1,0 +1,79 @@
+# Slack Cross-Org Channel Bridge
+
+Bridges one channel in **MLAI** with one channel in **Stone & Chalk**, relayed by
+this service on the droplet. Members of each org read and write entirely in their
+own workspace. Full design + rationale: [`../../SLACK_BRIDGE_PLAN.md`](../../SLACK_BRIDGE_PLAN.md).
+
+## Design
+
+A **dedicated "Bridge" Slack app** is installed in both workspaces (Roo is not
+involved). This service holds both bot tokens and polls both channels — no
+inbound webhooks, so it runs as its own process and nothing is wired into Roo.
+
+It is **store-and-forward**: the pollers *capture* each new message into a
+durable inbound queue (SQLite), and a separate delivery worker drains the queue,
+posting into the other workspace with retries + backoff. A failed post is
+retried, not lost.
+
+| | MLAI | Stone & Chalk |
+|---|---|---|
+| Auth | Bridge app's MLAI install (bot token) | Bridge app's S&C install (bot token) |
+| Ingest | poll `conversations.history` | poll `conversations.history` |
+| Egress | bot post w/ `chat:write.customize` | bot post w/ `chat:write.customize` |
+
+Both directions are symmetric: each author appears in the other workspace with
+their real name + avatar (small APP badge).
+
+Flow: `poll → capture to inbound queue → delivery worker → post`. Capture applies
+the cheap filters (loop guard, subtype, dedup) so only real content is queued;
+delivery does attribution, translation, posting, and retry/backoff.
+
+## Setup
+
+### 1. Create the Bridge app + install in both orgs
+Create a new app at api.slack.com (NOT Roo). Add these **bot token scopes**:
+`channels:history`, `channels:read`, `chat:write`, `chat:write.customize`,
+`users:read`, `files:read`, `files:write` (add `groups:history`, `groups:read`
+if either channel is private).
+
+Then install it into **both** workspaces — activate *Manage Distribution →
+Public Distribution* on the Bridge app and use its install URL to add it to MLAI
+and to Stone & Chalk. Each install yields a separate bot token (`xoxb-…`):
+`MLAI_BOT_TOKEN` and `SNC_BOT_TOKEN`. Invite the Bridge bot to the bridged
+channel in each workspace.
+
+No Request URL / Event Subscriptions needed — the bridge polls.
+
+### 2. Run
+```bash
+cd roo-standalone
+cp bridge/.env.example .env   # then fill it in (or merge into your existing .env)
+uvicorn bridge.main:app --host 0.0.0.0 --port 8100
+```
+Health: `GET /healthz`. On the droplet, run it as its own systemd unit
+(`slack-bridge.service`) behind nginx, separate from Roo.
+
+## v1 scope and limitations
+- **Both sides poll**, not real-time. Expect a few seconds of latency
+  (`MLAI_POLL_SECONDS` / `SNC_POLL_SECONDS`). Upgrade path: subscribe each install
+  to the Events API and feed events into the same relay handlers.
+- **Edits/deletes are not mirrored** in poll mode (polling sees current state,
+  not change/delete events).
+- **Reactions** are intentionally skipped in v1.
+- **Files** are re-uploaded best-effort across workspaces.
+- Pick a channel where Roo doesn't post automated content, or set
+  `BRIDGE_RELAY_BOT_MESSAGES=false`, so Roo's posts don't cross over.
+
+## Consent
+Mirroring members' messages into another org is a consent matter — get S&C's
+community-manager sign-off and note the bridge in both channel topics.
+
+## Loop prevention
+Every message the bridge posts is written to `posted_registry`; any polled
+message found there is dropped. A circuit breaker pauses posting if it ever
+exceeds `BRIDGE_MAX_POSTS_PER_MIN` and DMs `BRIDGE_ALERT_DM_USER_ID`.
+
+## Tests
+```bash
+cd roo-standalone && python -m pytest bridge/tests -q
+```

--- a/roo-standalone/bridge/README.md
+++ b/roo-standalone/bridge/README.md
@@ -1,93 +1,70 @@
 # Slack Cross-Org Channel Bridge
 
-Bridges one channel in **MLAI** with one channel in **Stone & Chalk**, relayed by
-this service on the droplet. Members of each org read and write entirely in their
-own workspace. Full design + rationale: [`../../SLACK_BRIDGE_PLAN.md`](../../SLACK_BRIDGE_PLAN.md).
+Mirrors channels between the **MLAI** workspace (the hub) and one or more partner
+Slack workspaces, relayed by this service on the droplet. Members of each org
+read and write entirely in their own workspace. Full design + rationale:
+[`../../SLACK_BRIDGE_PLAN.md`](../../SLACK_BRIDGE_PLAN.md).
 
 ## Design
 
-A **dedicated "Bridge" Slack app** is installed in both workspaces (Roo is not
-involved). This service holds both bot tokens and polls both channels — no
-inbound webhooks, so it runs as its own process and nothing is wired into Roo.
+A dedicated "Bridge" Slack app is installed in MLAI and in each partner
+workspace (Roo is not involved). MLAI is the hub: this service holds the MLAI
+token plus, for each mirrored channel, the partner workspace's token. Every side
+is **polled** — no inbound webhooks, so it runs as its own process and nothing is
+wired into Roo.
 
 It is **store-and-forward**: the pollers *capture* each new message into a
-durable inbound queue (SQLite), and a separate delivery worker drains the queue,
-posting into the other workspace with retries + backoff. A failed post is
-retried, not lost.
+durable inbound queue (SQLite), and a delivery worker drains the queue, posting
+into the other workspace with `chat:write.customize` (real name + avatar) and
+retries/backoff. A failed post is retried, not lost.
 
-| | MLAI | Stone & Chalk |
-|---|---|---|
-| Auth | Bridge app's MLAI install (bot token) | Bridge app's S&C install (bot token) |
-| Ingest | poll `conversations.history` | poll `conversations.history` |
-| Egress | bot post w/ `chat:write.customize` | bot post w/ `chat:write.customize` |
+```
+poll MLAI #x ─┐                      ┌─> post into partner #x
+              ├─> inbound queue ─> delivery worker
+poll partner #x ┘                    └─> post into MLAI #x
+```
 
-Both directions are symmetric: each author appears in the other workspace with
-their real name + avatar (small APP badge).
-
-Flow: `poll → capture to inbound queue → delivery worker → post`. Capture applies
-the cheap filters (loop guard, subtype, dedup) so only real content is queued;
-delivery does attribution, translation, posting, and retry/backoff.
+Each mirrored channel is a **pair** with two directions. Loop prevention is via a
+posted-message registry, keyed by `(team, channel, ts)` so it holds across all
+pairs; a circuit breaker pauses posting if it ever floods.
 
 ## Setup
 
-### 1. Create the Bridge app + install in both orgs
-Create a new app at api.slack.com (NOT Roo). Add these **bot token scopes**:
+### 1. Bridge app + scopes
+Create one app (or one per workspace — see SLACK_BRIDGE_PLAN.md) with bot scopes
 `channels:history`, `channels:read`, `chat:write`, `chat:write.customize`,
 `users:read`, `files:read`, `files:write` (add `groups:history`, `groups:read`
-if either channel is private).
+for private channels). Install it in MLAI and each partner workspace, and
+**invite the bot to every bridged channel** (`/invite @MLAI Bridge`).
 
-Then install it into **both** workspaces — activate *Manage Distribution →
-Public Distribution* on the Bridge app and use its install URL to add it to MLAI
-and to Stone & Chalk. Each install yields a separate bot token (`xoxb-…`):
-`MLAI_BOT_TOKEN` and `SNC_BOT_TOKEN`. Invite the Bridge bot to the bridged
-channel in each workspace.
-
-No Request URL / Event Subscriptions needed — the bridge polls.
-
-### 2. Run
-```bash
-cd roo-standalone
-cp bridge/.env.example .env   # then fill it in (or merge into your existing .env)
-uvicorn bridge.main:app --host 0.0.0.0 --port 8100
+### 2. Configure `.env`
 ```
-Health: `GET /healthz`. No public port is needed — the bridge only makes
-outbound calls (both sides poll), so there are no inbound webhooks to expose.
+MLAI_BOT_TOKEN=xoxb-…               # MLAI install
+BRIDGE_PAIRS=[{"label":"hex","mlai_channel":"exp-victor-ai","remote_token":"xoxb-…","remote_channel":"exp-victor-ai"}]
+```
+`mlai_channel` / `remote_channel` accept a channel **name** (resolved at startup)
+or an ID. Add a partner workspace by appending another object to the JSON list.
 
-### 3. Deploy on the droplet (Docker)
-Roo runs via Docker Compose, so the bridge ships the same way — its own
-container in its own Compose project, independent of Roo's deploy:
+### 3. Run / deploy
 ```bash
 cd roo-standalone
 docker compose -f docker-compose.bridge.yml up -d --build
 ```
-To have systemd supervise it (mirroring `ops/docker-health-watchdog.service.example`):
-```bash
-sudo cp ops/slack-bridge.service.example /etc/systemd/system/slack-bridge.service
-# edit WorkingDirectory if your deploy dir differs from /root/roo/roo-standalone
-sudo systemctl daemon-reload && sudo systemctl enable --now slack-bridge
-```
-Because it's a separate Compose project (`name: slack-bridge`), Roo's regular
-`docker compose up -d --remove-orphans` deploy never starts or removes it.
+…or install `ops/slack-bridge.service.example` as a systemd unit. Health:
+`GET /healthz`. A pair whose channel doesn't exist yet (or the bot isn't invited
+to) is skipped with a warning — create/invite, then restart.
 
 ## v1 scope and limitations
-- **Both sides poll**, not real-time. Expect a few seconds of latency
-  (`MLAI_POLL_SECONDS` / `SNC_POLL_SECONDS`). Upgrade path: subscribe each install
-  to the Events API and feed events into the same relay handlers.
-- **Edits/deletes are not mirrored** in poll mode (polling sees current state,
-  not change/delete events).
-- **Reactions** are intentionally skipped in v1.
-- **Files** are re-uploaded best-effort across workspaces.
-- Pick a channel where Roo doesn't post automated content, or set
+- **Both sides poll** (a few seconds of latency). Mirrors messages from when it
+  starts **forward** — it does not backfill existing history (a separate one-off).
+- **Edits/deletes are not mirrored** in poll mode; **reactions** are skipped;
+  **files** are re-uploaded best-effort.
+- Pick channels where Roo doesn't post automated content, or set
   `BRIDGE_RELAY_BOT_MESSAGES=false`, so Roo's posts don't cross over.
 
 ## Consent
-Mirroring members' messages into another org is a consent matter — get S&C's
-community-manager sign-off and note the bridge in both channel topics.
-
-## Loop prevention
-Every message the bridge posts is written to `posted_registry`; any polled
-message found there is dropped. A circuit breaker pauses posting if it ever
-exceeds `BRIDGE_MAX_POSTS_PER_MIN` and DMs `BRIDGE_ALERT_DM_USER_ID`.
+Mirroring members' messages into another org is a consent matter — get each
+partner's community-manager sign-off and note the bridge in both channel topics.
 
 ## Tests
 ```bash

--- a/roo-standalone/bridge/__init__.py
+++ b/roo-standalone/bridge/__init__.py
@@ -1,0 +1,13 @@
+"""
+Slack cross-org channel bridge.
+
+Bridges one channel in the MLAI workspace (where Roo lives; bridge runs as a
+normal bot, since Sam is admin) with one channel in the Stone & Chalk workspace
+(where Sam is only a member, so the bridge connects "Beeper-style" using Sam's
+own web-session credentials — no app installed in S&C).
+
+See SLACK_BRIDGE_PLAN.md at the repo root for the full design and the honest
+trade-offs of the session-token approach.
+"""
+
+__version__ = "0.1.0"

--- a/roo-standalone/bridge/config.py
+++ b/roo-standalone/bridge/config.py
@@ -1,0 +1,70 @@
+"""
+Bridge configuration.
+
+Pydantic Settings, mirroring roo/config.py conventions (env file, extra=ignore,
+singleton getter). The bridge is a dedicated "Bridge" Slack app installed in BOTH
+workspaces, so each side has its own normal bot token. Roo is not involved.
+Both sides are POLLED (no inbound webhooks), so there is no signing secret here.
+"""
+from typing import Optional
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class BridgeSettings(BaseSettings):
+    """Bridge settings loaded from environment variables / .env."""
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    # --- MLAI side (Bridge app's MLAI install) ---
+    MLAI_BOT_TOKEN: str
+    MLAI_CHANNEL_ID: str
+    MLAI_POLL_SECONDS: float = 5.0
+    # Resolved at startup via auth.test if left unset.
+    MLAI_TEAM_ID: Optional[str] = None
+    MLAI_BOT_USER_ID: Optional[str] = None
+
+    # --- Stone & Chalk side (Bridge app's S&C install) ---
+    SNC_BOT_TOKEN: Optional[str] = None
+    SNC_CHANNEL_ID: str
+    SNC_POLL_SECONDS: float = 5.0
+    # Resolved at startup via auth.test if left unset.
+    SNC_TEAM_ID: Optional[str] = None
+    SNC_BOT_USER_ID: Optional[str] = None
+
+    # --- Behaviour ---
+    BRIDGE_DB_PATH: str = "data/slack_bridge.db"
+    # Bridge messages from bots (e.g. Roo's own posts in the channel) across.
+    BRIDGE_RELAY_BOT_MESSAGES: bool = True
+    # Best-effort re-upload of shared files across workspaces.
+    BRIDGE_RELAY_FILES: bool = True
+    # Circuit breaker: if the bridge posts more than this in 60s, pause + alert.
+    BRIDGE_MAX_POSTS_PER_MIN: int = 30
+    # Store-and-forward delivery worker: how often it drains the queue, and how
+    # many times to retry a message before giving up (with exponential backoff).
+    BRIDGE_DELIVERY_POLL_SECONDS: float = 2.0
+    BRIDGE_MAX_DELIVERY_ATTEMPTS: int = 5
+    # Slack user id (MLAI side) to DM on errors / revoked tokens. Usually Sam.
+    BRIDGE_ALERT_DM_USER_ID: Optional[str] = None
+    # Prune dedupe/registry rows older than this many days.
+    BRIDGE_PRUNE_AFTER_DAYS: int = 7
+
+    DEBUG: bool = False
+
+    @property
+    def snc_configured(self) -> bool:
+        return bool(self.SNC_BOT_TOKEN)
+
+
+_settings: Optional[BridgeSettings] = None
+
+
+def get_bridge_settings() -> BridgeSettings:
+    """Get or create the bridge settings singleton."""
+    global _settings
+    if _settings is None:
+        _settings = BridgeSettings()
+    return _settings

--- a/roo-standalone/bridge/config.py
+++ b/roo-standalone/bridge/config.py
@@ -2,12 +2,26 @@
 Bridge configuration.
 
 Pydantic Settings, mirroring roo/config.py conventions (env file, extra=ignore,
-singleton getter). The bridge is a dedicated "Bridge" Slack app installed in BOTH
-workspaces, so each side has its own normal bot token. Roo is not involved.
-Both sides are POLLED (no inbound webhooks), so there is no signing secret here.
+singleton getter). MLAI is the hub: one MLAI bot token, plus a list of channel
+PAIRS, one per partner workspace channel. Each pair brings its own remote bot
+token + channel, so adding a workspace is just one more entry in BRIDGE_PAIRS.
+
+Channels may be given as an ID (e.g. C0123ABCD) or a name (e.g. exp-victor-ai),
+which is resolved at startup. Both sides are POLLED (no webhooks, no secret).
 """
-from typing import Optional
+from typing import List, Optional
+
+from pydantic import BaseModel
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class BridgePair(BaseModel):
+    """One mirrored channel: an MLAI channel <-> a channel in a partner workspace."""
+
+    label: str                 # short id, no ':' (e.g. "hex", "stone-and-chalk")
+    mlai_channel: str          # name or ID in the MLAI workspace
+    remote_token: str          # the Bridge bot token for the partner workspace
+    remote_channel: str        # name or ID in the partner workspace
 
 
 class BridgeSettings(BaseSettings):
@@ -19,44 +33,33 @@ class BridgeSettings(BaseSettings):
         extra="ignore",
     )
 
-    # --- MLAI side (Bridge app's MLAI install) ---
+    # --- Hub (MLAI) ---
     MLAI_BOT_TOKEN: str
-    MLAI_CHANNEL_ID: str
-    MLAI_POLL_SECONDS: float = 5.0
-    # Resolved at startup via auth.test if left unset.
-    MLAI_TEAM_ID: Optional[str] = None
-    MLAI_BOT_USER_ID: Optional[str] = None
+    MLAI_TEAM_ID: Optional[str] = None       # resolved at startup
+    MLAI_BOT_USER_ID: Optional[str] = None   # resolved at startup
 
-    # --- Stone & Chalk side (Bridge app's S&C install) ---
-    SNC_BOT_TOKEN: Optional[str] = None
-    SNC_CHANNEL_ID: str
-    SNC_POLL_SECONDS: float = 5.0
-    # Resolved at startup via auth.test if left unset.
-    SNC_TEAM_ID: Optional[str] = None
-    SNC_BOT_USER_ID: Optional[str] = None
+    # --- Spokes ---
+    # JSON list in the env var, e.g.
+    # BRIDGE_PAIRS=[{"label":"hex","mlai_channel":"exp-victor-ai","remote_token":"xoxb-...","remote_channel":"exp-victor-ai"}]
+    BRIDGE_PAIRS: List[BridgePair] = []
 
     # --- Behaviour ---
+    POLL_SECONDS: float = 5.0
+    BRIDGE_DELIVERY_POLL_SECONDS: float = 2.0
+    BRIDGE_MAX_DELIVERY_ATTEMPTS: int = 5
     BRIDGE_DB_PATH: str = "data/slack_bridge.db"
-    # Bridge messages from bots (e.g. Roo's own posts in the channel) across.
+    # Bridge messages from bots (e.g. Roo's own posts) across.
     BRIDGE_RELAY_BOT_MESSAGES: bool = True
     # Best-effort re-upload of shared files across workspaces.
     BRIDGE_RELAY_FILES: bool = True
     # Circuit breaker: if the bridge posts more than this in 60s, pause + alert.
     BRIDGE_MAX_POSTS_PER_MIN: int = 30
-    # Store-and-forward delivery worker: how often it drains the queue, and how
-    # many times to retry a message before giving up (with exponential backoff).
-    BRIDGE_DELIVERY_POLL_SECONDS: float = 2.0
-    BRIDGE_MAX_DELIVERY_ATTEMPTS: int = 5
-    # Slack user id (MLAI side) to DM on errors / revoked tokens. Usually Sam.
+    # Slack user id (MLAI side) to DM on errors. Usually Sam.
     BRIDGE_ALERT_DM_USER_ID: Optional[str] = None
     # Prune dedupe/registry rows older than this many days.
     BRIDGE_PRUNE_AFTER_DAYS: int = 7
 
     DEBUG: bool = False
-
-    @property
-    def snc_configured(self) -> bool:
-        return bool(self.SNC_BOT_TOKEN)
 
 
 _settings: Optional[BridgeSettings] = None

--- a/roo-standalone/bridge/identity.py
+++ b/roo-standalone/bridge/identity.py
@@ -1,0 +1,85 @@
+"""
+Author resolution and Slack-markup translation.
+
+Two jobs:
+  * Resolve a user id to a display name + avatar (cached per side), so messages
+    can be attributed to the real person.
+  * Rewrite Slack's wire markup into plain text that makes sense in the *other*
+    workspace, where user/channel ids mean nothing. Crucially, mentions become
+    inert "@Name" text — we deliberately do NOT ping across orgs in v1 (that
+    needs real puppet accounts; see SLACK_BRIDGE_PLAN.md).
+"""
+import re
+from typing import Any, Dict
+
+_USER_RE = re.compile(r"<@([UW][A-Z0-9]+)(?:\|([^>]+))?>")
+_CHANNEL_RE = re.compile(r"<#(C[A-Z0-9]+)(?:\|([^>]*))?>")
+_SPECIAL_RE = re.compile(r"<!(here|channel|everyone)>")
+_SUBTEAM_RE = re.compile(r"<!subteam\^[A-Z0-9]+(?:\|(@?[^>]+))?>")
+_LINK_RE = re.compile(r"<(https?://[^>|]+)(?:\|([^>]+))?>")
+
+
+class IdentityResolver:
+    def __init__(self):
+        # keyed by "team:user_id" so the same id in two workspaces never collides
+        self._user_cache: Dict[str, Dict[str, Any]] = {}
+
+    def user_info(self, client, user_id: str, team: str = "") -> Dict[str, Any]:
+        key = f"{team}:{user_id}"
+        cached = self._user_cache.get(key)
+        if cached is not None:
+            return cached
+
+        info = {"id": user_id, "name": user_id, "display_name": "", "real_name": "", "image": ""}
+        try:
+            resp = client.users_info(user=user_id)
+            if resp.get("ok"):
+                u = resp["user"]
+                p = u.get("profile", {})
+                info = {
+                    "id": user_id,
+                    "name": u.get("name", ""),
+                    "display_name": p.get("display_name", ""),
+                    "real_name": u.get("real_name", p.get("real_name", "")),
+                    "image": p.get("image_512") or p.get("image_192") or p.get("image_72") or "",
+                }
+        except Exception as e:
+            # Don't let a lookup miss break a relay — fall back to the raw id.
+            print(f"⚠️ users_info failed for {user_id}: {e}")
+
+        self._user_cache[key] = info
+        return info
+
+    def display_name(self, client, user_id: str, team: str = "") -> str:
+        info = self.user_info(client, user_id, team)
+        return info.get("display_name") or info.get("real_name") or info.get("name") or user_id
+
+    def avatar(self, client, user_id: str, team: str = "") -> str:
+        return self.user_info(client, user_id, team).get("image") or ""
+
+    def translate(self, client, text: str, team: str = "") -> str:
+        """Rewrite Slack markup for display in the other workspace."""
+        if not text:
+            return ""
+
+        def _user(m: "re.Match") -> str:
+            uid, label = m.group(1), m.group(2)
+            return f"@{label}" if label else f"@{self.display_name(client, uid, team)}"
+
+        text = _USER_RE.sub(_user, text)
+        text = _CHANNEL_RE.sub(lambda m: f"#{m.group(2) or m.group(1)}", text)
+        # @here/@channel as plain text — informative but does NOT ping the other org.
+        text = _SPECIAL_RE.sub(lambda m: f"@{m.group(1)}", text)
+        text = _SUBTEAM_RE.sub(lambda m: (m.group(1) or "@group"), text)
+        text = _LINK_RE.sub(
+            lambda m: f"{m.group(2)} ({m.group(1)})" if m.group(2) else m.group(1), text
+        )
+        # Slack escapes these in message text; unescape for the destination.
+        return text.replace("&lt;", "<").replace("&gt;", ">").replace("&amp;", "&")
+
+
+_resolver = IdentityResolver()
+
+
+def get_resolver() -> IdentityResolver:
+    return _resolver

--- a/roo-standalone/bridge/main.py
+++ b/roo-standalone/bridge/main.py
@@ -1,12 +1,10 @@
 """
 Bridge service.
 
-A dedicated "Bridge" Slack app is installed in both workspaces; this service
-holds both bot tokens. Store-and-forward design:
-
-  * two channel pollers CAPTURE new messages into the inbound DB queue, and
-  * one delivery worker drains the queue, posting into the other workspace with
-    retries.
+MLAI is the hub. For each pair in BRIDGE_PAIRS the service holds the partner
+workspace's bot token, resolves both channel IDs, and runs two capture pollers
+(MLAI channel + partner channel). A single delivery worker drains the shared
+inbound queue and posts into the destination workspace.
 
 No inbound webhooks; runs as its own process on the droplet, independent of Roo.
 A minimal FastAPI app exposes GET /healthz for nginx/monitoring.
@@ -20,8 +18,8 @@ from fastapi import FastAPI
 from .config import get_bridge_settings
 from .identity import get_resolver
 from .poller import channel_poll_loop, delivery_loop, poll_error_backoff
-from .relay import Relay
-from .slack import make_bot_client, resolve_identity
+from .relay import Relay, ResolvedPair
+from .slack import make_bot_client, resolve_channel_id, resolve_identity
 from .store import get_store
 
 
@@ -32,62 +30,69 @@ async def lifespan(app: FastAPI):
     identity = get_resolver()
 
     print("🌉 Slack bridge starting...")
-    print(f"   MLAI channel: {settings.MLAI_CHANNEL_ID}")
-    print(f"   S&C channel:  {settings.SNC_CHANNEL_ID}")
 
     mlai_client = make_bot_client(settings.MLAI_BOT_TOKEN)
     try:
         me = resolve_identity(mlai_client)
         settings.MLAI_BOT_USER_ID = settings.MLAI_BOT_USER_ID or me["user_id"]
         settings.MLAI_TEAM_ID = settings.MLAI_TEAM_ID or me["team_id"]
-        print(f"   MLAI bot: {settings.MLAI_BOT_USER_ID} @ team {settings.MLAI_TEAM_ID}")
+        print(f"   MLAI hub: bot {settings.MLAI_BOT_USER_ID} @ team {settings.MLAI_TEAM_ID}")
     except Exception as e:
         print(f"❌ MLAI bot auth.test failed — check MLAI_BOT_TOKEN: {e}")
         raise
 
-    snc_client = None
-    if settings.snc_configured:
-        snc_client = make_bot_client(settings.SNC_BOT_TOKEN)
+    # Resolve each pair into live clients + channel IDs. A pair that can't be
+    # resolved (channel missing or bot not invited) is skipped with a warning so
+    # the rest of the bridge still runs; fix it and restart.
+    resolved: List[ResolvedPair] = []
+    poll_specs = []  # (display, client, channel_id, team, label, to_mlai)
+    for pair in settings.BRIDGE_PAIRS:
         try:
-            who = resolve_identity(snc_client)
-            settings.SNC_BOT_USER_ID = settings.SNC_BOT_USER_ID or who["user_id"]
-            settings.SNC_TEAM_ID = settings.SNC_TEAM_ID or who["team_id"]
-            print(f"   S&C bot: {settings.SNC_BOT_USER_ID} @ team {settings.SNC_TEAM_ID}")
+            remote_client = make_bot_client(pair.remote_token)
+            who = resolve_identity(remote_client)
+            remote_team = who["team_id"]
         except Exception as e:
-            print(f"⚠️ S&C bot auth.test failed — check SNC_BOT_TOKEN: {e}")
-    else:
-        print("⚠️ SNC_BOT_TOKEN not set — S&C side disabled until configured")
+            print(f"⚠️ pair {pair.label!r}: remote token auth failed, skipping: {e}")
+            continue
+
+        mlai_ch = resolve_channel_id(mlai_client, pair.mlai_channel)
+        remote_ch = resolve_channel_id(remote_client, pair.remote_channel)
+        if not mlai_ch:
+            print(f"⚠️ pair {pair.label!r}: MLAI channel {pair.mlai_channel!r} not found "
+                  f"(create it + invite the bot, then restart) — skipping")
+            continue
+        if not remote_ch:
+            print(f"⚠️ pair {pair.label!r}: partner channel {pair.remote_channel!r} not found "
+                  f"(invite the bot there, then restart) — skipping")
+            continue
+
+        resolved.append(ResolvedPair(pair.label, remote_client, remote_team, mlai_ch, remote_ch))
+        poll_specs.append((f"MLAI#{pair.label}", mlai_client, mlai_ch, settings.MLAI_TEAM_ID, pair.label, False))
+        poll_specs.append((f"{pair.label}#remote", remote_client, remote_ch, remote_team, pair.label, True))
+        print(f"   pair {pair.label!r}: MLAI {mlai_ch} <-> {remote_team}/{remote_ch}")
+
+    if not resolved:
+        print("⚠️ no usable pairs — bridge is idle until BRIDGE_PAIRS is configured + channels exist")
 
     relay = Relay(
         settings=settings, store=store, identity=identity,
-        mlai_client=mlai_client, snc_client=snc_client,
+        mlai_client=mlai_client, pairs=resolved,
     )
     app.state.ready = True
 
     tasks: List[asyncio.Task] = []
-    # Capture pollers.
-    tasks.append(
-        asyncio.create_task(
-            channel_poll_loop(
-                label="📥 MLAI", client=mlai_client, channel_id=settings.MLAI_CHANNEL_ID,
-                hwm_key="mlai_last_ts", handler=relay.capture_from_mlai, store=store,
-                poll_seconds=settings.MLAI_POLL_SECONDS,
-                on_error=lambda e: poll_error_backoff(e, label="MLAI", relay=relay),
-            )
-        )
-    )
-    if snc_client is not None:
+    for display, client, channel_id, team, label, to_mlai in poll_specs:
         tasks.append(
             asyncio.create_task(
                 channel_poll_loop(
-                    label="📥 S&C", client=snc_client, channel_id=settings.SNC_CHANNEL_ID,
-                    hwm_key="snc_last_ts", handler=relay.capture_from_snc, store=store,
-                    poll_seconds=settings.SNC_POLL_SECONDS,
-                    on_error=lambda e: poll_error_backoff(e, label="S&C", relay=relay),
+                    label=f"📥 {display}", client=client, channel_id=channel_id,
+                    hwm_key=f"hwm:{team}:{channel_id}",
+                    handler=(lambda msg, _l=label, _t=to_mlai: relay.capture(_l, _t, msg)),
+                    store=store, poll_seconds=settings.POLL_SECONDS,
+                    on_error=(lambda e, _n=display: poll_error_backoff(e, label=_n, relay=relay)),
                 )
             )
         )
-    # Delivery worker.
     tasks.append(
         asyncio.create_task(
             delivery_loop(relay=relay, store=store, poll_seconds=settings.BRIDGE_DELIVERY_POLL_SECONDS)

--- a/roo-standalone/bridge/main.py
+++ b/roo-standalone/bridge/main.py
@@ -1,0 +1,113 @@
+"""
+Bridge service.
+
+A dedicated "Bridge" Slack app is installed in both workspaces; this service
+holds both bot tokens. Store-and-forward design:
+
+  * two channel pollers CAPTURE new messages into the inbound DB queue, and
+  * one delivery worker drains the queue, posting into the other workspace with
+    retries.
+
+No inbound webhooks; runs as its own process on the droplet, independent of Roo.
+A minimal FastAPI app exposes GET /healthz for nginx/monitoring.
+"""
+import asyncio
+from contextlib import asynccontextmanager, suppress
+from typing import List
+
+from fastapi import FastAPI
+
+from .config import get_bridge_settings
+from .identity import get_resolver
+from .poller import channel_poll_loop, delivery_loop, poll_error_backoff
+from .relay import Relay
+from .slack import make_bot_client, resolve_identity
+from .store import get_store
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    settings = get_bridge_settings()
+    store = get_store()
+    identity = get_resolver()
+
+    print("🌉 Slack bridge starting...")
+    print(f"   MLAI channel: {settings.MLAI_CHANNEL_ID}")
+    print(f"   S&C channel:  {settings.SNC_CHANNEL_ID}")
+
+    mlai_client = make_bot_client(settings.MLAI_BOT_TOKEN)
+    try:
+        me = resolve_identity(mlai_client)
+        settings.MLAI_BOT_USER_ID = settings.MLAI_BOT_USER_ID or me["user_id"]
+        settings.MLAI_TEAM_ID = settings.MLAI_TEAM_ID or me["team_id"]
+        print(f"   MLAI bot: {settings.MLAI_BOT_USER_ID} @ team {settings.MLAI_TEAM_ID}")
+    except Exception as e:
+        print(f"❌ MLAI bot auth.test failed — check MLAI_BOT_TOKEN: {e}")
+        raise
+
+    snc_client = None
+    if settings.snc_configured:
+        snc_client = make_bot_client(settings.SNC_BOT_TOKEN)
+        try:
+            who = resolve_identity(snc_client)
+            settings.SNC_BOT_USER_ID = settings.SNC_BOT_USER_ID or who["user_id"]
+            settings.SNC_TEAM_ID = settings.SNC_TEAM_ID or who["team_id"]
+            print(f"   S&C bot: {settings.SNC_BOT_USER_ID} @ team {settings.SNC_TEAM_ID}")
+        except Exception as e:
+            print(f"⚠️ S&C bot auth.test failed — check SNC_BOT_TOKEN: {e}")
+    else:
+        print("⚠️ SNC_BOT_TOKEN not set — S&C side disabled until configured")
+
+    relay = Relay(
+        settings=settings, store=store, identity=identity,
+        mlai_client=mlai_client, snc_client=snc_client,
+    )
+    app.state.ready = True
+
+    tasks: List[asyncio.Task] = []
+    # Capture pollers.
+    tasks.append(
+        asyncio.create_task(
+            channel_poll_loop(
+                label="📥 MLAI", client=mlai_client, channel_id=settings.MLAI_CHANNEL_ID,
+                hwm_key="mlai_last_ts", handler=relay.capture_from_mlai, store=store,
+                poll_seconds=settings.MLAI_POLL_SECONDS,
+                on_error=lambda e: poll_error_backoff(e, label="MLAI", relay=relay),
+            )
+        )
+    )
+    if snc_client is not None:
+        tasks.append(
+            asyncio.create_task(
+                channel_poll_loop(
+                    label="📥 S&C", client=snc_client, channel_id=settings.SNC_CHANNEL_ID,
+                    hwm_key="snc_last_ts", handler=relay.capture_from_snc, store=store,
+                    poll_seconds=settings.SNC_POLL_SECONDS,
+                    on_error=lambda e: poll_error_backoff(e, label="S&C", relay=relay),
+                )
+            )
+        )
+    # Delivery worker.
+    tasks.append(
+        asyncio.create_task(
+            delivery_loop(relay=relay, store=store, poll_seconds=settings.BRIDGE_DELIVERY_POLL_SECONDS)
+        )
+    )
+
+    try:
+        yield
+    finally:
+        for t in tasks:
+            t.cancel()
+        for t in tasks:
+            with suppress(asyncio.CancelledError):
+                await t
+        print("🌉 Slack bridge shutting down...")
+
+
+app = FastAPI(title="Slack Cross-Org Bridge", version="0.1.0", lifespan=lifespan)
+
+
+@app.get("/healthz")
+async def healthz():
+    return {"status": "ok" if getattr(app.state, "ready", False) else "starting"}

--- a/roo-standalone/bridge/poller.py
+++ b/roo-standalone/bridge/poller.py
@@ -1,0 +1,146 @@
+"""
+Channel poll loop — shared by both sides.
+
+Neither side uses a webhook: the MLAI side is polled with Roo's bot token, the
+S&C side with Sam's web session. Both poll conversations.history for new
+messages (and conversations.replies for active threads) and hand each message
+to a relay handler. A high-water mark (newest ts seen) is persisted in the kv
+store so restarts neither replay nor miss.
+
+The S&C poll is the deliberate v1 substitute for the web client's WebSocket;
+the clean upgrade is to swap that side's loop for a `client.userBoot` + WS
+listener. The relay handlers don't care where a message comes from.
+
+Behave like a real client: modest interval, cached user lookups, honour rate
+limits — anti-abuse heuristics invalidate the S&C session if it looks like a
+scraper.
+"""
+import asyncio
+import time
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+Handler = Callable[[Dict[str, Any]], Awaitable[None]]
+ErrorBackoff = Callable[[Exception], float]
+
+
+async def channel_poll_loop(
+    *,
+    label: str,
+    client,
+    channel_id: str,
+    hwm_key: str,
+    handler: Handler,
+    store,
+    poll_seconds: float,
+    on_error: Optional[ErrorBackoff] = None,
+) -> None:
+    # On first ever run, start from "now" so we don't replay history.
+    last_ts = store.get_kv(hwm_key)
+    if last_ts is None:
+        last_ts = f"{time.time():.6f}"
+        store.set_kv(hwm_key, last_ts)
+        print(f"{label} ingest starting fresh from {last_ts}")
+    else:
+        print(f"{label} ingest resuming from {last_ts}")
+
+    poll = max(1.0, float(poll_seconds))
+
+    while True:
+        try:
+            last_ts = await _poll_once(label, client, channel_id, hwm_key, handler, store, last_ts)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            sleep_for = on_error(e) if on_error else 10.0
+            await asyncio.sleep(sleep_for)
+            continue
+        await asyncio.sleep(poll)
+
+
+async def _poll_once(label, client, channel_id, hwm_key, handler, store, last_ts: str) -> str:
+    resp = client.conversations_history(channel=channel_id, oldest=last_ts, limit=200)
+    if not resp.get("ok"):
+        print(f"⚠️ {label} history not ok: {resp.get('error')}")
+        return last_ts
+
+    # History returns newest-first; process chronologically.
+    roots: List[Dict[str, Any]] = list(reversed(resp.get("messages", [])))
+    high = float(last_ts)
+
+    for msg in roots:
+        ts = msg.get("ts")
+        if ts and float(ts) > float(last_ts):
+            await handler(msg)
+            high = max(high, float(ts))
+
+        # Thread replies don't appear in history — pull them for active threads.
+        latest_reply = msg.get("latest_reply")
+        if latest_reply and float(latest_reply) > float(last_ts):
+            high = max(high, await _drain_thread(label, client, channel_id, handler, msg, last_ts))
+
+    new_hwm = f"{high:.6f}"
+    if new_hwm != last_ts:
+        store.set_kv(hwm_key, new_hwm)
+    return new_hwm
+
+
+async def _drain_thread(label, client, channel_id, handler, root, last_ts: str) -> float:
+    high = float(last_ts)
+    try:
+        replies = client.conversations_replies(
+            channel=channel_id,
+            ts=root.get("thread_ts") or root.get("ts"),
+            oldest=last_ts,
+            limit=200,
+        )
+        for r in replies.get("messages", []):
+            ts = r.get("ts")
+            # Skip the parent (handled as a root) and anything not new.
+            if not ts or ts == root.get("ts") or float(ts) <= float(last_ts):
+                continue
+            await handler(r)
+            high = max(high, float(ts))
+    except Exception as e:
+        print(f"⚠️ {label} thread drain failed for {root.get('ts')}: {e}")
+    return high
+
+
+async def delivery_loop(*, relay, store, poll_seconds: float) -> None:
+    """Drain the inbound queue, posting each message to the other workspace.
+
+    Capture (the channel pollers) and delivery are decoupled by the DB queue, so
+    a post failure here retries with backoff instead of losing the message.
+    """
+    poll = max(0.5, float(poll_seconds))
+    print(f"🚚 delivery worker started poll_seconds={poll}")
+    while True:
+        try:
+            due = store.claim_due_inbound(limit=20, now=time.time())
+            for row in due:
+                await relay.deliver(row)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            print(f"⚠️ delivery worker error: {e}")
+        await asyncio.sleep(poll)
+
+
+def poll_error_backoff(e: Exception, *, label: str, relay) -> float:
+    """Map a poll exception to a backoff (seconds), alerting on auth failure."""
+    retry = getattr(getattr(e, "response", None), "headers", {}) or {}
+    if "ratelimited" in str(e).lower() or retry.get("Retry-After"):
+        wait = float(retry.get("Retry-After", 5))
+        print(f"⏳ {label} rate limited — backing off {wait}s")
+        return wait
+
+    from .slack import is_auth_error
+
+    if is_auth_error(e):
+        print(f"🚫 {label} auth error ({e}) — token revoked or scopes changed? Reinstall the Bridge app.")
+        asyncio.create_task(
+            relay._alert(f"🚫 Bridge {label} auth error: {e}. Reinstall the Bridge app / refresh the token.")
+        )
+        return 60.0
+
+    print(f"⚠️ {label} poll error: {e}")
+    return 10.0

--- a/roo-standalone/bridge/relay.py
+++ b/roo-standalone/bridge/relay.py
@@ -1,26 +1,29 @@
 """
-Relay — split into capture and delivery for store-and-forward durability.
+Relay — capture + delivery, generalised to many MLAI<->partner channel pairs.
 
-CAPTURE (called by the channel pollers): cheap filtering + enqueue.
-  * capture_from_mlai(msg) / capture_from_snc(msg) — drop non-content subtypes,
-    our own echoes (loop guard), and (optionally) bot messages, then write the
-    raw message to the inbound queue exactly once. Never posts, never blocks on
-    the network — so a delivery problem can't lose a captured message.
+MLAI is the hub. Each pair has a label and two directions:
+  * to_remote — an MLAI message → the partner channel
+  * to_mlai   — a partner message → the MLAI channel
 
-DELIVERY (called by the delivery worker): attribution + post + bookkeeping.
-  * deliver(row) — render the queued message (real name + avatar via
-    chat:write.customize) and post it into the other workspace. On success,
-    record the loop-guard + thread mapping and mark the row delivered. On
-    failure, schedule a retry with backoff; after BRIDGE_MAX_DELIVERY_ATTEMPTS,
-    mark it failed and alert.
+CAPTURE (called by the channel pollers): cheap filtering + enqueue into the
+durable inbound queue. The queue row's `direction` is "<label>:to_remote" or
+"<label>:to_mlai" so delivery knows which pair + way to route it. Capture never
+posts, so a delivery problem can't lose a captured message.
 
-Loop prevention is authoritative via the posted_registry. Edits/deletes are not
-mirrored in poll mode. See SLACK_BRIDGE_PLAN.md.
+DELIVERY (called by the delivery worker): look up the pair, render the message
+(real name + avatar via chat:write.customize), post into the destination, record
+the loop-guard + thread mapping, mark delivered. On failure, retry with backoff;
+give up after BRIDGE_MAX_DELIVERY_ATTEMPTS.
+
+Loop prevention is authoritative via the posted_registry, keyed by (team,
+channel, ts) so it works across all pairs. Edits/deletes are not mirrored in
+poll mode. See SLACK_BRIDGE_PLAN.md.
 """
 import json
 import time
 from collections import deque
-from typing import Any, Dict, Optional
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
 
 import httpx
 
@@ -29,12 +32,18 @@ from .identity import IdentityResolver
 from .slack import is_auth_error
 from .store import BridgeStore
 
-# Subtypes that represent real content. Everything else (joins, leaves,
-# topic/purpose changes, pins, edits, deletes, ...) is dropped.
 _RELAYABLE_SUBTYPES = {None, "", "bot_message", "file_share", "thread_broadcast", "me_message"}
 
-_MLAI_TO_SNC = "mlai_to_snc"
-_SNC_TO_MLAI = "snc_to_mlai"
+
+@dataclass
+class ResolvedPair:
+    """A pair with live clients + resolved channel IDs (built at startup)."""
+
+    label: str
+    remote_client: Any
+    remote_team: str
+    mlai_channel_id: str
+    remote_channel_id: str
 
 
 class Relay:
@@ -45,14 +54,13 @@ class Relay:
         store: BridgeStore,
         identity: IdentityResolver,
         mlai_client,
-        snc_client,
+        pairs: List[ResolvedPair],
     ):
         self.s = settings
         self.store = store
         self.identity = identity
         self.mlai = mlai_client
-        self.snc = snc_client
-        # Circuit breaker: timestamps of recent bridge posts.
+        self.pairs: Dict[str, ResolvedPair] = {p.label: p for p in pairs}
         self._recent_posts: deque[float] = deque(maxlen=512)
         self._paused = False
         self._last_alert_at = 0.0
@@ -61,17 +69,17 @@ class Relay:
     # capture (pollers → queue)
     # ========================================================================
 
-    async def capture_from_mlai(self, msg: Dict[str, Any]) -> None:
-        # Don't capture toward S&C if that side isn't configured (nothing could
-        # ever deliver it).
-        if not self.snc:
+    async def capture(self, label: str, to_mlai: bool, msg: Dict[str, Any]) -> None:
+        pair = self.pairs.get(label)
+        if not pair:
             return
-        self._capture(_MLAI_TO_SNC, self.s.MLAI_TEAM_ID or "", self.s.MLAI_CHANNEL_ID, msg)
+        if to_mlai:
+            src_team, src_channel = pair.remote_team, pair.remote_channel_id
+            direction = f"{label}:to_mlai"
+        else:
+            src_team, src_channel = self.s.MLAI_TEAM_ID or "", pair.mlai_channel_id
+            direction = f"{label}:to_remote"
 
-    async def capture_from_snc(self, msg: Dict[str, Any]) -> None:
-        self._capture(_SNC_TO_MLAI, self.s.SNC_TEAM_ID or "", self.s.SNC_CHANNEL_ID, msg)
-
-    def _capture(self, direction: str, src_team: str, src_channel: str, msg: Dict[str, Any]) -> None:
         ts = msg.get("ts")
         if not ts or msg.get("subtype") not in _RELAYABLE_SUBTYPES:
             return
@@ -84,7 +92,7 @@ class Relay:
             print(f"📥 captured {direction} {ts}")
 
     # ========================================================================
-    # delivery (worker → other workspace)
+    # delivery (worker → destination workspace)
     # ========================================================================
 
     async def deliver(self, row: Dict[str, Any]) -> None:
@@ -94,18 +102,20 @@ class Relay:
             self.store.mark_failed(row["id"], f"bad payload: {e}")
             return
 
-        if row["direction"] == _MLAI_TO_SNC:
-            src_client, src_team, src_channel = self.mlai, self.s.MLAI_TEAM_ID or "", self.s.MLAI_CHANNEL_ID
-            dst_client, dst_team, dst_channel = self.snc, self.s.SNC_TEAM_ID or "", self.s.SNC_CHANNEL_ID
-            arrow = "➡️  MLAI→S&C"
-        else:
-            src_client, src_team, src_channel = self.snc, self.s.SNC_TEAM_ID or "", self.s.SNC_CHANNEL_ID
-            dst_client, dst_team, dst_channel = self.mlai, self.s.MLAI_TEAM_ID or "", self.s.MLAI_CHANNEL_ID
-            arrow = "⬅️  S&C→MLAI"
-
-        if dst_client is None:
-            self._fail_or_retry(row, Exception("destination not configured"))
+        label, _, way = row["direction"].partition(":")
+        pair = self.pairs.get(label)
+        if not pair:
+            self.store.mark_failed(row["id"], f"unknown pair {label!r}")
             return
+
+        if way == "to_mlai":
+            src_client, src_team, src_channel = pair.remote_client, pair.remote_team, pair.remote_channel_id
+            dst_client, dst_team, dst_channel = self.mlai, self.s.MLAI_TEAM_ID or "", pair.mlai_channel_id
+            arrow = f"⬅️  {label}→MLAI"
+        else:
+            src_client, src_team, src_channel = self.mlai, self.s.MLAI_TEAM_ID or "", pair.mlai_channel_id
+            dst_client, dst_team, dst_channel = pair.remote_client, pair.remote_team, pair.remote_channel_id
+            arrow = f"➡️  MLAI→{label}"
 
         # Circuit breaker — leave the row pending and try again shortly.
         if not self._allow_post():
@@ -197,7 +207,7 @@ class Relay:
         return dst[2] if dst else None
 
     def _allow_post(self) -> bool:
-        """Circuit breaker: never let a loop bug flood both channels."""
+        """Circuit breaker: never let a loop bug flood the channels."""
         now = time.time()
         while self._recent_posts and now - self._recent_posts[0] > 60:
             self._recent_posts.popleft()

--- a/roo-standalone/bridge/relay.py
+++ b/roo-standalone/bridge/relay.py
@@ -1,0 +1,265 @@
+"""
+Relay — split into capture and delivery for store-and-forward durability.
+
+CAPTURE (called by the channel pollers): cheap filtering + enqueue.
+  * capture_from_mlai(msg) / capture_from_snc(msg) — drop non-content subtypes,
+    our own echoes (loop guard), and (optionally) bot messages, then write the
+    raw message to the inbound queue exactly once. Never posts, never blocks on
+    the network — so a delivery problem can't lose a captured message.
+
+DELIVERY (called by the delivery worker): attribution + post + bookkeeping.
+  * deliver(row) — render the queued message (real name + avatar via
+    chat:write.customize) and post it into the other workspace. On success,
+    record the loop-guard + thread mapping and mark the row delivered. On
+    failure, schedule a retry with backoff; after BRIDGE_MAX_DELIVERY_ATTEMPTS,
+    mark it failed and alert.
+
+Loop prevention is authoritative via the posted_registry. Edits/deletes are not
+mirrored in poll mode. See SLACK_BRIDGE_PLAN.md.
+"""
+import json
+import time
+from collections import deque
+from typing import Any, Dict, Optional
+
+import httpx
+
+from .config import BridgeSettings
+from .identity import IdentityResolver
+from .slack import is_auth_error
+from .store import BridgeStore
+
+# Subtypes that represent real content. Everything else (joins, leaves,
+# topic/purpose changes, pins, edits, deletes, ...) is dropped.
+_RELAYABLE_SUBTYPES = {None, "", "bot_message", "file_share", "thread_broadcast", "me_message"}
+
+_MLAI_TO_SNC = "mlai_to_snc"
+_SNC_TO_MLAI = "snc_to_mlai"
+
+
+class Relay:
+    def __init__(
+        self,
+        *,
+        settings: BridgeSettings,
+        store: BridgeStore,
+        identity: IdentityResolver,
+        mlai_client,
+        snc_client,
+    ):
+        self.s = settings
+        self.store = store
+        self.identity = identity
+        self.mlai = mlai_client
+        self.snc = snc_client
+        # Circuit breaker: timestamps of recent bridge posts.
+        self._recent_posts: deque[float] = deque(maxlen=512)
+        self._paused = False
+        self._last_alert_at = 0.0
+
+    # ========================================================================
+    # capture (pollers → queue)
+    # ========================================================================
+
+    async def capture_from_mlai(self, msg: Dict[str, Any]) -> None:
+        # Don't capture toward S&C if that side isn't configured (nothing could
+        # ever deliver it).
+        if not self.snc:
+            return
+        self._capture(_MLAI_TO_SNC, self.s.MLAI_TEAM_ID or "", self.s.MLAI_CHANNEL_ID, msg)
+
+    async def capture_from_snc(self, msg: Dict[str, Any]) -> None:
+        self._capture(_SNC_TO_MLAI, self.s.SNC_TEAM_ID or "", self.s.SNC_CHANNEL_ID, msg)
+
+    def _capture(self, direction: str, src_team: str, src_channel: str, msg: Dict[str, Any]) -> None:
+        ts = msg.get("ts")
+        if not ts or msg.get("subtype") not in _RELAYABLE_SUBTYPES:
+            return
+        # Our own echo (we posted this) — never re-bridge.
+        if self.store.is_self_posted(src_team, src_channel, ts):
+            return
+        if msg.get("bot_id") and not self.s.BRIDGE_RELAY_BOT_MESSAGES:
+            return
+        if self.store.enqueue_inbound(direction, src_team, src_channel, ts, json.dumps(msg)):
+            print(f"📥 captured {direction} {ts}")
+
+    # ========================================================================
+    # delivery (worker → other workspace)
+    # ========================================================================
+
+    async def deliver(self, row: Dict[str, Any]) -> None:
+        try:
+            msg = json.loads(row["payload_json"])
+        except (json.JSONDecodeError, TypeError) as e:
+            self.store.mark_failed(row["id"], f"bad payload: {e}")
+            return
+
+        if row["direction"] == _MLAI_TO_SNC:
+            src_client, src_team, src_channel = self.mlai, self.s.MLAI_TEAM_ID or "", self.s.MLAI_CHANNEL_ID
+            dst_client, dst_team, dst_channel = self.snc, self.s.SNC_TEAM_ID or "", self.s.SNC_CHANNEL_ID
+            arrow = "➡️  MLAI→S&C"
+        else:
+            src_client, src_team, src_channel = self.snc, self.s.SNC_TEAM_ID or "", self.s.SNC_CHANNEL_ID
+            dst_client, dst_team, dst_channel = self.mlai, self.s.MLAI_TEAM_ID or "", self.s.MLAI_CHANNEL_ID
+            arrow = "⬅️  S&C→MLAI"
+
+        if dst_client is None:
+            self._fail_or_retry(row, Exception("destination not configured"))
+            return
+
+        # Circuit breaker — leave the row pending and try again shortly.
+        if not self._allow_post():
+            self.store.mark_retry(row["id"], "circuit breaker", time.time() + 5, row["attempt_count"])
+            return
+
+        try:
+            dst_ts = self._post(src_client, src_team, src_channel, dst_client, dst_channel, msg)
+        except Exception as e:
+            print(f"❌ post {arrow} error: {e}")
+            self._fail_or_retry(row, e)
+            return
+
+        if not dst_ts:
+            self._fail_or_retry(row, Exception("post returned not ok"))
+            return
+
+        self.store.record_posted(dst_team, dst_channel, dst_ts)
+        self.store.map_message(src_team, src_channel, msg["ts"], dst_team, dst_channel, dst_ts)
+        self.store.mark_delivered(row["id"])
+        print(f"{arrow} delivered {msg['ts']} → {dst_ts}")
+
+        if self.s.BRIDGE_RELAY_FILES and msg.get("files"):
+            dst_thread_ts = self._dst_thread_ts(src_team, src_channel, msg)
+            self._relay_files(
+                src_client=src_client, files=msg["files"],
+                dst_client=dst_client, dst_channel=dst_channel,
+                dst_thread_ts=dst_thread_ts or dst_ts,
+            )
+
+    def _post(self, src_client, src_team, src_channel, dst_client, dst_channel, msg) -> Optional[str]:
+        """Render + post one message. Returns the destination ts, or None."""
+        if msg.get("bot_id"):
+            name = self._bot_name(msg)
+            avatar = (msg.get("icons", {}) or {}).get("image_72", "")
+        else:
+            author_id = msg.get("user", "")
+            name = self.identity.display_name(src_client, author_id, src_team)
+            avatar = self.identity.avatar(src_client, author_id, src_team)
+
+        body = self.identity.translate(src_client, msg.get("text", ""), src_team)
+        dst_thread_ts = self._dst_thread_ts(src_team, src_channel, msg)
+
+        kwargs: Dict[str, Any] = {
+            "channel": dst_channel,
+            "text": body or " ",
+            "username": name,
+            "thread_ts": dst_thread_ts,
+            "unfurl_links": False,
+            "unfurl_media": False,
+        }
+        if avatar:
+            kwargs["icon_url"] = avatar
+
+        resp = dst_client.chat_postMessage(**kwargs)
+        if not resp.get("ok"):
+            print(f"❌ chat.postMessage not ok: {resp.get('error')}")
+            return None
+        return resp["ts"]
+
+    def _fail_or_retry(self, row: Dict[str, Any], e: Exception) -> None:
+        attempt = (row["attempt_count"] or 0) + 1
+        if attempt >= self.s.BRIDGE_MAX_DELIVERY_ATTEMPTS:
+            self.store.mark_failed(row["id"], str(e))
+            print(f"❌ delivery permanently failed id={row['id']} after {attempt} tries: {e}")
+            import asyncio
+            asyncio.create_task(self._alert(f"❌ Bridge gave up on a message after {attempt} tries: {e}"))
+        else:
+            backoff = min(60.0, float(2 ** attempt))
+            self.store.mark_retry(row["id"], str(e), time.time() + backoff, attempt)
+            print(f"⏳ delivery retry id={row['id']} attempt={attempt} in {backoff:.0f}s: {e}")
+        if is_auth_error(e):
+            import asyncio
+            asyncio.create_task(self._alert(f"⚠️ Bridge delivery auth error: {e}"))
+
+    # ========================================================================
+    # helpers
+    # ========================================================================
+
+    @staticmethod
+    def _bot_name(msg: Dict[str, Any]) -> str:
+        return msg.get("username") or (msg.get("bot_profile", {}) or {}).get("name") or "bot"
+
+    def _dst_thread_ts(self, src_team: str, src_channel: str, msg: Dict[str, Any]) -> Optional[str]:
+        thread_ts = msg.get("thread_ts")
+        if not thread_ts or thread_ts == msg.get("ts"):
+            return None
+        dst = self.store.dst_for(src_team, src_channel, thread_ts)
+        return dst[2] if dst else None
+
+    def _allow_post(self) -> bool:
+        """Circuit breaker: never let a loop bug flood both channels."""
+        now = time.time()
+        while self._recent_posts and now - self._recent_posts[0] > 60:
+            self._recent_posts.popleft()
+        if len(self._recent_posts) >= self.s.BRIDGE_MAX_POSTS_PER_MIN:
+            if not self._paused:
+                self._paused = True
+                print("🛑 Bridge circuit breaker tripped — pausing posts")
+                import asyncio
+                asyncio.create_task(
+                    self._alert(
+                        "🛑 Bridge circuit breaker tripped (>%d posts/min) — paused. "
+                        "Messages stay queued; check for a loop and restart." % self.s.BRIDGE_MAX_POSTS_PER_MIN
+                    )
+                )
+            return False
+        self._paused = False
+        self._recent_posts.append(now)
+        return True
+
+    def _relay_files(self, *, src_client, files, dst_client, dst_channel, dst_thread_ts) -> None:
+        """Best-effort cross-workspace file copy: file URLs are not portable
+        between workspaces, so download with the source creds and re-upload."""
+        for f in files:
+            try:
+                url = f.get("url_private_download") or f.get("url_private")
+                if not url:
+                    continue
+                data = self._download(src_client, url)
+                dst_client.files_upload_v2(
+                    channel=dst_channel,
+                    file=data,
+                    filename=f.get("name") or "file",
+                    title=f.get("title") or f.get("name"),
+                    thread_ts=dst_thread_ts,
+                )
+                print(f"📎 relayed file {f.get('name')}")
+            except Exception as e:
+                print(f"⚠️ file relay failed for {f.get('name')}: {e}")
+
+    @staticmethod
+    def _download(client, url: str) -> bytes:
+        resp = httpx.get(
+            url,
+            headers={"Authorization": f"Bearer {client.token}"},
+            timeout=30.0,
+            follow_redirects=False,
+        )
+        resp.raise_for_status()
+        return resp.content
+
+    async def _alert(self, text: str) -> None:
+        """DM Sam (MLAI side) about problems, throttled to avoid spam."""
+        user = self.s.BRIDGE_ALERT_DM_USER_ID
+        if not user:
+            return
+        now = time.time()
+        if now - self._last_alert_at < 300:
+            return
+        self._last_alert_at = now
+        try:
+            opened = self.mlai.conversations_open(users=user)
+            if opened.get("ok"):
+                self.mlai.chat_postMessage(channel=opened["channel"]["id"], text=text)
+        except Exception as e:
+            print(f"⚠️ alert DM failed: {e}")

--- a/roo-standalone/bridge/slack.py
+++ b/roo-standalone/bridge/slack.py
@@ -1,10 +1,14 @@
 """
 Slack client helpers.
 
-The bridge is a dedicated app installed in both workspaces, so each side is a
-plain bot token — one WebClient factory covers both.
+The bridge is a dedicated app installed in each workspace, so every side is a
+plain bot token — one WebClient factory covers them all. Plus a channel-name
+resolver so pairs can be configured by name instead of opaque IDs.
 """
-from typing import Any, Dict
+import re
+from typing import Any, Dict, Optional
+
+_ID_RE = re.compile(r"^[CGD][A-Z0-9]{6,}$")
 
 
 def make_bot_client(token: str):
@@ -25,6 +29,35 @@ def resolve_identity(client) -> Dict[str, Any]:
         "team": resp.get("team"),
         "url": resp.get("url"),
     }
+
+
+def resolve_channel_id(client, value: str) -> Optional[str]:
+    """Return a channel ID for `value`, which may already be an ID or a name.
+
+    Names are matched against conversations.list (falling back to public-only if
+    the token lacks the private-channel scope). Returns None if not found — e.g.
+    the channel doesn't exist yet or the bot can't see it.
+    """
+    v = (value or "").strip()
+    if _ID_RE.match(v):
+        return v
+    name = v.lstrip("#")
+    for types in ("public_channel,private_channel", "public_channel"):
+        try:
+            cursor = None
+            while True:
+                r = client.conversations_list(types=types, limit=1000, cursor=cursor)
+                for ch in r.get("channels", []):
+                    if ch.get("name") == name:
+                        return ch["id"]
+                cursor = (r.get("response_metadata") or {}).get("next_cursor")
+                if not cursor:
+                    return None
+        except Exception as e:
+            if "missing_scope" in str(e):
+                continue  # no groups:read → retry public channels only
+            raise
+    return None
 
 
 def is_auth_error(exc: Exception) -> bool:

--- a/roo-standalone/bridge/slack.py
+++ b/roo-standalone/bridge/slack.py
@@ -1,0 +1,44 @@
+"""
+Slack client helpers.
+
+The bridge is a dedicated app installed in both workspaces, so each side is a
+plain bot token — one WebClient factory covers both.
+"""
+from typing import Any, Dict
+
+
+def make_bot_client(token: str):
+    """WebClient for a bot token (one per workspace install of the Bridge app)."""
+    from slack_sdk import WebClient
+
+    client = WebClient(token=token)
+    print("🔌 Bridge bot client initialized")
+    return client
+
+
+def resolve_identity(client) -> Dict[str, Any]:
+    """auth.test → {team_id, user_id, ...}. Confirms a client actually works."""
+    resp = client.auth_test()
+    return {
+        "user_id": resp.get("user_id"),
+        "team_id": resp.get("team_id"),
+        "team": resp.get("team"),
+        "url": resp.get("url"),
+    }
+
+
+def is_auth_error(exc: Exception) -> bool:
+    """True if a Slack error looks like an auth failure worth alerting on."""
+    text = str(exc).lower()
+    return any(
+        marker in text
+        for marker in (
+            "invalid_auth",
+            "not_authed",
+            "token_revoked",
+            "account_inactive",
+            "token_expired",
+            "no_permission",
+            "missing_scope",
+        )
+    )

--- a/roo-standalone/bridge/store.py
+++ b/roo-standalone/bridge/store.py
@@ -1,0 +1,251 @@
+"""
+Bridge persistence (SQLite).
+
+Follows roo/coworking_booking_intents.py conventions: stdlib sqlite3, WAL,
+autocommit (isolation_level=None), a threading lock, lazily-created schema.
+
+Store-and-forward design — capture and delivery are decoupled:
+
+  * inbound          — the durable queue. Capture writes every relayable message
+                       here exactly once (UNIQUE on the source coordinates); a
+                       delivery worker drains it, posting to the other workspace
+                       with retries/backoff. A failed post is retried, never lost.
+  * posted_registry  — every (team, channel, ts) the bridge itself posted. The
+                       authoritative loop guard: a captured message found here is
+                       one of our own echoes and is skipped.
+  * message_map      — source message → the copy we posted, so threaded replies
+                       can be re-threaded on the other side.
+  * kv               — small values, e.g. each channel's poll high-water mark.
+"""
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class BridgeStore:
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self._lock = threading.RLock()
+        self._initialized = False
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.db_path), timeout=30, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=30000")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        with self._lock:
+            if self._initialized:
+                return
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS inbound (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        direction TEXT NOT NULL,           -- mlai_to_snc | snc_to_mlai
+                        src_team TEXT NOT NULL,
+                        src_channel TEXT NOT NULL,
+                        src_ts TEXT NOT NULL,
+                        payload_json TEXT NOT NULL,        -- raw Slack message object
+                        status TEXT NOT NULL DEFAULT 'pending',  -- pending|delivered|failed
+                        attempt_count INTEGER NOT NULL DEFAULT 0,
+                        next_attempt_at REAL NOT NULL DEFAULT 0,
+                        last_error TEXT,
+                        created_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        UNIQUE (src_team, src_channel, src_ts)
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_inbound_due
+                    ON inbound (status, next_attempt_at)
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS posted_registry (
+                        team TEXT NOT NULL,
+                        channel TEXT NOT NULL,
+                        ts TEXT NOT NULL,
+                        posted_at REAL NOT NULL,
+                        PRIMARY KEY (team, channel, ts)
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS message_map (
+                        src_team TEXT NOT NULL,
+                        src_channel TEXT NOT NULL,
+                        src_ts TEXT NOT NULL,
+                        dst_team TEXT NOT NULL,
+                        dst_channel TEXT NOT NULL,
+                        dst_ts TEXT NOT NULL,
+                        created_at REAL NOT NULL,
+                        PRIMARY KEY (src_team, src_channel, src_ts)
+                    )
+                    """
+                )
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS kv (
+                        key TEXT PRIMARY KEY,
+                        value TEXT,
+                        updated_at REAL NOT NULL
+                    )
+                    """
+                )
+            self._initialized = True
+
+    # --- inbound queue -------------------------------------------------------
+
+    def enqueue_inbound(
+        self, direction: str, src_team: str, src_channel: str, src_ts: str, payload_json: str
+    ) -> bool:
+        """Capture a message into the queue. Returns True if newly enqueued,
+        False if it was already captured (idempotent on the source coordinates)."""
+        self._ensure_schema()
+        now = time.time()
+        with self._lock, self._connect() as conn:
+            try:
+                conn.execute(
+                    "INSERT INTO inbound "
+                    "(direction, src_team, src_channel, src_ts, payload_json, status, "
+                    " attempt_count, next_attempt_at, created_at, updated_at) "
+                    "VALUES (?, ?, ?, ?, ?, 'pending', 0, 0, ?, ?)",
+                    (direction, src_team, src_channel, src_ts, payload_json, now, now),
+                )
+                return True
+            except sqlite3.IntegrityError:
+                return False
+
+    def claim_due_inbound(self, limit: int, now: float) -> List[Dict[str, Any]]:
+        """Pending rows whose next_attempt_at has passed, oldest first (FIFO)."""
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM inbound WHERE status='pending' AND next_attempt_at<=? "
+                "ORDER BY id LIMIT ?",
+                (now, limit),
+            ).fetchall()
+            return [dict(r) for r in rows]
+
+    def mark_delivered(self, row_id: int) -> None:
+        self._update_inbound(row_id, status="delivered")
+
+    def mark_retry(self, row_id: int, error: str, next_attempt_at: float, attempt_count: int) -> None:
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                "UPDATE inbound SET attempt_count=?, next_attempt_at=?, last_error=?, updated_at=? "
+                "WHERE id=?",
+                (attempt_count, next_attempt_at, error, time.time(), row_id),
+            )
+
+    def mark_failed(self, row_id: int, error: str) -> None:
+        self._update_inbound(row_id, status="failed", error=error)
+
+    def _update_inbound(self, row_id: int, *, status: str, error: Optional[str] = None) -> None:
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                "UPDATE inbound SET status=?, last_error=?, updated_at=? WHERE id=?",
+                (status, error, time.time(), row_id),
+            )
+
+    # --- loop guard ----------------------------------------------------------
+
+    def record_posted(self, team: str, channel: str, ts: str) -> None:
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO posted_registry (team, channel, ts, posted_at) "
+                "VALUES (?, ?, ?, ?)",
+                (team, channel, ts, time.time()),
+            )
+
+    def is_self_posted(self, team: str, channel: str, ts: str) -> bool:
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            row = conn.execute(
+                "SELECT 1 FROM posted_registry WHERE team=? AND channel=? AND ts=?",
+                (team, channel, ts),
+            ).fetchone()
+            return row is not None
+
+    # --- message correlation -------------------------------------------------
+
+    def map_message(
+        self, src_team, src_channel, src_ts, dst_team, dst_channel, dst_ts
+    ) -> None:
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO message_map "
+                "(src_team, src_channel, src_ts, dst_team, dst_channel, dst_ts, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (src_team, src_channel, src_ts, dst_team, dst_channel, dst_ts, time.time()),
+            )
+
+    def dst_for(self, src_team, src_channel, src_ts) -> Optional[Tuple[str, str, str]]:
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            row = conn.execute(
+                "SELECT dst_team, dst_channel, dst_ts FROM message_map "
+                "WHERE src_team=? AND src_channel=? AND src_ts=?",
+                (src_team, src_channel, src_ts),
+            ).fetchone()
+            return (row["dst_team"], row["dst_channel"], row["dst_ts"]) if row else None
+
+    # --- kv ------------------------------------------------------------------
+
+    def get_kv(self, key: str) -> Optional[str]:
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            row = conn.execute("SELECT value FROM kv WHERE key=?", (key,)).fetchone()
+            return row["value"] if row else None
+
+    def set_kv(self, key: str, value: str) -> None:
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            conn.execute(
+                "INSERT OR REPLACE INTO kv (key, value, updated_at) VALUES (?, ?, ?)",
+                (key, value, time.time()),
+            )
+
+    # --- maintenance ---------------------------------------------------------
+
+    def prune(self, max_age_seconds: float) -> int:
+        """Delete old delivered/failed queue rows + registry rows. Returns rows removed."""
+        self._ensure_schema()
+        cutoff = time.time() - max_age_seconds
+        removed = 0
+        with self._lock, self._connect() as conn:
+            for sql in (
+                "DELETE FROM inbound WHERE status IN ('delivered','failed') AND updated_at < ?",
+                "DELETE FROM posted_registry WHERE posted_at < ?",
+            ):
+                cur = conn.execute(sql, (cutoff,))
+                removed += cur.rowcount or 0
+        return removed
+
+
+_store: Optional[BridgeStore] = None
+
+
+def get_store(db_path: Optional[str] = None) -> BridgeStore:
+    global _store
+    if _store is None:
+        from .config import get_bridge_settings
+
+        _store = BridgeStore(db_path or get_bridge_settings().BRIDGE_DB_PATH)
+    return _store

--- a/roo-standalone/bridge/tests/test_relay.py
+++ b/roo-standalone/bridge/tests/test_relay.py
@@ -6,7 +6,7 @@ import time
 
 from bridge.config import BridgeSettings
 from bridge.identity import IdentityResolver
-from bridge.relay import Relay
+from bridge.relay import Relay, ResolvedPair
 from bridge.store import BridgeStore
 
 
@@ -40,18 +40,19 @@ def _store():
     return BridgeStore(os.path.join(d, "b.db"))
 
 
-def _relay(store, snc_fail=False):
-    settings = BridgeSettings(
-        MLAI_BOT_TOKEN="xoxb-x", MLAI_CHANNEL_ID="C_M", SNC_CHANNEL_ID="C_S",
-        MLAI_TEAM_ID="T_M", SNC_TEAM_ID="T_S",
-    )
+def _relay(store, remote_fail=False):
+    settings = BridgeSettings(MLAI_BOT_TOKEN="xoxb-x", MLAI_TEAM_ID="T_M")
     mlai = FakeClient()
-    snc = FakeClient(fail=snc_fail)
+    remote = FakeClient(fail=remote_fail)
+    pair = ResolvedPair(
+        label="hex", remote_client=remote, remote_team="T_R",
+        mlai_channel_id="C_M", remote_channel_id="C_R",
+    )
     relay = Relay(
         settings=settings, store=store, identity=IdentityResolver(),
-        mlai_client=mlai, snc_client=snc,
+        mlai_client=mlai, pairs=[pair],
     )
-    return relay, mlai, snc, settings
+    return relay, mlai, remote, settings
 
 
 # --- markup translation ---------------------------------------------------
@@ -61,12 +62,6 @@ def test_translate_labeled_mention_and_channel_and_special():
     out = r.translate(FakeClient(), "hey <@U123|alice> in <#C1|general> <!here>", team="T")
     assert "@alice" in out and "#general" in out and "@here" in out
     assert "<@" not in out and "<#" not in out and "<!" not in out
-
-
-def test_translate_unlabeled_mention_uses_lookup():
-    r = IdentityResolver()
-    out = r.translate(FakeClient({"U999": "bob"}), "yo <@U999>", team="T")
-    assert "@bob" in out
 
 
 def test_translate_links_and_unescape():
@@ -92,67 +87,77 @@ def test_message_map_roundtrip():
     assert s.dst_for("TA", "CA", "missing") is None
 
 
-def test_kv_roundtrip():
-    s = _store()
-    assert s.get_kv("hwm") is None
-    s.set_kv("hwm", "123.45")
-    assert s.get_kv("hwm") == "123.45"
-
-
 # --- capture (poller → queue) ---------------------------------------------
 
-def test_capture_enqueues_and_dedups():
+def test_capture_to_remote_enqueues_with_pair_direction():
     s = _store()
-    relay, mlai, snc, settings = _relay(s)
-    asyncio.run(relay.capture_from_mlai({"ts": "111.1", "user": "U_ALICE", "text": "hello"}))
+    relay, mlai, remote, settings = _relay(s)
+    asyncio.run(relay.capture("hex", False, {"ts": "111.1", "user": "U_ALICE", "text": "hi"}))
     due = s.claim_due_inbound(10, time.time())
-    assert len(due) == 1 and due[0]["direction"] == "mlai_to_snc"
-    # Idempotent: the same source ts is never enqueued twice.
-    asyncio.run(relay.capture_from_mlai({"ts": "111.1", "user": "U_ALICE", "text": "hello"}))
+    assert len(due) == 1 and due[0]["direction"] == "hex:to_remote"
+    # Idempotent on the source coordinates.
+    asyncio.run(relay.capture("hex", False, {"ts": "111.1", "user": "U_ALICE", "text": "hi"}))
     assert len(s.claim_due_inbound(10, time.time())) == 1
+
+
+def test_capture_to_mlai_uses_remote_team_and_channel():
+    s = _store()
+    relay, mlai, remote, settings = _relay(s)
+    asyncio.run(relay.capture("hex", True, {"ts": "222.2", "user": "U_BOB", "text": "yo"}))
+    due = s.claim_due_inbound(10, time.time())
+    assert len(due) == 1 and due[0]["direction"] == "hex:to_mlai"
+    assert due[0]["src_team"] == "T_R" and due[0]["src_channel"] == "C_R"
 
 
 def test_capture_skips_self_posted_echo():
     s = _store()
-    relay, mlai, snc, settings = _relay(s)
-    s.record_posted("T_M", "C_M", "222.2")  # a message the bridge itself posted
-    asyncio.run(relay.capture_from_mlai({"ts": "222.2", "user": "U_X", "text": "echo"}))
+    relay, mlai, remote, settings = _relay(s)
+    s.record_posted("T_M", "C_M", "333.3")  # a message the bridge itself posted
+    asyncio.run(relay.capture("hex", False, {"ts": "333.3", "user": "U_X", "text": "echo"}))
     assert s.claim_due_inbound(10, time.time()) == []
 
 
 def test_capture_skips_non_content_subtype():
     s = _store()
-    relay, mlai, snc, settings = _relay(s)
-    asyncio.run(relay.capture_from_mlai({"ts": "333.3", "subtype": "channel_join", "user": "U_X"}))
+    relay, mlai, remote, settings = _relay(s)
+    asyncio.run(relay.capture("hex", False, {"ts": "444.4", "subtype": "channel_join", "user": "U"}))
     assert s.claim_due_inbound(10, time.time()) == []
 
 
-# --- delivery (worker → other workspace) ----------------------------------
+# --- delivery (worker → destination) --------------------------------------
 
-def test_deliver_posts_records_and_maps():
+def test_deliver_to_remote_posts_records_and_maps():
     s = _store()
-    relay, mlai, snc, settings = _relay(s)
-    asyncio.run(relay.capture_from_mlai({"ts": "111.1", "user": "U_ALICE", "text": "hello"}))
+    relay, mlai, remote, settings = _relay(s)
+    asyncio.run(relay.capture("hex", False, {"ts": "111.1", "user": "U_ALICE", "text": "hello"}))
     row = s.claim_due_inbound(10, time.time())[0]
     asyncio.run(relay.deliver(row))
-    # Posted into S&C with the author spoofed via chat:write.customize.
-    assert len(snc.posted) == 1
-    assert snc.posted[0]["text"] == "hello"
-    assert snc.posted[0]["username"] == "U_ALICE"
-    assert snc.posted[0]["channel"] == "C_S"
-    # Mapped + registered (loop guard) + no longer pending.
+    # Posted into the partner channel, author spoofed via chat:write.customize.
+    assert len(remote.posted) == 1
+    assert remote.posted[0]["text"] == "hello"
+    assert remote.posted[0]["username"] == "U_ALICE"
+    assert remote.posted[0]["channel"] == "C_R"
     dst = s.dst_for("T_M", "C_M", "111.1")
-    assert dst is not None and s.is_self_posted("T_S", "C_S", dst[2])
+    assert dst is not None and s.is_self_posted("T_R", "C_R", dst[2])
     assert s.claim_due_inbound(10, time.time()) == []
+
+
+def test_deliver_to_mlai_routes_to_hub():
+    s = _store()
+    relay, mlai, remote, settings = _relay(s)
+    asyncio.run(relay.capture("hex", True, {"ts": "222.2", "user": "U_BOB", "text": "inbound"}))
+    row = s.claim_due_inbound(10, time.time())[0]
+    asyncio.run(relay.deliver(row))
+    assert len(mlai.posted) == 1 and mlai.posted[0]["channel"] == "C_M"
 
 
 def test_deliver_retries_on_failure_instead_of_dropping():
     s = _store()
-    relay, mlai, snc, settings = _relay(s, snc_fail=True)
-    asyncio.run(relay.capture_from_mlai({"ts": "111.1", "user": "U_ALICE", "text": "hello"}))
+    relay, mlai, remote, settings = _relay(s, remote_fail=True)
+    asyncio.run(relay.capture("hex", False, {"ts": "111.1", "user": "U_ALICE", "text": "hello"}))
     row = s.claim_due_inbound(10, time.time())[0]
     asyncio.run(relay.deliver(row))
-    assert snc.posted == []
+    assert remote.posted == []
     # Not lost: backed off into the future, attempt_count incremented.
     assert s.claim_due_inbound(10, time.time()) == []
     later = s.claim_due_inbound(10, time.time() + 120)

--- a/roo-standalone/bridge/tests/test_relay.py
+++ b/roo-standalone/bridge/tests/test_relay.py
@@ -1,0 +1,159 @@
+"""Pure-logic tests for the bridge — no network, no Slack."""
+import asyncio
+import os
+import tempfile
+import time
+
+from bridge.config import BridgeSettings
+from bridge.identity import IdentityResolver
+from bridge.relay import Relay
+from bridge.store import BridgeStore
+
+
+class FakeClient:
+    """Minimal stand-in for a slack_sdk WebClient."""
+
+    def __init__(self, names=None, fail=False):
+        self._names = names or {}
+        self.posted = []
+        self._ts = 1000.0
+        self.fail = fail
+
+    def users_info(self, user):
+        if user in self._names:
+            return {
+                "ok": True,
+                "user": {"name": self._names[user], "profile": {"display_name": self._names[user]}},
+            }
+        return {"ok": False}
+
+    def chat_postMessage(self, **kwargs):
+        if self.fail:
+            raise RuntimeError("boom")
+        self._ts += 1
+        self.posted.append(kwargs)
+        return {"ok": True, "ts": f"{self._ts:.6f}"}
+
+
+def _store():
+    d = tempfile.mkdtemp()
+    return BridgeStore(os.path.join(d, "b.db"))
+
+
+def _relay(store, snc_fail=False):
+    settings = BridgeSettings(
+        MLAI_BOT_TOKEN="xoxb-x", MLAI_CHANNEL_ID="C_M", SNC_CHANNEL_ID="C_S",
+        MLAI_TEAM_ID="T_M", SNC_TEAM_ID="T_S",
+    )
+    mlai = FakeClient()
+    snc = FakeClient(fail=snc_fail)
+    relay = Relay(
+        settings=settings, store=store, identity=IdentityResolver(),
+        mlai_client=mlai, snc_client=snc,
+    )
+    return relay, mlai, snc, settings
+
+
+# --- markup translation ---------------------------------------------------
+
+def test_translate_labeled_mention_and_channel_and_special():
+    r = IdentityResolver()
+    out = r.translate(FakeClient(), "hey <@U123|alice> in <#C1|general> <!here>", team="T")
+    assert "@alice" in out and "#general" in out and "@here" in out
+    assert "<@" not in out and "<#" not in out and "<!" not in out
+
+
+def test_translate_unlabeled_mention_uses_lookup():
+    r = IdentityResolver()
+    out = r.translate(FakeClient({"U999": "bob"}), "yo <@U999>", team="T")
+    assert "@bob" in out
+
+
+def test_translate_links_and_unescape():
+    r = IdentityResolver()
+    out = r.translate(FakeClient(), "see <https://x.com|the site> &amp; go", team="T")
+    assert "the site (https://x.com)" in out
+    assert "&" in out and "&amp;" not in out
+
+
+# --- store basics ---------------------------------------------------------
+
+def test_loop_guard_registry():
+    s = _store()
+    assert not s.is_self_posted("T", "C", "1.1")
+    s.record_posted("T", "C", "1.1")
+    assert s.is_self_posted("T", "C", "1.1")
+
+
+def test_message_map_roundtrip():
+    s = _store()
+    s.map_message("TA", "CA", "10.0", "TB", "CB", "20.0")
+    assert s.dst_for("TA", "CA", "10.0") == ("TB", "CB", "20.0")
+    assert s.dst_for("TA", "CA", "missing") is None
+
+
+def test_kv_roundtrip():
+    s = _store()
+    assert s.get_kv("hwm") is None
+    s.set_kv("hwm", "123.45")
+    assert s.get_kv("hwm") == "123.45"
+
+
+# --- capture (poller → queue) ---------------------------------------------
+
+def test_capture_enqueues_and_dedups():
+    s = _store()
+    relay, mlai, snc, settings = _relay(s)
+    asyncio.run(relay.capture_from_mlai({"ts": "111.1", "user": "U_ALICE", "text": "hello"}))
+    due = s.claim_due_inbound(10, time.time())
+    assert len(due) == 1 and due[0]["direction"] == "mlai_to_snc"
+    # Idempotent: the same source ts is never enqueued twice.
+    asyncio.run(relay.capture_from_mlai({"ts": "111.1", "user": "U_ALICE", "text": "hello"}))
+    assert len(s.claim_due_inbound(10, time.time())) == 1
+
+
+def test_capture_skips_self_posted_echo():
+    s = _store()
+    relay, mlai, snc, settings = _relay(s)
+    s.record_posted("T_M", "C_M", "222.2")  # a message the bridge itself posted
+    asyncio.run(relay.capture_from_mlai({"ts": "222.2", "user": "U_X", "text": "echo"}))
+    assert s.claim_due_inbound(10, time.time()) == []
+
+
+def test_capture_skips_non_content_subtype():
+    s = _store()
+    relay, mlai, snc, settings = _relay(s)
+    asyncio.run(relay.capture_from_mlai({"ts": "333.3", "subtype": "channel_join", "user": "U_X"}))
+    assert s.claim_due_inbound(10, time.time()) == []
+
+
+# --- delivery (worker → other workspace) ----------------------------------
+
+def test_deliver_posts_records_and_maps():
+    s = _store()
+    relay, mlai, snc, settings = _relay(s)
+    asyncio.run(relay.capture_from_mlai({"ts": "111.1", "user": "U_ALICE", "text": "hello"}))
+    row = s.claim_due_inbound(10, time.time())[0]
+    asyncio.run(relay.deliver(row))
+    # Posted into S&C with the author spoofed via chat:write.customize.
+    assert len(snc.posted) == 1
+    assert snc.posted[0]["text"] == "hello"
+    assert snc.posted[0]["username"] == "U_ALICE"
+    assert snc.posted[0]["channel"] == "C_S"
+    # Mapped + registered (loop guard) + no longer pending.
+    dst = s.dst_for("T_M", "C_M", "111.1")
+    assert dst is not None and s.is_self_posted("T_S", "C_S", dst[2])
+    assert s.claim_due_inbound(10, time.time()) == []
+
+
+def test_deliver_retries_on_failure_instead_of_dropping():
+    s = _store()
+    relay, mlai, snc, settings = _relay(s, snc_fail=True)
+    asyncio.run(relay.capture_from_mlai({"ts": "111.1", "user": "U_ALICE", "text": "hello"}))
+    row = s.claim_due_inbound(10, time.time())[0]
+    asyncio.run(relay.deliver(row))
+    assert snc.posted == []
+    # Not lost: backed off into the future, attempt_count incremented.
+    assert s.claim_due_inbound(10, time.time()) == []
+    later = s.claim_due_inbound(10, time.time() + 120)
+    assert len(later) == 1 and later[0]["attempt_count"] == 1

--- a/roo-standalone/docker-compose.bridge.yml
+++ b/roo-standalone/docker-compose.bridge.yml
@@ -1,0 +1,28 @@
+# Slack cross-org bridge — its own Compose project, independent of Roo's stack.
+# Run from roo-standalone/:
+#   docker compose -f docker-compose.bridge.yml up -d --build
+#
+# It is a SEPARATE project (name: slack-bridge), so Roo's regular
+# `docker compose up -d --remove-orphans` deploy never starts or removes it.
+name: slack-bridge
+
+services:
+  slack-bridge:
+    build: .
+    image: roo-slack-bridge:local
+    command: ["uvicorn", "bridge.main:app", "--host", "0.0.0.0", "--port", "8100"]
+    env_file:
+      - .env
+    restart: unless-stopped
+    # No published ports: both sides poll, so there are no inbound webhooks.
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8100/healthz', timeout=5).read()"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    volumes:
+      - slack-bridge-data:/app/data
+
+volumes:
+  slack-bridge-data:

--- a/roo-standalone/ops/slack-bridge.service.example
+++ b/roo-standalone/ops/slack-bridge.service.example
@@ -1,0 +1,29 @@
+# Systemd unit for the Slack cross-org bridge (runs the Docker Compose project).
+# Mirrors ops/docker-health-watchdog.service.example — on this droplet systemd
+# supervises Docker rather than running Python on the host.
+#
+# Install:
+#   sudo cp ops/slack-bridge.service.example /etc/systemd/system/slack-bridge.service
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now slack-bridge
+#
+# Adjust WorkingDirectory to your deploy dir (the GitHub deploy uses /root/roo)
+# and verify the docker path with `which docker`.
+[Unit]
+Description=Roo Slack cross-org bridge
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=simple
+WorkingDirectory=/root/roo/roo-standalone
+# Build then run the bridge Compose project in the foreground so systemd
+# supervises it and its logs land in journald.
+ExecStartPre=/usr/bin/docker compose -f docker-compose.bridge.yml build
+ExecStart=/usr/bin/docker compose -f docker-compose.bridge.yml up
+ExecStop=/usr/bin/docker compose -f docker-compose.bridge.yml down
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds a standalone service that mirrors one channel between the **MLAI** and **Stone & Chalk** Slack workspaces, via a dedicated "Bridge" Slack app installed in both. Roo is not touched.

## How it works
- A dedicated Bridge app is installed in both workspaces (two bot tokens). Each side is **polled**; messages are captured into a durable SQLite queue and a delivery worker posts them into the other workspace with `chat:write.customize` (real name + avatar), so every author shows up as themselves.
- **Store-and-forward**: capture → inbound queue → delivery worker with retries/backoff, so a failed post is retried, not dropped.
- Loop prevention via a posted-message registry; a circuit breaker pauses posting if it ever floods.
- Both directions symmetric; runs as its own process, independent of Roo.

## Code (`roo-standalone/bridge/`)
config, store (queue + loop registry + message map), slack client, identity/markup translation, relay (capture + deliver), pollers + delivery worker, FastAPI `/healthz`. 11 pure-logic tests (`python -m pytest bridge/tests` → 11 passing).

## Deploy
Own Docker Compose project (`docker-compose.bridge.yml`, `name: slack-bridge`) so Roo's deploy never touches it, plus `ops/slack-bridge.service.example` systemd unit (mirrors the existing docker-health-watchdog unit). The Dockerfile now includes the bridge package.

## Before it can run (Slack-side, not in this PR)
- [ ] Create the Bridge app; bot scopes: `channels:history`, `channels:read`, `chat:write`, `chat:write.customize`, `users:read`, `files:read`, `files:write` (+ `groups:*` if the channel is private)
- [ ] Activate distribution; install in **both** orgs; invite the bot to each channel
- [ ] Set `MLAI_BOT_TOKEN`, `SNC_BOT_TOKEN`, `MLAI_CHANNEL_ID`, `SNC_CHANNEL_ID` in `.env`
- [ ] Get Stone & Chalk's consent; note the bridge in both channel topics

## v1 limitations
Polling (a few seconds of latency); edits/deletes and reactions are not mirrored; files best-effort.

See `SLACK_BRIDGE_PLAN.md` for the full design and the approaches considered/superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
