### PR TITLE
Bridge: stop file uploads looping forever

### DIFF
--- a/roo-standalone/bridge/main.py
+++ b/roo-standalone/bridge/main.py
@@ -66,7 +66,7 @@ async def lifespan(app: FastAPI):
                   f"(invite the bot there, then restart) — skipping")
             continue
 
-        resolved.append(ResolvedPair(pair.label, remote_client, remote_team, mlai_ch, remote_ch))
+        resolved.append(ResolvedPair(pair.label, remote_client, remote_team, mlai_ch, remote_ch, who["user_id"]))
         poll_specs.append((f"MLAI#{pair.label}", mlai_client, mlai_ch, settings.MLAI_TEAM_ID, pair.label, False))
         poll_specs.append((f"{pair.label}#remote", remote_client, remote_ch, remote_team, pair.label, True))
         print(f"   pair {pair.label!r}: MLAI {mlai_ch} <-> {remote_team}/{remote_ch}")

--- a/roo-standalone/bridge/relay.py
+++ b/roo-standalone/bridge/relay.py
@@ -44,6 +44,7 @@ class ResolvedPair:
     remote_team: str
     mlai_channel_id: str
     remote_channel_id: str
+    remote_bot_user_id: str = ""  # the bridge bot's own user id in the partner workspace
 
 
 class Relay:
@@ -75,15 +76,23 @@ class Relay:
             return
         if to_mlai:
             src_team, src_channel = pair.remote_team, pair.remote_channel_id
+            own_bot_user_id = pair.remote_bot_user_id
             direction = f"{label}:to_mlai"
         else:
             src_team, src_channel = self.s.MLAI_TEAM_ID or "", pair.mlai_channel_id
+            own_bot_user_id = self.s.MLAI_BOT_USER_ID
             direction = f"{label}:to_remote"
 
         ts = msg.get("ts")
         if not ts or msg.get("subtype") not in _RELAYABLE_SUBTYPES:
             return
-        # Our own echo (we posted this) — never re-bridge.
+        # Our own post — never re-bridge. The registry catches chat posts (whose
+        # ts we record), but file uploads create a message whose ts we don't
+        # record, so also drop anything authored by our own bot user id. Safe
+        # because we run a dedicated Bridge app (its bot id is distinct from
+        # other bots we DO want to relay, e.g. Roo/Jeanette).
+        if own_bot_user_id and msg.get("user") == own_bot_user_id:
+            return
         if self.store.is_self_posted(src_team, src_channel, ts):
             return
         if msg.get("bot_id") and not self.s.BRIDGE_RELAY_BOT_MESSAGES:

--- a/roo-standalone/bridge/tests/test_relay.py
+++ b/roo-standalone/bridge/tests/test_relay.py
@@ -41,18 +41,36 @@ def _store():
 
 
 def _relay(store, remote_fail=False):
-    settings = BridgeSettings(MLAI_BOT_TOKEN="xoxb-x", MLAI_TEAM_ID="T_M")
+    settings = BridgeSettings(MLAI_BOT_TOKEN="xoxb-x", MLAI_TEAM_ID="T_M", MLAI_BOT_USER_ID="B_MLAI")
     mlai = FakeClient()
     remote = FakeClient(fail=remote_fail)
     pair = ResolvedPair(
         label="hex", remote_client=remote, remote_team="T_R",
-        mlai_channel_id="C_M", remote_channel_id="C_R",
+        mlai_channel_id="C_M", remote_channel_id="C_R", remote_bot_user_id="B_REMOTE",
     )
     relay = Relay(
         settings=settings, store=store, identity=IdentityResolver(),
         mlai_client=mlai, pairs=[pair],
     )
     return relay, mlai, remote, settings
+
+
+# --- loop guard: our own posts (incl. file uploads) never re-bridge ---------
+
+def test_capture_drops_own_bot_posts_including_file_uploads():
+    s = _store()
+    relay, mlai, remote, settings = _relay(s)
+    # A file upload the bridge made in the partner channel — NOT in the registry
+    # (file-message ts isn't recorded), so it must be dropped by bot-id or the
+    # photo loops forever.
+    asyncio.run(relay.capture("hex", True, {
+        "ts": "900.0", "user": "B_REMOTE", "subtype": "file_share",
+        "files": [{"name": "IMG_0516.jpg"}],
+    }))
+    assert s.claim_due_inbound(10, time.time()) == []
+    # A *different* bot (e.g. Jeanette) is still relayed.
+    asyncio.run(relay.capture("hex", True, {"ts": "901.0", "user": "U_OTHER", "bot_id": "B_J", "text": "hi"}))
+    assert len(s.claim_due_inbound(10, time.time())) == 1
 
 
 # --- markup translation ---------------------------------------------------


### PR DESCRIPTION
## The bug (why a shared photo looped forever)

The loop guard records every message the bridge posts in `posted_registry` and drops anything already there. But **file uploads escape it**: `deliver` records the ts of the text post (`chat_postMessage`), while files go through a *separate* `files_upload_v2` call that creates its **own** destination message whose ts is never recorded. So the opposite side's poller sees the re-uploaded file as "new", captures it, re-uploads it back, and it bounces forever — re-posting the photo every cycle (the incident: 122 replies, had to uninstall the app to stop it). Text never loops; only files did.

## The fix

Add an identity-based guard in `capture`: **drop any message authored by the bridge's own bot user id** (per workspace). This covers file uploads *and* chat posts regardless of the registry. Safe because this is a **dedicated** Bridge app — its bot user id is unique, distinct from other bots (Roo, Jeanette) that we still want to relay.

- `ResolvedPair` now carries `remote_bot_user_id` (resolved at startup via `auth.test`).
- 13 tests pass, incl. a new one: an own-bot file upload is dropped, a different bot's message is still relayed.

## Known cosmetic follow-ups (not in this PR)
- File messages post an empty placeholder text line + the file as two messages.
- Uploaded files show as the Bridge bot (Slack can't spoof the uploader identity on `files.upload`).

## Deploy
After merge, on the droplet: `docker compose -f docker-compose.bridge.yml up -d --build` (the auto-deploy only rebuilds Roo), then reinstall/re-invite the Bridge app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
