### PR TITLE
Add /api/sim-patient endpoint: patient + nurse roleplay for the health-hack ward

### DIFF
--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -77,6 +77,14 @@ class Settings(BaseSettings):
     JOBS_RETRY_DELAY_SECONDS: int = 300
     JOBS_FAILURE_STOP_AFTER_DAYS: int = 3
 
+    # Simulated patient endpoint (health-hack 3D ward "Guess the Diagnosis").
+    # All optional so nothing else breaks. Bearer auth is open when the key is
+    # unset (dev). The original Slack game used reasoning_effort="high"; the game
+    # world defaults to "low" for latency (both overridable via env).
+    SIM_PATIENT_API_KEY: Optional[str] = None
+    SIM_PATIENT_MODEL: str = "gpt-5"
+    SIM_PATIENT_REASONING_EFFORT: str = "low"
+
     @property
     def default_llm_provider(self) -> str:
         """Determine default LLM provider based on available keys."""

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -2136,8 +2136,55 @@ async def api_mention(request: Request):
         channel_id=channel_id,
         thread_ts=thread_ts
     )
-    
+
     return result
+
+
+@app.post("/api/sim-patient")
+async def api_sim_patient(request: Request, settings: Settings = Depends(get_settings)):
+    """Simulated-patient roleplay for the health-hack 3D ward.
+
+    Runs the medhack "Guess the Diagnosis" case as an in-character narrator.
+    Stateless: never touches medhack game state, points, or the guess lockout.
+
+    Auth is bearer-only and applied ONLY when SIM_PATIENT_API_KEY is set (open in
+    dev). Errors: 401 bad/missing token, 404 unknown case_id, 422 missing
+    question, 502 LLM failure.
+    """
+    if settings.SIM_PATIENT_API_KEY:
+        auth = request.headers.get("Authorization", "")
+        if auth != f"Bearer {settings.SIM_PATIENT_API_KEY}":
+            raise HTTPException(status_code=401, detail="bad token")
+
+    payload = await request.json()
+    question = (payload.get("question") or "").strip()
+    if not question:
+        raise HTTPException(status_code=422, detail="question required")
+
+    # Defensive caps: bound the question length and history depth server-side.
+    question = question[:500]
+    history = payload.get("history") or []
+    if isinstance(history, list):
+        history = history[-12:]
+    else:
+        history = []
+
+    from .sim_patient import handle_question
+
+    try:
+        return await handle_question(
+            question=question,
+            history=history,
+            case_id=payload.get("case_id"),
+            player_id=payload.get("player_id") or "web-anon",
+        )
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+    except HTTPException:
+        raise
+    except Exception as exc:
+        print(f"⚠️ sim-patient LLM failure: {exc}")
+        raise HTTPException(status_code=502, detail="patient unavailable")
 
 
 def _format_tier_display(tier: str) -> str:

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -2146,10 +2146,12 @@ async def api_sim_patient(request: Request, settings: Settings = Depends(get_set
 
     Runs the medhack "Guess the Diagnosis" case as an in-character narrator.
     Stateless: never touches medhack game state, points, or the guess lockout.
+    role="nurse" answers as the reception nurse (investigation results from the
+    same case file; never adjudicates guesses).
 
     Auth is bearer-only and applied ONLY when SIM_PATIENT_API_KEY is set (open in
     dev). Errors: 401 bad/missing token, 404 unknown case_id, 422 missing
-    question, 502 LLM failure.
+    question or bad role, 502 LLM failure.
     """
     if settings.SIM_PATIENT_API_KEY:
         auth = request.headers.get("Authorization", "")
@@ -2160,6 +2162,10 @@ async def api_sim_patient(request: Request, settings: Settings = Depends(get_set
     question = (payload.get("question") or "").strip()
     if not question:
         raise HTTPException(status_code=422, detail="question required")
+
+    role = (payload.get("role") or "patient").strip().lower()
+    if role not in ("patient", "nurse"):
+        raise HTTPException(status_code=422, detail="role must be 'patient' or 'nurse'")
 
     # Defensive caps: bound the question length and history depth server-side.
     question = question[:500]
@@ -2177,6 +2183,7 @@ async def api_sim_patient(request: Request, settings: Settings = Depends(get_set
             history=history,
             case_id=payload.get("case_id"),
             player_id=payload.get("player_id") or "web-anon",
+            role=role,
         )
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -1,0 +1,307 @@
+"""
+Simulated Patient endpoint logic — Slack-free.
+
+Powers the health-hack 3D ward "Guess the Diagnosis" interaction: a player walks
+up to a patient in the game world, asks a question, and this module produces an
+in-character reply using the medhack skill's clinical case files.
+
+This module is deliberately independent of the Slack executor (whose patient
+simulator is currently DISABLED — see roo/skills/executor.py) and of the medhack
+game state. It reuses ONLY pure, local logic:
+
+  - the case YAML load (copied ~10 lines to avoid touching backend init)
+  - the fuzzy-match verdict (copied from MedHackClient._fuzzy_match)
+  - the verbatim PQM system prompt (recovered from
+    `git show 2427ff6^:roo-standalone/roo/skills/executor.py`)
+  - the guess classifier prompt (copied from executor._classify_medhack_intent)
+
+The web game is stateless: it NEVER mutates medhack game state, never awards
+points, and never enforces the one-guess lockout (out of scope — there is no
+penalty for a wrong guess here).
+"""
+from __future__ import annotations
+
+import json as _json
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from .config import get_settings
+from .llm import get_llm_client
+
+# cases.yaml lives alongside the medhack skill. Resolve relative to this file so
+# the load works regardless of the process cwd.
+CASES_FILE = Path(__file__).resolve().parent.parent / "skills" / "medhack" / "cases.yaml"
+
+# Fields that must NEVER reach the LLM prompt (the secret the player is guessing).
+_SECRET_FIELDS = ("diagnosis", "acceptable_answers")
+
+# Defensive caps (also enforced at the HTTP layer, belt-and-braces here).
+MAX_HISTORY_TURNS = 12
+
+
+# ---------------------------------------------------------------------------
+# Case loading (copied from MedHackClient._load_cases — pure, no backend init)
+# ---------------------------------------------------------------------------
+
+def _load_all_cases() -> list[dict]:
+    """Load every case from cases.yaml (pure local read, never cached globally)."""
+    with open(CASES_FILE, "r") as f:
+        data = yaml.safe_load(f)
+    return data.get("cases", [])
+
+
+def load_case(case_id: Optional[int]) -> dict:
+    """Return the full case dict (INCLUDING secrets) for a given case_id.
+
+    When ``case_id`` is None, fall back to the first case in cases.yaml. We do
+    NOT read medhack's active-case game state — the web game is stateless and
+    must never disturb the Slack game. The first case (id 1, "Salt & Static")
+    is a stable, sensible default.
+
+    Raises KeyError when a specific case_id is requested but not found (the HTTP
+    layer maps this to 404).
+    """
+    cases = _load_all_cases()
+    if not cases:
+        raise KeyError("no cases available")
+    if case_id is None:
+        return cases[0]
+    for case in cases:
+        if case.get("id") == case_id:
+            return case
+    raise KeyError(f"unknown case_id: {case_id}")
+
+
+def case_for_prompt(case: dict) -> dict:
+    """Strip the secret fields (diagnosis + acceptable_answers) before the LLM sees it."""
+    return {k: v for k, v in case.items() if k not in _SECRET_FIELDS}
+
+
+# ---------------------------------------------------------------------------
+# Guess handling
+# ---------------------------------------------------------------------------
+
+def check_guess(guess: str, case: dict) -> bool:
+    """Whether ``guess`` matches the case diagnosis.
+
+    Self-contained copy of MedHackClient._fuzzy_match: exact match against
+    acceptable_answers, then 0.75 SequenceMatcher against the primary diagnosis
+    and each acceptable answer. We do NOT import the executor or the client.
+    """
+    guess_clean = guess.strip().lower()
+    acceptable = case.get("acceptable_answers", [])
+    diagnosis = case.get("diagnosis", "").lower()
+
+    # Exact match against acceptable answers
+    if guess_clean in [a.lower() for a in acceptable]:
+        return True
+
+    # Fuzzy match against the primary diagnosis
+    if SequenceMatcher(None, guess_clean, diagnosis).ratio() >= 0.75:
+        return True
+
+    # Fuzzy match against acceptable answers
+    for answer in acceptable:
+        if SequenceMatcher(None, guess_clean, answer.lower()).ratio() >= 0.75:
+            return True
+
+    return False
+
+
+async def classify_guess(question: str) -> dict:
+    """Classify whether a message is a diagnosis guess.
+
+    Returns {"is_guess": bool, "diagnosis": str | None}. Prompt copied verbatim
+    from executor._classify_medhack_intent (gpt-4o-mini, max_tokens=100).
+    """
+    prompt = f"""You are classifying messages in a medical diagnosis guessing game. Players interact with a simulated patient and can ask questions or guess the diagnosis.
+
+A message is a DIAGNOSIS GUESS if the player is proposing what they think the medical diagnosis is. Examples:
+- "I think it's pneumonia" → guess: "pneumonia"
+- "Is it gastroenteritis?" → guess: "gastroenteritis"
+- "I guess Addison's disease" → guess: "Addison's disease"
+- "She has COPD" → guess: "COPD"
+- "Could it be lupus?" → guess: "lupus"
+- "My diagnosis is acute appendicitis" → guess: "acute appendicitis"
+- "gastroenteritis!" → guess: "gastroenteritis"
+
+NOT a guess (these are clinical questions or requests):
+- "What are her vitals?"
+- "Can I see the blood results?"
+- "Does she have any allergies?" (asking about patient history, not guessing)
+- "Order a chest X-ray"
+- "Tell me about her symptoms"
+- "What medications is she on?"
+
+Classify this message: "{question}"
+
+Respond with ONLY valid JSON, no markdown:
+{{"is_guess": true, "diagnosis": "the diagnosis"}} or {{"is_guess": false, "diagnosis": null}}"""
+
+    openai_client = get_llm_client("openai")
+    response = await openai_client.chat(
+        [{"role": "user", "content": prompt}],
+        model="gpt-4o-mini",
+        max_tokens=100,
+    )
+
+    try:
+        content = response.content.strip()
+        if content.startswith("```"):
+            content = content.split("\n", 1)[1].rsplit("```", 1)[0].strip()
+        parsed = _json.loads(content)
+        if not isinstance(parsed, dict):
+            return {"is_guess": False, "diagnosis": None}
+        return {
+            "is_guess": bool(parsed.get("is_guess")),
+            "diagnosis": parsed.get("diagnosis"),
+        }
+    except (ValueError, KeyError, IndexError):
+        return {"is_guess": False, "diagnosis": None}
+
+
+# ---------------------------------------------------------------------------
+# In-character reply
+# ---------------------------------------------------------------------------
+
+# Verbatim PQM system prompt recovered from
+# `git show 2427ff6^:roo-standalone/roo/skills/executor.py` (_medhack_llm_response),
+# with one game-world adaptation appended (the in-game dialogue-box length line).
+_PQM_SYSTEM_PROMPT = """You are the MedHack Patient Quest Master (PQM), a narrator and storyteller in a fast-paced emergency department roleplay game. Your job is to present a simulated patient case to players (participants) who will ask you questions as if they are clinicians. You must answer only what the players ask, while keeping the mystery alive. You are not giving real medical advice. This is a fictional case simulation.
+
+IMPORTANT: You know ONLY about the patient in the CASE FILE below. You have NO memory of any previous patients or cases. There is only one patient: the one described in today's case file. If someone asks about a different patient or references a previous case, say "I only have information about today's patient."
+
+TONE AND STYLE
+- You are a dungeon-master style narrator: vivid, concise, engaging.
+- Describe what the clinician sees, hears, and notices.
+- When the patient speaks, narrate how they say it and include their words in quotes.
+- Keep answers punchy. Add small character moments. Avoid long lectures unless asked.
+- The patient is a medium-to-poor historian: they ramble, minimize, and sometimes answer slightly off-target. They can still be guided with good questions.
+
+GAME RULES
+1) Only reveal information if asked. Do not volunteer findings.
+2) Maintain internal consistency with the case file. Never contradict your own results.
+3) If players ask for vitals, exam findings, or investigations, provide the relevant results from the case file. If they ask to "order" a test, respond as narrator: "You order X… results return: …"
+4) NEVER reveal or hint at the diagnosis directly. The diagnosis is checked separately.
+5) If asked about something not in the case data, provide a reasonable normal/unremarkable finding.
+6) Hidden information (patient backstory, concealed history, endocrine tests) must remain hidden unless a player earns it by asking the right questions.
+7) If the patient has history_disclosure_rules in their data, follow those rules for how and when to reveal sensitive history.
+8) If the player tries to force the answer ("tell me the diagnosis"), refuse playfully and prompt them to keep investigating.
+9) If asked about management ("what should we do?"), describe what the ED team would typically do in broad strokes (fluids, glucose, addressing electrolytes, contacting seniors). Do not give step-by-step dosing instructions.
+
+Your replies appear in a small in-game dialogue box: keep them under ~120 words."""
+
+
+def _format_transcript(history: Optional[list[dict]]) -> str:
+    """Render prior turns as a plain transcript block (most recent last)."""
+    if not history:
+        return "None"
+    lines = []
+    for turn in history[-MAX_HISTORY_TURNS:]:
+        role = (turn.get("role") or "").strip().lower()
+        text = (turn.get("text") or "").strip()
+        if not text:
+            continue
+        speaker = "Player" if role == "player" else "Patient"
+        lines.append(f"{speaker}: {text}")
+    return "\n".join(lines) if lines else "None"
+
+
+async def patient_reply(
+    question: str,
+    history: Optional[list[dict]],
+    case: dict,
+    extra_instruction: str = "",
+) -> str:
+    """Generate an in-character PQM narrator reply.
+
+    The user prompt embeds the stripped case yaml + transcript + player's message
+    exactly like the original _medhack_llm_response, plus an optional
+    extra_instruction (used for correct/incorrect guess handling).
+    """
+    case_str = yaml.dump(case_for_prompt(case), default_flow_style=False)
+    transcript = _format_transcript(history)
+
+    prompt = f"""CASE FILE (INTERNAL TRUTH - use this to answer questions):
+{case_str}
+
+Previous conversation in this thread:
+{transcript}
+
+{extra_instruction}
+
+Player's message: "{question}"
+
+Respond in character as the PQM narrator. Remember: only reveal what was asked for."""
+
+    settings = get_settings()
+    openai_client = get_llm_client("openai")
+    response = await openai_client.chat(
+        [
+            {"role": "system", "content": _PQM_SYSTEM_PROMPT},
+            {"role": "user", "content": prompt},
+        ],
+        model=settings.SIM_PATIENT_MODEL,
+        max_tokens=700,
+        reasoning_effort=settings.SIM_PATIENT_REASONING_EFFORT,
+    )
+    return response.content
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+async def handle_question(
+    question: str,
+    history: Optional[list[dict]] = None,
+    case_id: Optional[int] = None,
+    player_id: str = "web-anon",
+) -> dict:
+    """Orchestrate: load case → classify → reply (with guess verdict) → response dict.
+
+    Never mutates game state. On a correct guess the LLM is asked to celebrate and
+    reveal the diagnosis in-character; on a wrong guess it rebuffs clinically
+    without hinting. There is no one-guess lockout and no points here.
+    """
+    history = (history or [])[-MAX_HISTORY_TURNS:]
+    case = load_case(case_id)
+
+    classification = await classify_guess(question)
+    is_guess = bool(classification.get("is_guess"))
+
+    correct: Optional[bool] = None
+    diagnosis: Optional[str] = None
+    extra_instruction = ""
+
+    if is_guess:
+        correct = check_guess(classification.get("diagnosis") or question, case)
+        if correct:
+            diagnosis = case.get("diagnosis")
+            extra_instruction = (
+                f"The player just guessed correctly: {diagnosis}. Celebrate warmly, "
+                "reveal the diagnosis, and stay in narrator character."
+            )
+        else:
+            # Wording adapted from the disabled _handle_guess_result wrong-guess branch.
+            extra_instruction = (
+                "The player just made an INCORRECT diagnosis guess. Respond clinically: "
+                "let them know their guess was wrong and suggest they review the findings "
+                "again. Do NOT reveal the correct diagnosis or hint at it."
+            )
+
+    reply = await patient_reply(question, history, case, extra_instruction=extra_instruction)
+
+    return {
+        "reply": reply,
+        "case_id": case.get("id"),
+        "case_title": case.get("title"),
+        "patient_name": (case.get("patient") or {}).get("name"),
+        "presenting_complaint": (case.get("presenting_complaint") or "").strip(),
+        "is_guess": is_guess,
+        "correct": correct,          # true/false only when is_guess
+        "diagnosis": diagnosis,      # set ONLY when is_guess && correct
+    }

--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -22,6 +22,7 @@ penalty for a wrong guess here).
 from __future__ import annotations
 
 import json as _json
+import re
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Optional
@@ -35,8 +36,10 @@ from .llm import get_llm_client
 # the load works regardless of the process cwd.
 CASES_FILE = Path(__file__).resolve().parent.parent / "skills" / "medhack" / "cases.yaml"
 
-# Fields that must NEVER reach the LLM prompt (the secret the player is guessing).
-_SECRET_FIELDS = ("diagnosis", "acceptable_answers")
+# Fields that must NEVER reach the LLM prompt. `hints` is authored coaching that
+# names/points at the answer (the original Slack game only ever revealed
+# hints[:hint_level]; stateless here means hint_level 0, i.e. none).
+_SECRET_FIELDS = ("diagnosis", "acceptable_answers", "hints")
 
 # Defensive caps (also enforced at the HTTP layer, belt-and-braces here).
 MAX_HISTORY_TURNS = 12
@@ -69,6 +72,11 @@ def load_case(case_id: Optional[int]) -> dict:
         raise KeyError("no cases available")
     if case_id is None:
         return cases[0]
+    # Coerce so a string id from a JSON body (e.g. "1") still matches int ids.
+    try:
+        case_id = int(case_id)
+    except (TypeError, ValueError):
+        raise KeyError(f"invalid case_id: {case_id!r}")
     for case in cases:
         if case.get("id") == case_id:
             return case
@@ -76,8 +84,24 @@ def load_case(case_id: Optional[int]) -> dict:
 
 
 def case_for_prompt(case: dict) -> dict:
-    """Strip the secret fields (diagnosis + acceptable_answers) before the LLM sees it."""
+    """Strip the secret fields (diagnosis, acceptable_answers, hints) before the LLM sees it."""
     return {k: v for k, v in case.items() if k not in _SECRET_FIELDS}
+
+
+def _redact_answer(case_text: str, case: dict) -> str:
+    """Redact the primary diagnosis string from the serialized case text.
+
+    Defense-in-depth: some case notes editorialise the answer verbatim
+    (e.g. investigations.*.note = "...pathognomonic for salicylate toxicity"),
+    so even with the diagnosis KEY stripped the answer can sit in free text and
+    be echoed under prompt injection. We redact the primary `diagnosis` string
+    only — NOT the acceptable-answer synonyms, which can legitimately appear as
+    discoverable findings the player earns by ordering the right test.
+    """
+    dx = (case.get("diagnosis") or "").strip()
+    if not dx:
+        return case_text
+    return re.sub(re.escape(dx), "[diagnosis withheld]", case_text, flags=re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------
@@ -91,21 +115,23 @@ def check_guess(guess: str, case: dict) -> bool:
     acceptable_answers, then 0.75 SequenceMatcher against the primary diagnosis
     and each acceptable answer. We do NOT import the executor or the client.
     """
