### PR TITLE
[codex] Support multi-person coworking check-ins

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -1189,6 +1189,47 @@ class MLAIBackendClient:
         )
         response.raise_for_status()
         return response.json()
+
+    async def book_coworking_many(
+        self,
+        admin_slack_user_id: str,
+        target_slack_user_ids: List[str],
+        booking_date: str,
+        slack_channel_id: Optional[str] = None,
+    ) -> dict:
+        """Book multiple coworking days as a full Points Admin."""
+        try:
+            from datetime import datetime
+            current_time = datetime.now().isoformat()
+        except Exception:
+            current_time = ""
+
+        cleaned_targets: List[str] = []
+        for target in target_slack_user_ids or []:
+            cleaned = self._clean_slack_id(target)
+            if cleaned and cleaned not in cleaned_targets:
+                cleaned_targets.append(cleaned)
+
+        payload = {
+            "admin_slack_user_id": self._clean_slack_id(admin_slack_user_id),
+            "target_slack_user_ids": cleaned_targets,
+            "date": booking_date,
+            "current_time": current_time,
+        }
+        if slack_channel_id:
+            payload["slack_channel_id"] = slack_channel_id
+
+        response = await self._request(
+            "POST",
+            f"{self._points_base}/coworking/book-many/",
+            json=payload,
+            timeout=20.0,
+            transport_retries=1,
+            retry_backoff_seconds=0.5,
+            circuit_breaker=True,
+        )
+        response.raise_for_status()
+        return response.json()
     
     async def get_github_auth_url(self, slack_user_id: str, domain: Optional[str] = None) -> dict:
         """Get the GitHub OAuth URL for a user from the backend."""

--- a/roo-standalone/roo/routing_eval/cases/paraphrases.yaml
+++ b/roo-standalone/roo/routing_eval/cases/paraphrases.yaml
@@ -117,6 +117,14 @@
   text: "book a coworking spot for friday"
   expect: {skill: mlai-points, action: book_coworking}
   tags: [paraphrase]
+- id: para-points-admin-book-two-today
+  text: "book <@U123ABC> <@U456DEF> in today"
+  expect: {skill: mlai-points, action: admin_checkin_coworking}
+  tags: [paraphrase, coworking-admin]
+- id: para-points-admin-check-three-tomorrow
+  text: "check <@U123ABC>, <@U456DEF>, <@U789GHI> in tomorrow"
+  expect: {skill: mlai-points, action: admin_checkin_coworking}
+  tags: [paraphrase, coworking-admin]
 - id: para-points-cancel-tomorrow
   text: "cancel my coworking booking tomorrow"
   expect: {skill: mlai-points, action: cancel_coworking}

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -8043,6 +8043,118 @@ Chunk {index} source: {label}
                 pass
         return f"🛑 I couldn't check <@{target_user_id}> in: {error_detail}{balance_line}"
 
