### PR TITLE
Quote per-user coworking price and nudge founders to submit monthly updates

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -1059,11 +1059,23 @@ class MLAIBackendClient:
         response.raise_for_status()
         return response.json()
 
-    async def check_coworking(self, check_date: Optional[str] = None, days: int = 7) -> List[dict]:
-        """Check coworking availability."""
+    async def check_coworking(
+        self,
+        check_date: Optional[str] = None,
+        days: int = 7,
+        slack_user_id: Optional[str] = None,
+    ) -> List[dict]:
+        """Check coworking availability.
+
+        When ``slack_user_id`` is supplied the backend quotes the price that
+        user would actually be charged (which drops with a current monthly
+        update), so the displayed cost matches the booking cost.
+        """
         params = {"days": days}
         if check_date:
             params["date"] = check_date
+        if slack_user_id:
+            params["slack_user_id"] = self._clean_slack_id(slack_user_id)
         response = await self._request(
             "GET",
             f"{self._points_base}/coworking/availability/",

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -107,7 +107,8 @@ class SkillExecutor:
     2. Routes to skill-specific handlers if available
     3. Falls back to generic LLM execution with skill instructions
     """
-    
+
+
     async def execute(
         self,
         skill: Skill,
@@ -7920,6 +7921,7 @@ Chunk {index} source: {label}
         cost: int,
         new_balance: Optional[int],
         admin_checkin: bool,
+        discount_applied: bool = False,
     ) -> str:
         point_word = "point" if cost == 1 else "points"
         if admin_checkin:
@@ -7934,12 +7936,24 @@ Chunk {index} source: {label}
         if new_balance is not None:
             balance_line = f" (Balance remaining: {new_balance} points)"
 
-        return (
+        message = (
             f"You beauty! 🎉\n\n"
             f"Booked you in for **{booking_date}** at the coworking space.\n"
             f"Cost: {cost} {point_word}{balance_line}\n\n"
             f"See you there, legend!"
         )
+
+        # Nudge founders who paid the standard (undiscounted) price: submitting a
+        # monthly startup update lowers the coworking cost for that month. The
+        # backend tells us whether the discount already applied.
+        if not discount_applied:
+            message += (
+                "\n\n💡 Startup founders get a discount on coworking bookings when they "
+                "submit a monthly update for their startup. Submit yours here: "
+                "https://mlai.au/platform/login?app=founder-tools&next=/founder-tools"
+            )
+
+        return message
 
     async def _format_admin_coworking_bad_request(
         self,
@@ -8024,6 +8038,9 @@ Chunk {index} source: {label}
             raise
 
         cost = result.get("points_cost", 1)
+        # The backend is the single source of truth for whether the
+        # monthly-update discount applied; we only render the nudge off this.
+        discount_applied = bool(result.get("monthly_update_discount_applied", False))
         from roo.clients.mlai_backend import MLAIBackendUnavailableError
 
         new_balance = None
@@ -8039,6 +8056,7 @@ Chunk {index} source: {label}
             cost=cost,
             new_balance=new_balance,
             admin_checkin=admin_checkin,
+            discount_applied=discount_applied,
         )
 
     async def _handle_points_action(
@@ -8423,8 +8441,8 @@ Chunk {index} source: {label}
         elif action == "check_coworking":
             check_date = params.get("date")
             days = params.get("days", 7)
-            
-            availability = await client.check_coworking(check_date, days)
+
+            availability = await client.check_coworking(check_date, days, slack_user_id=user_id)
             
             if not availability:
                 return "Couldn't check availability right now. Try again in a tick?"

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -3168,3 +3168,103 @@ async def test_dependency_health_check_reports_degraded_backend(monkeypatch):
     assert result["dependencies"]["mlai_backend"]["status"] == "degraded"
     assert result["dependencies"]["mlai_backend"]["readiness"]["status"] == "ok"
     assert "points_error" in result["dependencies"]["mlai_backend"]
+
+
+@pytest.mark.asyncio
+async def test_check_coworking_passes_slack_user_id_for_per_user_pricing():
+    class FakeAvailabilityClient:
+        def __init__(self):
+            self.call = None
+
+        async def check_coworking(self, check_date=None, days=7, slack_user_id=None):
+            self.call = (check_date, days, slack_user_id)
+            return [
+                {
+                    "date": "2026-05-04",
+                    "available_slots": 5,
+                    "cost_points": 4,
+                    "is_bookable": True,
+                }
+            ]
+
+    client = FakeAvailabilityClient()
+    executor = SkillExecutor()
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="check_coworking",
+        params={"date": "2026-05-04", "days": 7},
+        text="coworking availability",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    # The user's slack id is forwarded so the backend can quote the discounted price.
+    assert client.call == ("2026-05-04", 7, "U123")
+    assert "4 pt" in result
+
+
+@pytest.mark.asyncio
+async def test_book_coworking_nudges_founder_when_charged_standard_price(tmp_path, monkeypatch):
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "intents.db")
+
+    class FakeCoworkingClient:
+        async def book_coworking(self, slack_user_id, booking_date, slack_channel_id=None):
+            return {"points_cost": 8, "monthly_update_discount_applied": False}
+
+        async def get_balance(self, slack_user_id):
+            return {"balance": 12}
+
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+
+    result = await executor._handle_points_action(
+        client=FakeCoworkingClient(),
+        action="book_coworking",
+        params={"date": "2026-05-04"},
+        text="book coworking today",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "Booked you in for **2026-05-04**" in result
+    assert "Cost: 8 points" in result
+    assert "submit a monthly update" in result
+    assert "https://mlai.au/platform/login?app=founder-tools&next=/founder-tools" in result
+
+
+@pytest.mark.asyncio
+async def test_book_coworking_omits_nudge_when_discount_applied(tmp_path, monkeypatch):
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "intents.db")
+
+    class FakeCoworkingClient:
+        async def book_coworking(self, slack_user_id, booking_date, slack_channel_id=None):
+            return {"points_cost": 4, "monthly_update_discount_applied": True}
+
+        async def get_balance(self, slack_user_id):
+            return {"balance": 12}
+
+    executor = SkillExecutor()
+    monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+
+    result = await executor._handle_points_action(
+        client=FakeCoworkingClient(),
+        action="book_coworking",
+        params={"date": "2026-05-04"},
+        text="book coworking today",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "Booked you in for **2026-05-04**" in result
+    assert "Cost: 4 points" in result
+    assert "submit a monthly update" not in result
+    assert "founder-tools" not in result


### PR DESCRIPTION
Companion to mlai-backend #497 (coworking 8 pts, 4 with a current monthly update).

## Changes
- `check_coworking()` forwards `slack_user_id` so the availability listing quotes the price the user will actually be charged.
- Booking success message nudges founders to submit a monthly update (with the founder-tools link) when no discount was applied.
- The nudge keys off the backend's `monthly_update_discount_applied` flag, so Roo no longer hardcodes the coworking price.

## Tests
`test_points_requests.py` passes, including new cases: availability forwards `slack_user_id`, nudge shown at standard price, nudge suppressed when discounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)