-    guess_clean = guess.strip().lower()
-    acceptable = case.get("acceptable_answers", [])
-    diagnosis = case.get("diagnosis", "").lower()
+    guess_clean = str(guess).strip().lower()
+    # Coerce defensively: a malformed case (null/non-string values) must not
+    # crash the whole turn.
+    acceptable = [str(a).lower() for a in (case.get("acceptable_answers") or [])]
+    diagnosis = (case.get("diagnosis") or "").lower()
 
     # Exact match against acceptable answers
-    if guess_clean in [a.lower() for a in acceptable]:
+    if guess_clean in acceptable:
         return True
 
     # Fuzzy match against the primary diagnosis
-    if SequenceMatcher(None, guess_clean, diagnosis).ratio() >= 0.75:
+    if diagnosis and SequenceMatcher(None, guess_clean, diagnosis).ratio() >= 0.75:
         return True
 
     # Fuzzy match against acceptable answers
     for answer in acceptable:
-        if SequenceMatcher(None, guess_clean, answer.lower()).ratio() >= 0.75:
+        if SequenceMatcher(None, guess_clean, answer).ratio() >= 0.75:
             return True
 
     return False
@@ -155,9 +181,12 @@ Respond with ONLY valid JSON, no markdown:
         parsed = _json.loads(content)
         if not isinstance(parsed, dict):
             return {"is_guess": False, "diagnosis": None}