+    def _format_admin_coworking_batch_success(
+        self,
+        *,
+        booking_date: str,
+        batch_result: dict,
+    ) -> str:
+        results = batch_result.get("results") or []
+        created_count = int(batch_result.get("created_count") or 0)
+        already_booked_count = int(batch_result.get("already_booked_count") or 0)
+
+        lines = [
+            "You beauty! 🎉",
+            "",
+            f"Checked **{len(results)}** people for coworking on **{booking_date}**.",
+        ]
+        if created_count or already_booked_count:
+            lines.append(
+                f"Created: **{created_count}** · Already booked: **{already_booked_count}**"
+            )
+
+        for result in results:
+            slack_user_id = str(result.get("slack_user_id") or "").strip()
+            if not slack_user_id:
+                booking = result.get("booking") or {}
+                slack_user_id = str(booking.get("slack_id") or booking.get("slack_user_id") or "").strip()
+            if not slack_user_id:
+                continue
+
+            status = "already booked" if result.get("already_booked") else "booked"
+            points_cost = result.get("points_cost")
+            cost_text = f" · {points_cost} pts" if points_cost is not None else ""
+            lines.append(f"• <@{slack_user_id}>: {status}{cost_text}")
+
+        lines.extend([
+            "",
+            "Admin Roo Points were not charged; each target user's Roo Points were used.",
+        ])
+        return "\n".join(lines)
+
+    def _format_admin_coworking_batch_bad_request(
+        self,
+        *,
+        booking_date: str,
+        exc: httpx.HTTPStatusError,
+    ) -> str:
+        error_detail = self._extract_http_error_detail(exc) or "The booking request was rejected."
+        per_target_errors: list[dict] = []
+        try:
+            payload = exc.response.json()
+            if isinstance(payload, dict) and isinstance(payload.get("errors"), list):
+                per_target_errors = [
+                    item for item in payload["errors"] if isinstance(item, dict)
+                ]
+        except Exception:
+            per_target_errors = []
+
+        lines = [
+            f"🛑 No bookings were created for **{booking_date}**.",
+            error_detail,
+        ]
+        for item in per_target_errors[:10]:
+            slack_user_id = str(item.get("slack_user_id") or "").strip()
+            target_label = f"<@{slack_user_id}>" if slack_user_id else "Target"
+            reason = str(item.get("error") or item.get("detail") or item.get("message") or "Rejected").strip()
+            lines.append(f"• {target_label}: {reason}")
+        return "\n".join(lines)
+
+    async def _book_coworking_many_for_admin(
+        self,
+        *,
+        client,
+        admin_user_id: str,
+        target_user_ids: list[str],
+        booking_date: str,
+        channel_id: Optional[str],
+    ) -> str:
+        try:
+            result = await client.book_coworking_many(
+                admin_slack_user_id=admin_user_id,
+                target_slack_user_ids=target_user_ids,
+                booking_date=booking_date,
+                slack_channel_id=channel_id,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 400:
+                return self._format_admin_coworking_batch_bad_request(
+                    booking_date=booking_date,
+                    exc=exc,
+                )
+            if exc.response.status_code == 403:
+                return self._full_points_admin_denial(None, "check people in for coworking")
+            if is_retryable_coworking_exception(exc):
+                return (
+                    "I couldn't confirm that multi-person coworking check-in because MLAI backend "
+                    "didn't respond cleanly. Please retry the same command; existing bookings are "
+                    "treated as already booked and won't be charged twice."
+                )
+            raise
+        except Exception as exc:
+            if is_retryable_coworking_exception(exc):
+                return (
+                    "I couldn't confirm that multi-person coworking check-in because MLAI backend "
+                    "didn't respond cleanly. Please retry the same command; existing bookings are "
+                    "treated as already booked and won't be charged twice."
+                )
+            raise
+
+        return self._format_admin_coworking_batch_success(
+            booking_date=str(result.get("date") or booking_date),
+            batch_result=result,
+        )
+
     async def _book_coworking_with_intent(
         self,
         *,
@@ -8473,21 +8585,28 @@ Chunk {index} source: {label}
                 bot_id=bot_id,
             )
             if not target_slack_ids:
-                return "Who should I check in? Mention exactly one user, like `check @Jasmine in today`."
-            if len(target_slack_ids) != 1:
-                return "Tag exactly one user to check them in for coworking."
+                return "Who should I check in? Mention one or more users, like `check @Jasmine @Lee in today`."
 
             admin_details = await client.get_admin_details(user_id)
             if not self._is_full_points_admin_details(admin_details):
                 return self._full_points_admin_denial(admin_details, "check people in for coworking")
 
-            target_user_id = target_slack_ids[0]
             booking_date = self._resolve_coworking_booking_date(
                 params,
                 text,
                 default_to_today=True,
             )
 
+            if len(target_slack_ids) > 1:
+                return await self._book_coworking_many_for_admin(
+                    client=client,
+                    admin_user_id=user_id,
+                    target_user_ids=target_slack_ids,
+                    booking_date=booking_date,
+                    channel_id=channel_id,
+                )
+
+            target_user_id = target_slack_ids[0]
             try:
                 return await self._book_coworking_with_intent(
                     client=client,
@@ -8540,11 +8659,45 @@ Chunk {index} source: {label}
                 bot_id=bot_id,
             )
             if target_slack_ids:
-                return (
-                    "I saw a tagged user in that coworking booking request, so I didn't book you. "
-                    "Please retry as `book @user in today` or `check @user in today` so I can run "
-                    "the admin check-in flow."
+                admin_details = await client.get_admin_details(user_id)
+                if not self._is_full_points_admin_details(admin_details):
+                    return self._full_points_admin_denial(admin_details, "check people in for coworking")
+
+                booking_date = self._resolve_coworking_booking_date(
+                    params,
+                    text,
+                    default_to_today=True,
                 )
+
+                if len(target_slack_ids) > 1:
+                    return await self._book_coworking_many_for_admin(
+                        client=client,
+                        admin_user_id=user_id,
+                        target_user_ids=target_slack_ids,
+                        booking_date=booking_date,
+                        channel_id=channel_id,
+                    )
+
+                target_user_id = target_slack_ids[0]
+                try:
+                    return await self._book_coworking_with_intent(
+                        client=client,
+                        target_user_id=target_user_id,
+                        requested_by_user_id=user_id,
+                        booking_date=booking_date,
+                        text=text,
+                        channel_id=channel_id,
+                        thread_ts=thread_ts,
+                        admin_checkin=True,
+                    )
+                except httpx.HTTPStatusError as exc:
+                    if exc.response.status_code == 400:
+                        return await self._format_admin_coworking_bad_request(
+                            client=client,
+                            target_user_id=target_user_id,
+                            exc=exc,
+                        )
+                    raise
 
             booking_date = self._resolve_coworking_booking_date(
                 params,

--- a/roo-standalone/roo/tests/test_coworking_admin_batch.py
+++ b/roo-standalone/roo/tests/test_coworking_admin_batch.py
@@ -1,0 +1,181 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("frontmatter", SimpleNamespace(load=lambda *args, **kwargs: None))
+
+executor_module = importlib.import_module("roo.skills.executor")
+slack_client_module = importlib.import_module("roo.slack_client")
+SkillExecutor = executor_module.SkillExecutor
+
+
+class FakeCoworkingClient:
+    def __init__(self, *, admin_details=None, batch_result=None, batch_exc=None):
+        self.admin_details = admin_details
+        self.batch_result = batch_result or {
+            "date": "2026-07-04",
+            "created_count": 2,
+            "already_booked_count": 0,
+            "results": [
+                {"slack_user_id": "U1", "created": True, "already_booked": False, "points_cost": 8},
+                {"slack_user_id": "U2", "created": True, "already_booked": False, "points_cost": 8},
+            ],
+        }
+        self.batch_exc = batch_exc
+        self.admin_lookup_calls = []
+        self.batch_calls = []
+        self.single_calls = []
+
+    async def get_admin_details(self, slack_user_id):
+        self.admin_lookup_calls.append(slack_user_id)
+        return self.admin_details
+
+    async def book_coworking_many(
+        self,
+        *,
+        admin_slack_user_id,
+        target_slack_user_ids,
+        booking_date,
+        slack_channel_id=None,
+    ):
+        self.batch_calls.append(
+            {
+                "admin_slack_user_id": admin_slack_user_id,
+                "target_slack_user_ids": list(target_slack_user_ids),
+                "booking_date": booking_date,
+                "slack_channel_id": slack_channel_id,
+            }
+        )
+        if self.batch_exc:
+            raise self.batch_exc
+        return self.batch_result
+
+    async def book_coworking(self, *args, **kwargs):
+        self.single_calls.append({"args": args, "kwargs": kwargs})
+        raise AssertionError("single booking should not be called in this test")
+
+
+def _batch_http_error(payload, status_code=400):
+    request = httpx.Request(
+        "POST",
+        "https://backend.test/api/v1/points/coworking/book-many/",
+    )
+    response = httpx.Response(status_code, request=request, json=payload)
+    return httpx.HTTPStatusError("backend rejected batch", request=request, response=response)
+
+
+async def _run_points_action(client, *, action, text, params=None, user_id="UADMIN"):
+    executor = SkillExecutor()
+    return await executor._handle_points_action(
+        client=client,
+        action=action,
+        params=params or {"date": "2026-07-04"},
+        text=text,
+        user_id=user_id,
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=None,
+    )
+
+
+@pytest.fixture(autouse=True)
+def bot_user(monkeypatch):
+    monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+
+
+@pytest.mark.asyncio
+async def test_admin_checkin_coworking_batches_deduped_targets():
+    client = FakeCoworkingClient(
+        admin_details={"role": "admin"},
+        batch_result={
+            "date": "2026-07-04",
+            "created_count": 1,
+            "already_booked_count": 1,
+            "results": [
+                {"slack_user_id": "U1", "created": True, "already_booked": False, "points_cost": 8},
+                {"slack_user_id": "U2", "created": False, "already_booked": True, "points_cost": 8},
+            ],
+        },
+    )
+
+    result = await _run_points_action(
+        client,
+        action="admin_checkin_coworking",
+        text="<@UROO> check <@U1> <@U2> <@U1> in today",
+    )
+
+    assert client.batch_calls == [
+        {
+            "admin_slack_user_id": "UADMIN",
+            "target_slack_user_ids": ["U1", "U2"],
+            "booking_date": "2026-07-04",
+            "slack_channel_id": "C123",
+        }
+    ]
+    assert client.single_calls == []
+    assert "<@U1>: booked" in result
+    assert "<@U2>: already booked" in result
+    assert "Admin Roo Points were not charged" in result
+
+
+@pytest.mark.asyncio
+async def test_non_admin_tagged_booking_is_denied_before_booking_call():
+    client = FakeCoworkingClient(admin_details=None)
+
+    result = await _run_points_action(
+        client,
+        action="book_coworking",
+        text="book <@U1> <@U2> in today",
+        user_id="UNOTADMIN",
+    )
+
+    assert "full Points Admin" in result
+    assert client.batch_calls == []
+    assert client.single_calls == []
+
+
+@pytest.mark.asyncio
+async def test_book_coworking_with_tagged_users_routes_to_admin_batch_flow():
+    client = FakeCoworkingClient(admin_details={"role": "committee"})
+
+    result = await _run_points_action(
+        client,
+        action="book_coworking",
+        text="book <@U1> <@U2> in today",
+    )
+
+    assert client.batch_calls[0]["target_slack_user_ids"] == ["U1", "U2"]
+    assert "Checked **2** people" in result
+    assert "Admin Roo Points were not charged" in result
+
+
+@pytest.mark.asyncio
+async def test_backend_batch_failure_formats_no_bookings_created_response():
+    exc = _batch_http_error(
+        {
+            "error": "One or more users have insufficient Roo Points",
+            "errors": [
+                {
+                    "slack_user_id": "U2",
+                    "error": "Insufficient balance: 4 < 8 required",
+                }
+            ],
+        }
+    )
+    client = FakeCoworkingClient(admin_details={"role": "portfolio_lead"}, batch_exc=exc)
+
+    result = await _run_points_action(
+        client,
+        action="admin_checkin_coworking",
+        text="check <@U1> <@U2> in today",
+    )
+
+    assert "No bookings were created" in result
+    assert "One or more users have insufficient Roo Points" in result
+    assert "<@U2>: Insufficient balance: 4 < 8 required" in result

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -167,6 +167,41 @@ async def test_get_coworking_report_uses_canonical_endpoint(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_book_coworking_many_uses_canonical_endpoint_and_deduped_payload(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = kwargs["json"]
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(201, request=request, json={"created_count": 2, "results": []})
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.book_coworking_many(
+        admin_slack_user_id="<@UADMIN>",
+        target_slack_user_ids=["<@U1>", "U2", "<@U1>"],
+        booking_date="2026-07-04",
+        slack_channel_id="C123",
+    )
+
+    assert result == {"created_count": 2, "results": []}
+    assert captured["method"] == "POST"
+    assert captured["endpoint"] == "/api/v1/points/coworking/book-many/"
+    assert captured["json"]["admin_slack_user_id"] == "UADMIN"
+    assert captured["json"]["target_slack_user_ids"] == ["U1", "U2"]
+    assert captured["json"]["date"] == "2026-07-04"
+    assert captured["json"]["slack_channel_id"] == "C123"
+    assert captured["json"]["current_time"]
+
+
+@pytest.mark.asyncio
 async def test_get_data_catalog_uses_canonical_endpoint(monkeypatch):
     captured = {}
 

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -87,9 +87,10 @@ actions:
     params:
       date: {type: string}
   - name: admin_checkin_coworking
-    description: Admin — check ANOTHER member in for coworking (message mentions someone else).
+    description: Admin — check one or more OTHER members in for coworking (message mentions someone else).
     params:
       date: {type: string}
+      target_users: {type: array}
   - name: coworking_report
     description: Usage report/trends/comparisons for the coworking space.
     params:
@@ -195,7 +196,7 @@ Example responses:
 - **points**: The number of points to award (integer, positive only)
 - **reason**: A short description of why the points are being awarded or requested
 - **target_user**: A single Slack User ID (e.g., U012ABC) or mention (e.g., <@U012ABC>) of the person receiving points. For single-user awards.
-- **target_users**: A list of Slack User IDs extracted from mentions for multi-user awards. Extract ALL <@U...> patterns from the message. Example: ["U012ABC", "U034DEF"] or ["<@U012ABC>", "<@U034DEF>"]
+- **target_users**: A list of Slack User IDs extracted from mentions for multi-user awards or admin coworking check-ins. Extract ALL <@U...> patterns from the message. Example: ["U012ABC", "U034DEF"] or ["<@U012ABC>", "<@U034DEF>"]
 - **target_slack_id**: (Alias for target_user) A single Slack User ID
 - **weekly_allowance**: (Super Admin) Positive integer weekly allowance for one tagged Points Admin
 - **submission_text**: Description of work completed for task submissions
@@ -246,7 +247,7 @@ Parse user messages to identify the action and parameters:
 | `coworking report last 3/6 months` | coworking_report | "Coworking report last 3 months" |
 | `coworking report last year` | coworking_report | "Coworking report last year" |
 | `coworking book <date/today>` | book_coworking | "Book me in", "Book me in for today", "@Roo coworking book" |
-| `check/book <@USER> in <date/today>` | admin_checkin_coworking | (Admin) "Check <@U123> in", "Book <@U123> in today" |
+| `check/book <@USER...> in <date/today>` | admin_checkin_coworking | (Admin) "Check <@U123> in", "Book <@U123> <@U456> in today", "Check <@U123>, <@U456>, <@U789> in tomorrow" |
 | `coworking cancel <date>` | cancel_coworking | "Cancel my booking for Friday", "@Roo coworking cancel" |
 | `rewards`, `points rewards` | list_rewards | "What rewards are available?", "@Roo points rewards" |
 | `reward request <code>` | request_reward | "I want to get the HOTDESK_DAY reward" |
@@ -280,7 +281,7 @@ Parse the user's message to determine which action they want:
 - Treat `request ... points for ...` as `request_points`, not `award_points`
 - For admin actions, verify the Slack mention format
 - Treat coworking booking requests without a date as a booking for today
-- For admin coworking check-ins, require exactly one tagged Slack user and book that user, not the admin
+- For admin coworking check-ins, require one or more tagged Slack users and book those users, not the admin
 - For super admin actions, require exactly one tagged Slack user, never fall through into `award_points`, and require a positive numeric allowance when changing allowance
 
 ### Step 2: Permission Check
@@ -292,9 +293,10 @@ For full admin-only actions (create, edit, cancel, approve, reject, award):
 For admin coworking check-ins:
 - Roo must fail fast unless the requester is a full Points Admin
 - Partner admins are report-only and cannot check people in
-- The target user is the single non-Roo Slack mention in the message
+- The target users are the non-Roo Slack mentions in the message
 - The booking date defaults to today when omitted
-- The coworking booking must be created for the target user's Slack ID so the target user's points are deducted
+- The coworking booking must be created for each target user's Slack ID so each target user's points are deducted
+- Multiple tagged users must be booked through the backend batch flow so success/failure is all-or-nothing; admin Roo Points must not be charged
 
 For super admin actions (promote admin, revoke admin, change allowance):
 - Roo must fail fast unless the requester Slack ID is `U05QPB483K9`


### PR DESCRIPTION
## Summary
- adds Roo backend client support for `/coworking/book-many/`
- lets full Points Admins check in one or more tagged users, while non-admin tagged booking is denied before any booking call
- routes tagged `book_coworking` requests through the admin check-in flow and formats batch success/failure responses
- updates skill docs and routing eval cases for multi-person coworking phrases

## Validation
- `pytest roo-standalone/roo/tests/test_coworking_admin_batch.py`
- `pytest roo-standalone/roo/tests/test_mlai_backend_client.py`
- `pytest roo-standalone/roo/tests/test_router_catalog.py roo-standalone/roo/tests/test_routing_eval_gate.py` from an external Python 3.12 venv
- Roo `MLAIBackendClient` and `SkillExecutor` smoke-tested against the local Django backend
