### PR TITLE
Bridge: mirror threaded replies (sweep + bidirectional thread mapping)

### DIFF
--- a/roo-standalone/bridge/README.md
+++ b/roo-standalone/bridge/README.md
@@ -57,6 +57,9 @@ to) is skipped with a warning — create/invite, then restart.
 ## v1 scope and limitations
 - **Both sides poll** (a few seconds of latency). Mirrors messages from when it
   starts **forward** — it does not backfill existing history (a separate one-off).
+- **Threaded replies are mirrored** (and re-threaded under the right parent),
+  via a per-poll sweep of recent threads — but only for threads whose parent is
+  within `THREAD_SWEEP_SECONDS` (default 3 days).
 - **Edits/deletes are not mirrored** in poll mode; **reactions** are skipped;
   **files** are re-uploaded best-effort.
 - Pick channels where Roo doesn't post automated content, or set

--- a/roo-standalone/bridge/config.py
+++ b/roo-standalone/bridge/config.py
@@ -45,6 +45,9 @@ class BridgeSettings(BaseSettings):
 
     # --- Behaviour ---
     POLL_SECONDS: float = 5.0
+    # Thread replies are swept by re-scanning recent threads each poll; replies
+    # on threads whose parent is older than this window are not picked up.
+    THREAD_SWEEP_SECONDS: float = 3 * 24 * 3600
     BRIDGE_DELIVERY_POLL_SECONDS: float = 2.0
     BRIDGE_MAX_DELIVERY_ATTEMPTS: int = 5
     BRIDGE_DB_PATH: str = "data/slack_bridge.db"

--- a/roo-standalone/bridge/main.py
+++ b/roo-standalone/bridge/main.py
@@ -89,6 +89,7 @@ async def lifespan(app: FastAPI):
                     hwm_key=f"hwm:{team}:{channel_id}",
                     handler=(lambda msg, _l=label, _t=to_mlai: relay.capture(_l, _t, msg)),
                     store=store, poll_seconds=settings.POLL_SECONDS,
+                    thread_sweep_seconds=settings.THREAD_SWEEP_SECONDS,
                     on_error=(lambda e, _n=display: poll_error_backoff(e, label=_n, relay=relay)),
                 )
             )

--- a/roo-standalone/bridge/poller.py
+++ b/roo-standalone/bridge/poller.py
@@ -1,19 +1,19 @@
 """
-Channel poll loop — shared by both sides.
+Channel poll loop — shared by every pair side.
 
-Neither side uses a webhook: the MLAI side is polled with Roo's bot token, the
-S&C side with Sam's web session. Both poll conversations.history for new
-messages (and conversations.replies for active threads) and hand each message
-to a relay handler. A high-water mark (newest ts seen) is persisted in the kv
-store so restarts neither replay nor miss.
+Each bridged channel is polled with its workspace's bot token. Two things are
+tracked, because Slack surfaces them differently:
 
-The S&C poll is the deliberate v1 substitute for the web client's WebSocket;
-the clean upgrade is to swap that side's loop for a `client.userBoot` + WS
-listener. The relay handlers don't care where a message comes from.
+  * New top-level messages — conversations.history(oldest=hwm). The hwm advances
+    past everything processed, so we never replay or miss a root message.
+  * New thread replies — these do NOT appear in conversations.history, and a
+    reply can land on a parent that is OLDER than the hwm (so the parent is never
+    returned by the oldest=hwm query). So we run a separate "thread sweep": each
+    poll re-scans recent history for any thread whose latest_reply is newer than
+    a reply high-water mark, and drains those replies via conversations.replies.
 
-Behave like a real client: modest interval, cached user lookups, honour rate
-limits — anti-abuse heuristics invalidate the S&C session if it looks like a
-scraper.
+Both marks are persisted in the kv store so restarts neither replay nor miss.
+A delivery worker (below) drains the inbound queue the handlers fill.
 """
 import asyncio
 import time
@@ -21,6 +21,10 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 Handler = Callable[[Dict[str, Any]], Awaitable[None]]
 ErrorBackoff = Callable[[Exception], float]