+        diag = parsed.get("diagnosis")
         return {
             "is_guess": bool(parsed.get("is_guess")),
-            "diagnosis": parsed.get("diagnosis"),
+            # The model occasionally emits a non-string (array/number); coerce
+            # to None so check_guess never receives a non-string.
+            "diagnosis": diag if isinstance(diag, str) else None,
         }
     except (ValueError, KeyError, IndexError):
         return {"is_guess": False, "diagnosis": None}
@@ -201,6 +230,8 @@ def _format_transcript(history: Optional[list[dict]]) -> str:
         return "None"
     lines = []
     for turn in history[-MAX_HISTORY_TURNS:]:
+        if not isinstance(turn, dict):
+            continue
         role = (turn.get("role") or "").strip().lower()
         text = (turn.get("text") or "").strip()
         if not text:
@@ -222,7 +253,7 @@ async def patient_reply(
     exactly like the original _medhack_llm_response, plus an optional
     extra_instruction (used for correct/incorrect guess handling).
     """
-    case_str = yaml.dump(case_for_prompt(case), default_flow_style=False)
+    case_str = _redact_answer(yaml.dump(case_for_prompt(case), default_flow_style=False), case)
     transcript = _format_transcript(history)
 
     prompt = f"""CASE FILE (INTERNAL TRUTH - use this to answer questions):

--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -5,6 +5,13 @@ Powers the health-hack 3D ward "Guess the Diagnosis" interaction: a player walks
 up to a patient in the game world, asks a question, and this module produces an
 in-character reply using the medhack skill's clinical case files.
 
+Two personas share the endpoint via ``role``:
+  - "patient" (default): the PQM narrator voicing the patient in cubicle 3.
+    Guesses are classified and adjudicated.
+  - "nurse": the reception nurse who reads out investigation results (bloods,
+    imaging, ECG, obs) from the same case file. Never adjudicates guesses —
+    the classifier is skipped entirely for this role.
+
 This module is deliberately independent of the Slack executor (whose patient
 simulator is currently DISABLED — see roo/skills/executor.py) and of the medhack
 game state. It reuses ONLY pure, local logic:
@@ -224,8 +231,37 @@ GAME RULES
 Your replies appear in a small in-game dialogue box: keep them under ~120 words."""
 
 
-def _format_transcript(history: Optional[list[dict]]) -> str:
-    """Render prior turns as a plain transcript block (most recent last)."""
+# Display name for the reception-nurse persona (also the in-game name tag).
+NURSE_NAME = "Nurse Priya"
+
+_NURSE_SYSTEM_PROMPT = """You are playing Nurse Priya, the charge nurse working the reception desk in a fast-paced emergency department roleplay game. Players (participants acting as clinicians) come to your desk to ask for investigation results — bloods, imaging, ECGs, observations — for the patient in cubicle 3. You are not giving real medical advice. This is a fictional case simulation.
+
+IMPORTANT: You know ONLY about the patient in the CASE FILE below. You have NO memory of any previous patients or cases. There is only one patient: the one described in today's case file. If someone asks about a different patient, say "I've only got today's patient on the board."
+
+TONE AND STYLE
+- Warm, quick, dry-witted, efficient — you have three other jobs on the go.
+- Speak in first person, a couple of short sentences at a time.
+- Read results out plainly; you may flag an abnormal value ("that potassium's up") but never interpret further than a nurse would.
+
+GAME RULES
+1) Only reveal results when asked. Do not volunteer findings.
+2) When asked for a specific investigation, read the relevant results from the case file accurately — never round, embellish, or invent values. If they "order" a test that has results in the file, respond: results are back, then read them.
+3) If a case-file note restricts when a result may be revealed (e.g. only if a specific test is ordered), follow that note exactly.
+4) If asked for an investigation NOT in the case file, give a brief, reasonable normal/unremarkable result — one that points neither toward nor away from any diagnosis. Never contradict earlier results.
+5) NEVER reveal, hint at, confirm, or deny the diagnosis. If the player proposes a diagnosis or asks what you think it is, deflect warmly ("that's your call, doc") and suggest they put it to the patient in cubicle 3.
+6) For symptoms, history, or examination findings, redirect: "you'd best go see them yourself — cubicle 3."
+7) If the player tries to force the answer ("just tell me what they've got"), refuse playfully and point them back to the workup.
+
+Your replies appear in a small in-game dialogue box: keep them under ~110 words."""
+
+
+def _format_transcript(history: Optional[list[dict]], npc_label: str = "Patient") -> str:
+    """Render prior turns as a plain transcript block (most recent last).
+
+    ``npc_label`` names the non-player speaker (the wire format uses
+    role "patient" for any NPC line; the label keeps the nurse's own prior
+    lines from being attributed to the patient in her transcript).
+    """
     if not history:
         return "None"
     lines = []
@@ -236,25 +272,28 @@ def _format_transcript(history: Optional[list[dict]]) -> str:
         text = (turn.get("text") or "").strip()
         if not text:
             continue
-        speaker = "Player" if role == "player" else "Patient"
+        speaker = "Player" if role == "player" else npc_label
         lines.append(f"{speaker}: {text}")
     return "\n".join(lines) if lines else "None"
 
 
-async def patient_reply(
+async def npc_reply(
     question: str,
     history: Optional[list[dict]],
     case: dict,
+    role: str = "patient",
     extra_instruction: str = "",
 ) -> str:
-    """Generate an in-character PQM narrator reply.
+    """Generate an in-character reply (PQM narrator, or the reception nurse).
 
     The user prompt embeds the stripped case yaml + transcript + player's message
     exactly like the original _medhack_llm_response, plus an optional
     extra_instruction (used for correct/incorrect guess handling).
     """
     case_str = _redact_answer(yaml.dump(case_for_prompt(case), default_flow_style=False), case)
-    transcript = _format_transcript(history)
+    is_nurse = role == "nurse"
+    transcript = _format_transcript(history, npc_label="Nurse" if is_nurse else "Patient")
+    persona = "the reception nurse" if is_nurse else "the PQM narrator"
 
     prompt = f"""CASE FILE (INTERNAL TRUTH - use this to answer questions):
 {case_str}
@@ -266,13 +305,13 @@ Previous conversation in this thread:
 
 Player's message: "{question}"
 
-Respond in character as the PQM narrator. Remember: only reveal what was asked for."""
+Respond in character as {persona}. Remember: only reveal what was asked for."""
 
     settings = get_settings()
     openai_client = get_llm_client("openai")
     response = await openai_client.chat(
         [
-            {"role": "system", "content": _PQM_SYSTEM_PROMPT},
+            {"role": "system", "content": _NURSE_SYSTEM_PROMPT if is_nurse else _PQM_SYSTEM_PROMPT},
             {"role": "user", "content": prompt},
         ],
         model=settings.SIM_PATIENT_MODEL,
@@ -291,46 +330,55 @@ async def handle_question(
     history: Optional[list[dict]] = None,
     case_id: Optional[int] = None,
     player_id: str = "web-anon",
+    role: str = "patient",
 ) -> dict:
     """Orchestrate: load case → classify → reply (with guess verdict) → response dict.
 
     Never mutates game state. On a correct guess the LLM is asked to celebrate and
     reveal the diagnosis in-character; on a wrong guess it rebuffs clinically
     without hinting. There is no one-guess lockout and no points here.