+
+# Replies on threads whose parent is older than this are not swept (keeps the
+# per-poll scan bounded). Replies almost always arrive well within this window.
+DEFAULT_THREAD_SWEEP_SECONDS = 3 * 24 * 3600
 
 
 async def channel_poll_loop(
@@ -33,21 +37,29 @@ async def channel_poll_loop(
     store,
     poll_seconds: float,
     on_error: Optional[ErrorBackoff] = None,
+    thread_sweep_seconds: float = DEFAULT_THREAD_SWEEP_SECONDS,
 ) -> None:
+    reply_key = f"{hwm_key}:replies"
+
     # On first ever run, start from "now" so we don't replay history.
     last_ts = store.get_kv(hwm_key)
     if last_ts is None:
         last_ts = f"{time.time():.6f}"
         store.set_kv(hwm_key, last_ts)
+        store.set_kv(reply_key, last_ts)
         print(f"{label} ingest starting fresh from {last_ts}")
     else:
+        if store.get_kv(reply_key) is None:  # existing install, new reply mark
+            store.set_kv(reply_key, last_ts)
         print(f"{label} ingest resuming from {last_ts}")
 
     poll = max(1.0, float(poll_seconds))
 
     while True:
         try:
-            last_ts = await _poll_once(label, client, channel_id, hwm_key, handler, store, last_ts)
+            last_ts = await _poll_once(
+                label, client, channel_id, hwm_key, reply_key, handler, store, last_ts, thread_sweep_seconds
+            )
         except asyncio.CancelledError:
             raise
         except Exception as e:
@@ -57,51 +69,64 @@ async def channel_poll_loop(
         await asyncio.sleep(poll)
 
 
-async def _poll_once(label, client, channel_id, hwm_key, handler, store, last_ts: str) -> str:
+async def _poll_once(
+    label, client, channel_id, hwm_key, reply_key, handler, store, last_ts: str, sweep_seconds: float
+) -> str:
+    # 1) New top-level messages.
     resp = client.conversations_history(channel=channel_id, oldest=last_ts, limit=200)
     if not resp.get("ok"):
         print(f"⚠️ {label} history not ok: {resp.get('error')}")
         return last_ts
 
-    # History returns newest-first; process chronologically.
-    roots: List[Dict[str, Any]] = list(reversed(resp.get("messages", [])))
+    roots: List[Dict[str, Any]] = list(reversed(resp.get("messages", [])))  # chronological
     high = float(last_ts)
-
     for msg in roots:
         ts = msg.get("ts")
         if ts and float(ts) > float(last_ts):
             await handler(msg)
             high = max(high, float(ts))
-
-        # Thread replies don't appear in history — pull them for active threads.
-        latest_reply = msg.get("latest_reply")
-        if latest_reply and float(latest_reply) > float(last_ts):
-            high = max(high, await _drain_thread(label, client, channel_id, handler, msg, last_ts))
-
     new_hwm = f"{high:.6f}"
     if new_hwm != last_ts:
         store.set_kv(hwm_key, new_hwm)
+
+    # 2) Thread replies — independent of the top-level hwm.
+    await _sweep_threads(label, client, channel_id, reply_key, handler, store, sweep_seconds)
     return new_hwm
 
 
-async def _drain_thread(label, client, channel_id, handler, root, last_ts: str) -> float:
-    high = float(last_ts)
+async def _sweep_threads(label, client, channel_id, reply_key, handler, store, sweep_seconds: float) -> None:
+    """Re-scan recent threads for replies newer than the reply high-water mark."""
+    reply_hwm = float(store.get_kv(reply_key) or 0)
+    oldest = f"{max(0.0, time.time() - sweep_seconds):.6f}"
+    resp = client.conversations_history(channel=channel_id, oldest=oldest, limit=200)
+    if not resp.get("ok"):
+        return
+
+    new_hwm = reply_hwm
+    for msg in resp.get("messages", []):
+        latest_reply = msg.get("latest_reply")
+        if msg.get("reply_count") and latest_reply and float(latest_reply) > reply_hwm:
+            new_hwm = max(new_hwm, await _drain_replies(label, client, channel_id, handler, msg, reply_hwm))
+    if new_hwm > reply_hwm:
+        store.set_kv(reply_key, f"{new_hwm:.6f}")
+
+
+async def _drain_replies(label, client, channel_id, handler, parent, reply_hwm: float) -> float:
+    high = reply_hwm
+    parent_ts = parent.get("thread_ts") or parent.get("ts")
     try:
         replies = client.conversations_replies(
-            channel=channel_id,
-            ts=root.get("thread_ts") or root.get("ts"),
-            oldest=last_ts,
-            limit=200,
+            channel=channel_id, ts=parent_ts, oldest=f"{reply_hwm:.6f}", limit=200
         )
         for r in replies.get("messages", []):
             ts = r.get("ts")
-            # Skip the parent (handled as a root) and anything not new.
-            if not ts or ts == root.get("ts") or float(ts) <= float(last_ts):
+            # Skip the parent itself and anything not newer than the mark.
+            if not ts or ts == parent_ts or float(ts) <= reply_hwm:
                 continue
             await handler(r)
             high = max(high, float(ts))
     except Exception as e:
-        print(f"⚠️ {label} thread drain failed for {root.get('ts')}: {e}")
+        print(f"⚠️ {label} reply drain failed for {parent_ts}: {e}")
     return high
 
 

--- a/roo-standalone/bridge/relay.py
+++ b/roo-standalone/bridge/relay.py
@@ -200,11 +200,18 @@ class Relay:
         return msg.get("username") or (msg.get("bot_profile", {}) or {}).get("name") or "bot"
 
     def _dst_thread_ts(self, src_team: str, src_channel: str, msg: Dict[str, Any]) -> Optional[str]:
+        """Map a reply's parent to its counterpart on the destination side.
+
+        The parent may have been sent FROM this side (forward map) or RECEIVED on
+        this side (reverse map), so check both directions."""
         thread_ts = msg.get("thread_ts")
         if not thread_ts or thread_ts == msg.get("ts"):
             return None
         dst = self.store.dst_for(src_team, src_channel, thread_ts)
-        return dst[2] if dst else None
+        if dst:
+            return dst[2]
+        src = self.store.src_for(src_team, src_channel, thread_ts)
+        return src[2] if src else None
 
     def _allow_post(self) -> bool:
         """Circuit breaker: never let a loop bug flood the channels."""

--- a/roo-standalone/bridge/store.py
+++ b/roo-standalone/bridge/store.py
@@ -197,6 +197,7 @@ class BridgeStore:
             )
 
     def dst_for(self, src_team, src_channel, src_ts) -> Optional[Tuple[str, str, str]]:
+        """Forward: where did we post the copy of this source message?"""
         self._ensure_schema()
         with self._lock, self._connect() as conn:
             row = conn.execute(
@@ -205,6 +206,18 @@ class BridgeStore:
                 (src_team, src_channel, src_ts),
             ).fetchone()
             return (row["dst_team"], row["dst_channel"], row["dst_ts"]) if row else None
+
+    def src_for(self, dst_team, dst_channel, dst_ts) -> Optional[Tuple[str, str, str]]:
+        """Reverse: given a posted copy, what source message produced it? Needed
+        to thread a reply that lands on a parent which was *received* on this side."""
+        self._ensure_schema()
+        with self._lock, self._connect() as conn:
+            row = conn.execute(
+                "SELECT src_team, src_channel, src_ts FROM message_map "
+                "WHERE dst_team=? AND dst_channel=? AND dst_ts=?",
+                (dst_team, dst_channel, dst_ts),
+            ).fetchone()
+            return (row["src_team"], row["src_channel"], row["src_ts"]) if row else None
 
     # --- kv ------------------------------------------------------------------
 

--- a/roo-standalone/bridge/tests/test_relay.py
+++ b/roo-standalone/bridge/tests/test_relay.py
@@ -85,6 +85,9 @@ def test_message_map_roundtrip():
     s.map_message("TA", "CA", "10.0", "TB", "CB", "20.0")
     assert s.dst_for("TA", "CA", "10.0") == ("TB", "CB", "20.0")
     assert s.dst_for("TA", "CA", "missing") is None
+    # reverse lookup (needed to thread replies on received parents)
+    assert s.src_for("TB", "CB", "20.0") == ("TA", "CA", "10.0")
+    assert s.src_for("TB", "CB", "missing") is None
 
 
 # --- capture (poller → queue) ---------------------------------------------
@@ -162,3 +165,18 @@ def test_deliver_retries_on_failure_instead_of_dropping():
     assert s.claim_due_inbound(10, time.time()) == []
     later = s.claim_due_inbound(10, time.time() + 120)
     assert len(later) == 1 and later[0]["attempt_count"] == 1
+
+
+def test_reply_threads_under_received_parent_via_reverse_map():
+    # An MLAI message was already mirrored to the partner (parent 100 -> 200).
+    s = _store()
+    relay, mlai, remote, settings = _relay(s)
+    s.map_message("T_M", "C_M", "100.0", "T_R", "C_R", "200.0")
+    # A reply now lands in the partner channel, on the *received* parent (200).
+    asyncio.run(relay.capture("hex", True, {"ts": "205.0", "user": "U_HEX", "text": "looks good", "thread_ts": "200.0"}))
+    row = s.claim_due_inbound(10, time.time())[0]
+    asyncio.run(relay.deliver(row))
+    # It must land in MLAI threaded under the original parent (100), via the reverse map.
+    assert len(mlai.posted) == 1
+    assert mlai.posted[0]["channel"] == "C_M"
+    assert mlai.posted[0]["thread_ts"] == "100.0"


### PR DESCRIPTION
Fixes threaded replies not mirroring across the bridge (e.g. a reply made in Hex didn't appear in MLAI).

Two stacked bugs:
1. The poller only fetched replies for threads whose **parent was newer than the high-water mark** — so a reply on an already-processed parent was never picked up. Adds a per-poll **thread sweep** (its own reply mark, re-scans recent threads up to `THREAD_SWEEP_SECONDS`, default 3 days) independent of the top-level mark.
2. Thread mapping was **one-directional** (`dst_for` only), so a reply on a parent that was *received* (not sent) on this side wouldn't thread. Adds `store.src_for` and makes `relay._dst_thread_ts` check both directions.

12 tests pass (added reverse-map + bidirectional thread-reply coverage).

**After merge**, on the droplet (deploy auto-pulls `main`):
```
docker compose -f docker-compose.bridge.yml up -d --build
```
to rebuild the bridge container with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