+
+    role="nurse" answers as the reception nurse instead: the guess classifier is
+    skipped entirely (guesses go to the patient), so is_guess is always False and
+    the diagnosis can never be revealed through this persona.
     """
     history = (history or [])[-MAX_HISTORY_TURNS:]
     case = load_case(case_id)
-
-    classification = await classify_guess(question)
-    is_guess = bool(classification.get("is_guess"))
+    is_nurse = role == "nurse"
 
     correct: Optional[bool] = None
     diagnosis: Optional[str] = None
     extra_instruction = ""
+    is_guess = False
 
-    if is_guess:
-        correct = check_guess(classification.get("diagnosis") or question, case)
-        if correct:
-            diagnosis = case.get("diagnosis")
-            extra_instruction = (
-                f"The player just guessed correctly: {diagnosis}. Celebrate warmly, "
-                "reveal the diagnosis, and stay in narrator character."
-            )
-        else:
-            # Wording adapted from the disabled _handle_guess_result wrong-guess branch.
-            extra_instruction = (
-                "The player just made an INCORRECT diagnosis guess. Respond clinically: "
-                "let them know their guess was wrong and suggest they review the findings "
-                "again. Do NOT reveal the correct diagnosis or hint at it."
-            )
+    if not is_nurse:
+        classification = await classify_guess(question)
+        is_guess = bool(classification.get("is_guess"))
 
-    reply = await patient_reply(question, history, case, extra_instruction=extra_instruction)
+        if is_guess:
+            correct = check_guess(classification.get("diagnosis") or question, case)
+            if correct:
+                diagnosis = case.get("diagnosis")
+                extra_instruction = (
+                    f"The player just guessed correctly: {diagnosis}. Celebrate warmly, "
+                    "reveal the diagnosis, and stay in narrator character."
+                )
+            else:
+                # Wording adapted from the disabled _handle_guess_result wrong-guess branch.
+                extra_instruction = (
+                    "The player just made an INCORRECT diagnosis guess. Respond clinically: "
+                    "let them know their guess was wrong and suggest they review the findings "
+                    "again. Do NOT reveal the correct diagnosis or hint at it."
+                )
+
+    reply = await npc_reply(question, history, case, role=role, extra_instruction=extra_instruction)
 
     return {
         "reply": reply,
         "case_id": case.get("id"),
         "case_title": case.get("title"),
-        "patient_name": (case.get("patient") or {}).get("name"),
+        # The speaker's display name — the in-game dialogue header / name tag.
+        "patient_name": NURSE_NAME if is_nurse else (case.get("patient") or {}).get("name"),
         "presenting_complaint": (case.get("presenting_complaint") or "").strip(),
         "is_guess": is_guess,
         "correct": correct,          # true/false only when is_guess

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -209,3 +209,75 @@ def test_422_when_question_missing(monkeypatch):
     client = TestClient(app)
     resp = client.post("/api/sim-patient", json={"question": "   "})
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Regression: no case may leak the diagnosis or hints into the LLM prompt
+# ---------------------------------------------------------------------------
+
+def test_no_case_leaks_diagnosis_or_hints_into_prompt():
+    """For EVERY case in cases.yaml, the case text embedded in the LLM prompt
+    (case_for_prompt → yaml → _redact_answer) must NOT contain the primary
+    diagnosis string, the secret keys, or the authored hints. Guards against
+    the deny-list gap where notes/hints named the answer verbatim."""
+    import yaml as _yaml
+
+    cases = sim_patient._load_all_cases()
+    assert cases, "expected cases to load"
+    for case in cases:
+        cid = case.get("id")
+        stripped = sim_patient.case_for_prompt(case)
+        assert "hints" not in stripped, f"case {cid} leaks hints key"
+        assert "diagnosis" not in stripped, f"case {cid} leaks diagnosis key"
+        assert "acceptable_answers" not in stripped, f"case {cid} leaks acceptable_answers key"
+
+        prompt_text = sim_patient._redact_answer(
+            _yaml.dump(stripped, default_flow_style=False), case
+        )
+        dx = case["diagnosis"]
+        assert dx.lower() not in prompt_text.lower(), (
+            f"case {cid} leaks primary diagnosis '{dx}' into the prompt"
+        )
+        # hint free-text must be gone too
+        for hint in case.get("hints", []):
+            assert str(hint) not in prompt_text, f"case {cid} leaks a hint into the prompt"
+
+
+# ---------------------------------------------------------------------------
+# Robustness: malformed input degrades gracefully instead of 502-ing
+# ---------------------------------------------------------------------------
+
+def test_malformed_history_item_does_not_crash(monkeypatch):
+    _install_fake(monkeypatch, '{"is_guess": false, "diagnosis": null}')
+    # history with a non-dict item (a direct caller could send this)
+    result = _run(
+        sim_patient.handle_question("what are her vitals?", history=["not-a-dict", None, 123])
+    )
+    assert result["is_guess"] is False
+    assert result["reply"] == "The patient blinks slowly."
+
+
+def test_non_string_classifier_diagnosis_does_not_crash(monkeypatch):
+    # classifier returns a truthy NON-string diagnosis (array) — must not crash.
+    _install_fake(monkeypatch, '{"is_guess": true, "diagnosis": ["adrenal crisis"]}')
+    result = _run(sim_patient.handle_question("is it adrenal crisis?"))
+    assert result["is_guess"] is True
+    # diagnosis coerced to None → check_guess falls back to the raw question,
+    # which fuzzy-matches "adrenal crisis" → correct.
+    assert result["correct"] is True
+    assert result["diagnosis"] == "Adrenal Crisis"
+
+
+def test_string_case_id_resolves(monkeypatch):
+    # A string id from a JSON body still resolves to the int-keyed case.
+    assert sim_patient.load_case("1")["id"] == 1
+    with pytest.raises(KeyError):
+        sim_patient.load_case("999")
+
+
+def test_check_guess_tolerates_malformed_case():
+    # A case authored with diagnosis:null / non-string acceptable answers must
+    # not crash the guess check.
+    bad = {"diagnosis": None, "acceptable_answers": [None, 123, "pneumonia"]}
+    assert sim_patient.check_guess("pneumonia", bad) is True
+    assert sim_patient.check_guess("something else", bad) is False

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -1,0 +1,211 @@
+"""Hermetic tests for the simulated-patient endpoint logic (no real LLM, no network).
+
+Covers plan §2.5:
+  (a) case loads + secrets stripped from the prompt payload
+  (b) a non-guess question returns is_guess: false
+  (c) a guess matching acceptable_answers/fuzzy diagnosis returns correct: true + diagnosis
+  (d) a wrong guess returns correct: false and no diagnosis
+  (e) 401 when SIM_PATIENT_API_KEY is set and the bearer header is missing (TestClient)
+"""
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from roo import sim_patient
+
+
+class _FakeLLMResponse:
+    def __init__(self, content: str):
+        self.content = content
+
+
+class _FakeLLMClient:
+    """Records every chat() call and returns canned content.
+
+    Both the guess classifier (gpt-4o-mini) and the narrator reply route through
+    get_llm_client("openai").chat(...). We branch on the model kwarg so a single
+    fake serves both: gpt-4o-mini → the classifier JSON, anything else → reply.
+    """
+
+    def __init__(self, classifier_json: str, reply_text: str = "The patient blinks slowly."):
+        self.classifier_json = classifier_json
+        self.reply_text = reply_text
+        self.calls: list[dict] = []
+
+    async def chat(self, messages, **kwargs):
+        self.calls.append({"messages": messages, "kwargs": kwargs})
+        if kwargs.get("model") == "gpt-4o-mini":
+            return _FakeLLMResponse(self.classifier_json)
+        return _FakeLLMResponse(self.reply_text)
+
+
+def _install_fake(monkeypatch, classifier_json, reply_text="The patient blinks slowly."):
+    fake = _FakeLLMClient(classifier_json, reply_text)
+    # sim_patient imports get_llm_client into its own namespace.
+    monkeypatch.setattr(sim_patient, "get_llm_client", lambda provider=None: fake)
+    return fake
+
+
+def _run(coro):
+    # Use a fresh loop rather than asyncio.get_event_loop() — in the full-suite
+    # run another test may have closed/detached the main-thread loop, which makes
+    # get_event_loop() raise "no current event loop".
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# (a) case loads + secrets stripped from the prompt payload
+# ---------------------------------------------------------------------------
+
+def test_case_loads_and_secrets_stripped_from_prompt(monkeypatch):
+    fake = _install_fake(monkeypatch, '{"is_guess": false, "diagnosis": null}')
+
+    result = _run(sim_patient.handle_question("what are her vitals?"))
+
+    # Case 1 loaded by default.
+    assert result["case_id"] == 1
+    assert result["case_title"] == "Salt & Static"
+    assert result["patient_name"] == "Sasha 'Sash' Nguyen"
+    assert result["presenting_complaint"].startswith("27F")
+
+    # The narrator user-prompt payload must NOT contain the secret answer.
+    reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
+    assert reply_calls, "expected a narrator reply LLM call"
+    user_prompt = reply_calls[0]["messages"][1]["content"]
+    assert "Adrenal Crisis" not in user_prompt
+    assert "acceptable_answers" not in user_prompt
+    assert "addisonian crisis" not in user_prompt
+    # But the case content (vitals etc.) IS present.
+    assert "CASE FILE" in user_prompt
+
+    # case_for_prompt directly strips the secret fields.
+    full = sim_patient.load_case(1)
+    stripped = sim_patient.case_for_prompt(full)
+    assert "diagnosis" not in stripped
+    assert "acceptable_answers" not in stripped
+    assert "diagnosis" in full  # original untouched
+
+
+# ---------------------------------------------------------------------------
+# (b) non-guess → is_guess false
+# ---------------------------------------------------------------------------
+
+def test_non_guess_question(monkeypatch):
+    _install_fake(monkeypatch, '{"is_guess": false, "diagnosis": null}')
+
+    result = _run(sim_patient.handle_question("what medications is she on?"))
+
+    assert result["is_guess"] is False
+    assert result["correct"] is None
+    assert result["diagnosis"] is None
+    assert result["reply"] == "The patient blinks slowly."
+
+
+# ---------------------------------------------------------------------------
+# (c) correct guess (via acceptable_answers / fuzzy) → correct true + diagnosis
+# ---------------------------------------------------------------------------
+
+def test_correct_guess_reveals_diagnosis(monkeypatch):
+    fake = _install_fake(
+        monkeypatch,
+        '{"is_guess": true, "diagnosis": "addisonian crisis"}',
+        reply_text="Sash grins weakly. \"Yeah… that's it.\"",
+    )
+
+    result = _run(sim_patient.handle_question("is it addisonian crisis?"))
+
+    assert result["is_guess"] is True
+    assert result["correct"] is True
+    assert result["diagnosis"] == "Adrenal Crisis"
+
+    # The reply prompt should carry the celebratory extra instruction with the dx.
+    reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
+    user_prompt = reply_calls[0]["messages"][1]["content"]
+    assert "guessed correctly" in user_prompt
+    assert "Adrenal Crisis" in user_prompt  # revealed to the LLM only on a correct guess
+
+
+def test_correct_guess_via_fuzzy_match(monkeypatch):
+    # "adrenal crises" (typo) fuzzy-matches "adrenal crisis" at >= 0.75.
+    _install_fake(monkeypatch, '{"is_guess": true, "diagnosis": "adrenal crises"}')
+
+    result = _run(sim_patient.handle_question("adrenal crises?"))
+
+    assert result["is_guess"] is True
+    assert result["correct"] is True
+    assert result["diagnosis"] == "Adrenal Crisis"
+
+
+# ---------------------------------------------------------------------------
+# (d) wrong guess → correct false, no diagnosis
+# ---------------------------------------------------------------------------
+
+def test_wrong_guess_no_diagnosis(monkeypatch):
+    fake = _install_fake(monkeypatch, '{"is_guess": true, "diagnosis": "appendicitis"}')
+
+    result = _run(sim_patient.handle_question("is it appendicitis?"))
+
+    assert result["is_guess"] is True
+    assert result["correct"] is False
+    assert result["diagnosis"] is None
+
+    # Wrong-guess reply prompt must NOT contain the real answer.
+    reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
+    user_prompt = reply_calls[0]["messages"][1]["content"]
+    assert "INCORRECT" in user_prompt
+    assert "Adrenal Crisis" not in user_prompt
+
+
+# ---------------------------------------------------------------------------
+# (e) 401 when key set and bearer header missing (FastAPI TestClient)
+# ---------------------------------------------------------------------------
+
+def test_401_when_key_set_and_header_missing(monkeypatch):
+    from fastapi.testclient import TestClient
+    from roo import config
+    from roo.main import app
+
+    # Force a Settings instance with the bearer key set. get_settings() is a
+    # cached singleton, so replace it and restore the original key afterward to
+    # avoid leaking mutated state into the full-suite run.
+    real = config.get_settings()
+    monkeypatch.setattr(real, "SIM_PATIENT_API_KEY", "secret-key", raising=False)
+    monkeypatch.setattr(config, "get_settings", lambda: real)
+
+    # Do NOT use `with TestClient(app)` — that would run the lifespan (background
+    # retry loops / agent load). A bare client dispatches routes without lifespan.
+    client = TestClient(app)
+
+    # Missing header → 401.
+    resp = client.post("/api/sim-patient", json={"question": "hi"})
+    assert resp.status_code == 401
+
+    # Wrong token → 401.
+    resp = client.post(
+        "/api/sim-patient",
+        json={"question": "hi"},
+        headers={"Authorization": "Bearer wrong"},
+    )
+    assert resp.status_code == 401
+
+
+def test_422_when_question_missing(monkeypatch):
+    from fastapi.testclient import TestClient
+    from roo import config
+    from roo.main import app
+
+    real = config.get_settings()
+    monkeypatch.setattr(real, "SIM_PATIENT_API_KEY", None, raising=False)  # auth open
+    monkeypatch.setattr(config, "get_settings", lambda: real)
+
+    client = TestClient(app)
+    resp = client.post("/api/sim-patient", json={"question": "   "})
+    assert resp.status_code == 422

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -281,3 +281,79 @@ def test_check_guess_tolerates_malformed_case():
     bad = {"diagnosis": None, "acceptable_answers": [None, 123, "pneumonia"]}
     assert sim_patient.check_guess("pneumonia", bad) is True
     assert sim_patient.check_guess("something else", bad) is False
+
+
+# ---------------------------------------------------------------------------
+# Nurse role: results persona, no guess adjudication, no secret leak
+# ---------------------------------------------------------------------------
+
+def test_nurse_role_skips_classifier_and_never_adjudicates(monkeypatch):
+    # Even a blatant guess phrased at the nurse must NOT be classified or
+    # adjudicated — the classifier (gpt-4o-mini) must never be called.
+    fake = _install_fake(
+        monkeypatch,
+        '{"is_guess": true, "diagnosis": "adrenal crisis"}',  # would win if consulted
+        reply_text='"That\'s your call, doc — want me to chase anything else?"',
+    )
+
+    result = _run(sim_patient.handle_question("is it adrenal crisis?", role="nurse"))
+
+    assert result["is_guess"] is False
+    assert result["correct"] is None
+    assert result["diagnosis"] is None
+    assert result["patient_name"] == sim_patient.NURSE_NAME
+    assert result["case_id"] == 1  # same case file as the patient
+
+    classifier_calls = [c for c in fake.calls if c["kwargs"].get("model") == "gpt-4o-mini"]
+    assert not classifier_calls, "nurse role must never invoke the guess classifier"
+
+    # The reply call uses the nurse persona, not the PQM narrator.
+    reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
+    assert len(reply_calls) == 1
+    system_prompt = reply_calls[0]["messages"][0]["content"]
+    assert "Nurse Priya" in system_prompt
+    assert "Patient Quest Master" not in system_prompt
+
+
+def test_nurse_prompt_carries_case_but_no_secrets(monkeypatch):
+    fake = _install_fake(monkeypatch, "{}", reply_text='"Bloods are back: sodium 122."')
+
+    result = _run(sim_patient.handle_question("can I get the bloods?", role="nurse"))
+    assert result["reply"].startswith('"Bloods')
+
+    reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
+    user_prompt = reply_calls[0]["messages"][1]["content"]
+    # Case content present (so she can actually read results out)…
+    assert "CASE FILE" in user_prompt
+    assert "122 mmol/L" in user_prompt
+    # …but never the secret answer, keys, or hints.
+    assert "Adrenal Crisis" not in user_prompt
+    assert "acceptable_answers" not in user_prompt
+    assert "addisonian" not in user_prompt.lower()
+    assert "hints" not in user_prompt
+
+
+def test_nurse_transcript_labels_prior_npc_lines_as_nurse():
+    text = sim_patient._format_transcript(
+        [
+            {"role": "player", "text": "bloods please"},
+            {"role": "patient", "text": "Sodium's 122, potassium 6.1."},
+        ],
+        npc_label="Nurse",
+    )
+    assert "Nurse: Sodium's 122" in text
+    assert "Patient:" not in text
+
+
+def test_422_when_role_invalid(monkeypatch):
+    from fastapi.testclient import TestClient
+    from roo import config
+    from roo.main import app
+
+    real = config.get_settings()
+    monkeypatch.setattr(real, "SIM_PATIENT_API_KEY", None, raising=False)  # auth open
+    monkeypatch.setattr(config, "get_settings", lambda: real)
+
+    client = TestClient(app)
+    resp = client.post("/api/sim-patient", json={"question": "hi", "role": "doctor"})
+    assert resp.status_code == 422


### PR DESCRIPTION
Backs the health-hack 3D ward's **Guess the Diagnosis** interaction (companion PR: MLAI-AUS-Inc/health-hack#4). Slack-free and stateless — it never touches medhack game state, points, or the guess lockout.

## What's in it
- **`roo/sim_patient.py`** — loads the medhack case file, classifies whether a message is a diagnosis guess (gpt-4o-mini), fuzzy-matches the guess, and generates an in-character reply using the recovered PQM narrator prompt. The secret `diagnosis`/`acceptable_answers`/`hints` are stripped from the prompt and the primary diagnosis string is redacted from free text, so the answer can't leak.
- **`role="nurse"`** — a reception-nurse persona that reads out investigation results (bloods, imaging, ECG, obs) from the same case file and honours reveal-restriction notes. The guess classifier is skipped entirely for this role, so the nurse can never adjudicate or reveal the diagnosis.
- **`POST /api/sim-patient`** in `main.py` — bearer auth applied only when `SIM_PATIENT_API_KEY` is set (open in dev); 401 / 404 / 422 / 502.
- **16 hermetic tests** (no network, no real LLM), including a regression test asserting no case leaks its diagnosis/hints into the prompt.

## Notes
- Runtime needs a valid `OPENAI_API_KEY` for the live roleplay; the health-hack side degrades to an offline mock when this endpoint is unavailable.
- Rebased onto current `main` (the branch's original base has since been squash-merged separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)