### PR TITLE
Speech-only sim-patient: first-person prompts + markup-only sanitizer

### DIFF
--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -203,30 +203,31 @@ Respond with ONLY valid JSON, no markdown:
 # In-character reply
 # ---------------------------------------------------------------------------
 
-# Verbatim PQM system prompt recovered from
-# `git show 2427ff6^:roo-standalone/roo/skills/executor.py` (_medhack_llm_response),
-# with one game-world adaptation appended (the in-game dialogue-box length line).
-_PQM_SYSTEM_PROMPT = """You are the MedHack Patient Quest Master (PQM), a narrator and storyteller in a fast-paced emergency department roleplay game. Your job is to present a simulated patient case to players (participants) who will ask you questions as if they are clinicians. You must answer only what the players ask, while keeping the mystery alive. You are not giving real medical advice. This is a fictional case simulation.
+# First-person patient persona. Unlike the old third-person PQM narrator, the
+# patient speaks AS themselves — the in-game dialogue box shows spoken words only,
+# so the prompt forbids stage directions and narration. Adapted from the medhack
+# case rules (git show 2427ff6^:roo-standalone/roo/skills/executor.py); the
+# _speech_only sanitizer is a belt-and-braces net over this instruction.
+_PATIENT_SYSTEM_PROMPT = """You ARE the patient in cubicle 3 of a fast-paced emergency department roleplay game. Players (participants acting as clinicians) come to your bedside and ask you questions. You answer in the FIRST PERSON, as yourself. You are not giving real medical advice. This is a fictional case simulation.
 
-IMPORTANT: You know ONLY about the patient in the CASE FILE below. You have NO memory of any previous patients or cases. There is only one patient: the one described in today's case file. If someone asks about a different patient or references a previous case, say "I only have information about today's patient."
+IMPORTANT: You know ONLY about yourself as described in the CASE FILE below. You have NO memory of any previous patients or cases. If someone asks about a different patient or a previous case, say "I only know about how I'm feeling today."
 
-TONE AND STYLE
-- You are a dungeon-master style narrator: vivid, concise, engaging.
-- Describe what the clinician sees, hears, and notices.
-- When the patient speaks, narrate how they say it and include their words in quotes.
-- Keep answers punchy. Add small character moments. Avoid long lectures unless asked.
-- The patient is a medium-to-poor historian: they ramble, minimize, and sometimes answer slightly off-target. They can still be guided with good questions.
+SPEECH ONLY
+- Reply with ONLY the words you say out loud — no stage directions, no narration, no asterisk actions (*coughs*), no bracketed gestures, no third-person description of yourself.
+- Do NOT narrate how you say it or describe what the clinician sees. Just speak.
+- NEVER refer to yourself in the third person and NEVER wrap your words in quotation marks. For example, write exactly: Sorry, could you ask that another way? My head's a bit fuzzy. — do NOT write: She shifts on the bed and says "Sorry, could you ask that another way?"
+- First person, in character. A couple of short sentences at a time.
+- You are a medium-to-poor historian: you ramble, minimise, and sometimes answer slightly off-target. Good questions can still guide you.
 
 GAME RULES
 1) Only reveal information if asked. Do not volunteer findings.
-2) Maintain internal consistency with the case file. Never contradict your own results.
-3) If players ask for vitals, exam findings, or investigations, provide the relevant results from the case file. If they ask to "order" a test, respond as narrator: "You order X… results return: …"
+2) Stay internally consistent with the case file. Never contradict earlier answers.
+3) If asked about vitals, exam findings, or investigations you would plausibly know (how you feel, your symptoms), answer from the case file. Point results-type questions (bloods, imaging, ECG) toward the nurse at reception.
 4) NEVER reveal or hint at the diagnosis directly. The diagnosis is checked separately.
-5) If asked about something not in the case data, provide a reasonable normal/unremarkable finding.
-6) Hidden information (patient backstory, concealed history, endocrine tests) must remain hidden unless a player earns it by asking the right questions.
-7) If the patient has history_disclosure_rules in their data, follow those rules for how and when to reveal sensitive history.
-8) If the player tries to force the answer ("tell me the diagnosis"), refuse playfully and prompt them to keep investigating.
-9) If asked about management ("what should we do?"), describe what the ED team would typically do in broad strokes (fluids, glucose, addressing electrolytes, contacting seniors). Do not give step-by-step dosing instructions.
+5) If asked about something not in the case data, give a reasonable normal/unremarkable answer about yourself.
+6) Hidden information (backstory, concealed history) stays hidden unless a player earns it by asking the right questions.
+7) If you have history_disclosure_rules in your data, follow those rules for how and when to reveal sensitive history.
+8) If the player tries to force the answer ("just tell me the diagnosis"), deflect in character and keep them investigating.
 
 Your replies appear in a small in-game dialogue box: keep them under ~120 words."""
 
@@ -238,7 +239,8 @@ _NURSE_SYSTEM_PROMPT = """You are playing Nurse Priya, the charge nurse working 
 
 IMPORTANT: You know ONLY about the patient in the CASE FILE below. You have NO memory of any previous patients or cases. There is only one patient: the one described in today's case file. If someone asks about a different patient, say "I've only got today's patient on the board."
 
-TONE AND STYLE
+SPEECH ONLY
+- Reply with ONLY the words you say out loud — speech only, no stage directions, no asterisk actions (*checks the chart*), no bracketed gestures, no narration.
 - Warm, quick, dry-witted, efficient — you have three other jobs on the go.
 - Speak in first person, a couple of short sentences at a time.
 - Read results out plainly; you may flag an abnormal value ("that potassium's up") but never interpret further than a nurse would.
@@ -277,6 +279,270 @@ def _format_transcript(history: Optional[list[dict]], npc_label: str = "Patient"
     return "\n".join(lines) if lines else "None"
 
 
+# ---------------------------------------------------------------------------
+# Speech-only sanitizer
+#
+# The LLM reply is narrated prose that mixes the NPC's SPOKEN words with stage
+# directions (*coughs*, [long pause]), speaker labels, and third-person framing
+# ("She says ..."). The in-game dialogue box shows only what the character says
+# aloud, so _speech_only strips the non-spoken scaffolding.
+#
+# Design bias: KEEP speech. Deleting a real word inverts meaning ("does *not*
+# hurt" → "does hurt") and loses the symptom detail the game elicits, which is
+# far worse than a rare COSMETIC leak of a stage direction. Every rule below is
+# tuned so the safe failure is a leaked stage direction, never a deleted word.
+# There is deliberately NO bare-narration blanker (see the note in Step E).
+# ---------------------------------------------------------------------------
+
+_FIRST_PERSON_RE = re.compile(
+    r"\b(?:i|i'm|i've|i'll|i'd|me|my|mine|myself|we|we're|we've|we'll|our|ours|us)\b",
+    re.IGNORECASE,
+)
+
+# Markdown bold/emphasis — unwrap (keep inner text) BEFORE the single-asterisk
+# action handling, or "**bold**" is misread as a "*…*" span.
+_BOLD_RE = re.compile(r"(\*\*|__)(.+?)\1", re.DOTALL)
+
+# A *…* or _…_ span (inner text captured). These are usually stage directions
+# (*coughs*), but LLMs also use them for spoken emphasis (*not*), so we classify
+# each span rather than deleting wholesale (see _clean_emphasis_span).
+_STAR_SPAN_RE = re.compile(r"\*([^*\n]{1,140})\*")
+_UNDERSCORE_SPAN_RE = re.compile(r"(?<!\w)_([^_\n]{1,140})_(?!\w)")  # not snake_case
+# Bracket spans ([winces], [except the potassium at 6.1]) — inner text captured;
+# classified like a paren (drop gestures, unwrap clinical content).
+_ACTION_BRACKET_RE = re.compile(r"\[([^\]\n]{1,140})\]")
+# Parentheticals — kept unless they read as a gesture (see _clean_paren).
+_PAREN_RE = re.compile(r"\(([^()\n]{1,120})\)")
+
+# A reply wholly wrapped in one quote pair (no internal quotes) — unwrapped in
+# Step F. (There is no prose-narration collapse; see the note in _speech_only.)
+_WHOLE_QUOTE_RE = re.compile(r"^[\"“”]([^\"“”]+)[\"“”]$", re.DOTALL)
+
+# Stage-direction lexicon: UNAMBIGUOUS involuntary / manner / gesture words used
+# to tell a "*…*" or "(…)" span apart from spoken emphasis. Deliberately EXCLUDES
+# words that double as ordinary patient/nurse speech (look, press, hold, breathe,
+# grip, lean, turn, shift, reach, point, close, wave, swallow, beat, shake): the
+# safe failure for a speech-only net is a rare cosmetic leak, never deleting a
+# real word ("does *not* hurt" must not become "does hurt"). Stored as roots
+# (see _norm) so inflections match.
+_STAGE_ROOTS = frozenset({
+    "cough", "sigh", "winc", "grimac", "groan", "gasp", "wheez", "sniff", "sniffl",
+    "sob", "weep", "wept", "whimper", "mumbl", "mutter", "whisper", "murmur",
+    "chuckl", "grumbl", "splutter", "rasp", "slur", "gulp", "gag", "retch",
+    "trembl", "shudder", "flinch", "slump", "collaps", "fidget", "squirm", "slouch",
+    "blush", "nod", "shrug", "blink", "star", "gaz", "glanc", "voic", "silenc",
+    "laugh", "grin", "smil", "frown", "clutch", "hesitat", "muffl", "stiffen",
+    "exhal", "inhal", "tremor", "moan", "wail", "snort", "scoff", "smirk",
+})
+
+
+def _norm(word: str) -> str:
+    """Crude stem: drop one inflectional suffix and a trailing 'e' for matching."""
+    for suf in ("ing", "ed", "es", "s", "d"):
+        if word.endswith(suf) and len(word) - len(suf) >= 3:
+            word = word[: -len(suf)]
+            break
+    return word.rstrip("e")
+
+
+def _is_stage_span(text: str) -> bool:
+    """True if any word in `text` is a stage-direction word (see _STAGE_ROOTS)."""
+    return any(_norm(w) in _STAGE_ROOTS for w in re.findall(r"[a-z]+", text.lower()))
+
+
+# A 1st/2nd-person subject or possessive: its presence in the clause before an
+# emphasis span means the span is the SPEAKER'S OWN word ("when I *laugh*",
+# "lost my *voice*", "you *press* here", "Just *nod*, love") — never a stage
+# direction, so it must be kept.
+_SPEAKER_PRONOUN_RE = re.compile(
+    r"\b(?:i|i'm|i've|i'd|i'll|me|my|mine|myself|we|we're|we've|we'll|us|our|ours|"
+    r"you|you're|you've|you'll|your|yours)\b",
+    re.IGNORECASE,
+)
+
+# A 3rd-person PRONOUN subject (he/she/they) — the tight signal for a genuine
+# stage-direction narrator ("*he nods*", "(she winces)") or a quote narrator
+# ('She says "…"'). Deliberately excludes "the <word>": an emphasised symptom
+# noun ("*the cough*") or clinical object ("the pain feels like …") is NOT a
+# narrator subject and its words must be kept.
+_NARRATOR_SUBJ_RE = re.compile(r"\b(?:he|she|they)\b", re.IGNORECASE)
+
+_RESIDUAL_MD_RE = re.compile(r"[*`]+")
+_MULTISPACE_RE = re.compile(r"[ \t]{2,}")
+_MULTINEWLINE_RE = re.compile(r"\n{3,}")
+
+# Role/persona words that may appear as a speaker label to strip. Never strip an
+# arbitrary "Word:" prefix — "One thing: it hurts" is speech.
+_ROLE_LABELS = ("patient", "nurse", "narrator", "pqm")
+
+
+def _label_tokens(speaker_names: tuple[str, ...]) -> list[str]:
+    """Known speaker labels (role words + names/name-parts), longest-first.
+
+    Longest-first so a two-word name ("Nurse Priya") is matched before its
+    parts ("Nurse") in the regex alternation.
+    """
+    toks: set[str] = set(_ROLE_LABELS)
+    for name in speaker_names:
+        n = (name or "").strip()
+        if not n:
+            continue
+        toks.add(n.lower())
+        for part in re.split(r"[^A-Za-z]+", n):
+            if len(part) >= 3:
+                toks.add(part.lower())
+    return sorted(toks, key=len, reverse=True)
+
+
+def _clean_emphasis_span(m: "re.Match") -> str:
+    """Keep emphasised speech; drop only an UNAMBIGUOUS stage direction.
+
+    Harm asymmetry: never delete a real word. Deleting "*laugh*" in "hurts when I
+    *laugh*", "*voice*" in "lost my *voice*", or "*dangerously high at 6.1*" guts
+    the meaning — far worse than a rare cosmetic leak. So a *…*/_…_ span is dropped
+    ONLY when it is a stage-lexicon word that is EITHER the leading token of its
+    line ("*coughs* Sorry, doc.") OR narrated in the 3rd person ("*he nods*",
+    "She *winces*"). A span the speaker governs ("when I *laugh*", "Just *nod*")
+    or any non-stage span (emphasis, a clinical value) is unwrapped.
+    """
+    inner = m.group(1).strip()
+    if not inner:
+        return ""
+    if _FIRST_PERSON_RE.search(inner):
+        return inner  # "*I can't*" — emphasis on real speech
+    pre = m.string[: m.start()]
+    cut = max(pre.rfind("."), pre.rfind("!"), pre.rfind("?"), pre.rfind("\n"))
+    clause_pre = pre[cut + 1:]  # text before the span, within this sentence
+    if _SPEAKER_PRONOUN_RE.search(clause_pre):
+        return inner  # governed by the speaker ("when I *laugh*", "you *press*")
+    if _is_stage_span(inner):
+        # Drop only when removing the span is CLEAN: it LEADS the line and is
+        # followed by a NEW sentence ("*coughs* Sorry, doc."), or it carries its
+        # own 3rd-person subject ("*he nods*"). A leading span that heads a
+        # continuous clause is an emphasised imperative, not a stage direction
+        # ("*Nod* if you can hear me"); a subject OUTSIDE the span ("She *winces*
+        # …") would leave dangling text — both are kept.
+        post = m.string[m.end():]
+        leads_new_sentence = clause_pre.strip() == "" and bool(
+            re.match(r"\s*(?:[.!?,;:]|$|[A-Z])", post)
+        )
+        subject_inside = bool(_NARRATOR_SUBJ_RE.search(inner))
+        if leads_new_sentence or subject_inside:
+            return ""
+    return inner  # emphasis / clinical content — never delete a real word
+
+
+def _clean_paren(m: "re.Match") -> str:
+    """Drop only a SHORT first-person-free gesture parenthetical; keep the rest.
+
+    "(she winces)", "(voice cracking)" are gestures. But a longer parenthetical is
+    clinical detail even if it mentions a gesture word — "(a dry cough that won't
+    shift, worse at night)", "(the voice is completely gone since Tuesday)" — so
+    only a ≤3-word first-person-free stage parenthetical is dropped.
+    """
+    inner = m.group(1).strip()
+    if _FIRST_PERSON_RE.search(inner):
+        return m.group(0)
+    # Drop only a short gesture NARRATED with a 3rd-person pronoun ("(she winces)",
+    # "(he coughs)"). A subject-less clinical noun phrase — "(no gag reflex)",
+    # "(audible wheeze)", "(voice cracking)" — is kept even though it names a
+    # stage-lexicon word, because it is a spoken exam finding, not a gesture.
+    if _is_stage_span(inner) and len(inner.split()) <= 3 and _NARRATOR_SUBJ_RE.search(inner):
+        return ""
+    return m.group(0)
+
+
+def _clean_bracket(m: "re.Match") -> str:
+    """Unwrap bracketed text, dropping only a 3rd-person-narrated gesture.
+
+    Symmetric with _clean_paren: a bare clinical noun in brackets is real speech
+    ("[cough]", "[wheeze]", "[nod] to command", "[except the potassium at 6.1]")
+    and is kept (unwrapped); only a short gesture with a 3rd-person pronoun
+    subject ("[she winces]", "[he coughs]") is a stage direction and dropped.
+    """
+    inner = m.group(1).strip()
+    if (
+        _is_stage_span(inner)
+        and len(inner.split()) <= 3
+        and _NARRATOR_SUBJ_RE.search(inner)
+        and not _FIRST_PERSON_RE.search(inner)
+    ):
+        return ""
+    return inner
+
+
+def _speech_only(text: str, speaker_names: tuple[str, ...] = ()) -> str:
+    """Reduce an NPC reply to just the spoken words (see module note above).
+
+    MAY return "" — when the reply is nothing but stage directions / third-person
+    narration there are no spoken words to show, and the caller substitutes a
+    short in-character line (see _EMPTY_REPLY_FALLBACK in handle_question).
+    """
+    if not text or not text.strip():
+        return ""
+    s = text.strip()
+
+    # A) code fences
+    if s.startswith("```"):
+        s = re.sub(r"^\s*```[^\n]*\n?", "", s)
+        s = re.sub(r"\n?```\s*$", "", s).strip()
+
+    # B) markdown bold → keep inner text (before the single-* / single-_ handling)
+    s = _BOLD_RE.sub(r"\2", s)
+
+    # C) stage directions: emphasis-aware for *…*/_…_, [ … ] and ( … ) drop only a
+    #    gesture and keep clinical content.
+    s = _STAR_SPAN_RE.sub(_clean_emphasis_span, s)
+    s = _UNDERSCORE_SPAN_RE.sub(_clean_emphasis_span, s)
+    s = _ACTION_BRACKET_RE.sub(_clean_bracket, s)
+    s = _PAREN_RE.sub(_clean_paren, s)
+
+    # D) known speaker labels at line starts
+    labels = _label_tokens(speaker_names)
+    if labels:
+        # Colon delimiter only — a dash after a name is more often a vocative
+        # ("Nurse — over here!") than a speaker label, and mustn't be stripped.
+        label_re = re.compile(
+            r"^[ \t>]*(?:" + "|".join(re.escape(t) for t in labels) + r")\s*[:：]\s+",
+            re.IGNORECASE,
+        )
+        s = "\n".join(label_re.sub("", ln) for ln in s.split("\n"))
+
+    # NOTE: NO prose-narration stripping. Collapsing 'She says "…"' to the quote,
+    # or blanking bare 3rd-person narration, is unsafe — the same surface form
+    # carries real content ('His sats are 92 but she says "…" now'; the nurse
+    # legitimately speaks about the patient in the 3rd person), so a lexical rule
+    # deletes clinical words. This sanitizer strips only MARKUP and unambiguous
+    # stage directions; genuine prose narration (a rare slip under the
+    # first-person prompt) is left to the prompt, never guessed at here.
+
+    # F) whole reply wrapped in a single quote pair → unwrap
+    s = s.strip()
+    m = _WHOLE_QUOTE_RE.match(s)
+    if m:
+        s = m.group(1).strip()
+
+    # G) residual markdown + repair artifacts left by removed inline spans
+    #    (orphaned "space-before-punctuation" and doubled commas), then tidy space.
+    s = _RESIDUAL_MD_RE.sub("", s)
+    s = re.sub(r"\s+([,;:!?])", r"\1", s)
+    s = re.sub(r" +\.", ".", s)
+    s = re.sub(r"([,;:])(\s*\1)+", r"\1", s)
+    s = "\n".join(_MULTISPACE_RE.sub(" ", ln).strip() for ln in s.split("\n"))
+    s = _MULTINEWLINE_RE.sub("\n\n", s).strip()
+
+    # H) may be empty — the caller substitutes a canned in-character line.
+    return s
+
+
+# Shown when the model returns nothing usable (e.g. a gpt-5 reply where reasoning
+# tokens consumed the whole budget → empty content). Keyed by role.
+_EMPTY_REPLY_FALLBACK = {
+    "patient": "Sorry doc — I lost my train of thought there. What did you want to ask?",
+    "nurse": "Sorry doc — swamped for a sec. What did you need?",
+}
+
+
 async def npc_reply(
     question: str,
     history: Optional[list[dict]],
@@ -311,7 +577,7 @@ Respond in character as {persona}. Remember: only reveal what was asked for."""
     openai_client = get_llm_client("openai")
     response = await openai_client.chat(
         [
-            {"role": "system", "content": _NURSE_SYSTEM_PROMPT if is_nurse else _PQM_SYSTEM_PROMPT},
+            {"role": "system", "content": _NURSE_SYSTEM_PROMPT if is_nurse else _PATIENT_SYSTEM_PROMPT},
             {"role": "user", "content": prompt},
         ],
         model=settings.SIM_PATIENT_MODEL,
@@ -371,14 +637,25 @@ async def handle_question(
                     "again. Do NOT reveal the correct diagnosis or hint at it."
                 )
 
-    reply = await npc_reply(question, history, case, role=role, extra_instruction=extra_instruction)
+    raw_reply = await npc_reply(question, history, case, role=role, extra_instruction=extra_instruction)
+
+    # Choke point: every reply is sanitized to spoken words only here (not inside
+    # npc_reply), so any caller / future path is covered. Pass the speaker's known
+    # names so their own name label ("Sash:") is stripped. When nothing spoken
+    # remains (reply was pure stage direction / empty model output) substitute a
+    # short in-character line rather than showing an empty or markup-only box.
+    display_name = NURSE_NAME if is_nurse else (case.get("patient") or {}).get("name")
+    speaker_names = tuple(n for n in (display_name, NURSE_NAME) if n)
+    reply = _speech_only(raw_reply, speaker_names=speaker_names)
+    if not reply:
+        reply = _EMPTY_REPLY_FALLBACK["nurse" if is_nurse else "patient"]
 
     return {
         "reply": reply,
         "case_id": case.get("id"),
         "case_title": case.get("title"),
         # The speaker's display name — the in-game dialogue header / name tag.
-        "patient_name": NURSE_NAME if is_nurse else (case.get("patient") or {}).get("name"),
+        "patient_name": display_name,
         "presenting_complaint": (case.get("presenting_complaint") or "").strip(),
         "is_guess": is_guess,
         "correct": correct,          # true/false only when is_guess

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -31,7 +31,7 @@ class _FakeLLMClient:
     fake serves both: gpt-4o-mini → the classifier JSON, anything else → reply.
     """
 
-    def __init__(self, classifier_json: str, reply_text: str = "The patient blinks slowly."):
+    def __init__(self, classifier_json: str, reply_text: str = "I feel awful, honestly."):
         self.classifier_json = classifier_json
         self.reply_text = reply_text
         self.calls: list[dict] = []
@@ -43,7 +43,7 @@ class _FakeLLMClient:
         return _FakeLLMResponse(self.reply_text)
 
 
-def _install_fake(monkeypatch, classifier_json, reply_text="The patient blinks slowly."):
+def _install_fake(monkeypatch, classifier_json, reply_text="I feel awful, honestly."):
     fake = _FakeLLMClient(classifier_json, reply_text)
     # sim_patient imports get_llm_client into its own namespace.
     monkeypatch.setattr(sim_patient, "get_llm_client", lambda provider=None: fake)
@@ -106,7 +106,7 @@ def test_non_guess_question(monkeypatch):
     assert result["is_guess"] is False
     assert result["correct"] is None
     assert result["diagnosis"] is None
-    assert result["reply"] == "The patient blinks slowly."
+    assert result["reply"] == "I feel awful, honestly."
 
 
 # ---------------------------------------------------------------------------
@@ -254,7 +254,7 @@ def test_malformed_history_item_does_not_crash(monkeypatch):
         sim_patient.handle_question("what are her vitals?", history=["not-a-dict", None, 123])
     )
     assert result["is_guess"] is False
-    assert result["reply"] == "The patient blinks slowly."
+    assert result["reply"] == "I feel awful, honestly."
 
 
 def test_non_string_classifier_diagnosis_does_not_crash(monkeypatch):
@@ -319,7 +319,8 @@ def test_nurse_prompt_carries_case_but_no_secrets(monkeypatch):
     fake = _install_fake(monkeypatch, "{}", reply_text='"Bloods are back: sodium 122."')
 
     result = _run(sim_patient.handle_question("can I get the bloods?", role="nurse"))
-    assert result["reply"].startswith('"Bloods')
+    # The speech-only sanitizer unwraps the model's wrapping quotes.
+    assert result["reply"] == "Bloods are back: sodium 122."
 
     reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
     user_prompt = reply_calls[0]["messages"][1]["content"]
@@ -357,3 +358,213 @@ def test_422_when_role_invalid(monkeypatch):
     client = TestClient(app)
     resp = client.post("/api/sim-patient", json={"question": "hi", "role": "doctor"})
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Speech-only sanitizer: strip narration/stage-directions, keep spoken words
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "raw,expected,names",
+    [
+        # asterisk stage direction
+        ("*coughs* It hurts when I breathe.", "It hurts when I breathe.", ()),
+        # parenthetical action with no first-person voice → dropped
+        ("(She winces.) My chest is tight.", "My chest is tight.", ()),
+        # named speaker label (short name from the full patient name) → dropped
+        ("Sash: I feel dizzy, doc.", "I feel dizzy, doc.", ("Sasha 'Sash' Nguyen",)),
+        # role-word speaker label with no names supplied → dropped
+        ("Patient: It hurts.", "It hurts.", ()),
+        # a bracketed gesture NARRATED with a 3rd-person pronoun is dropped…
+        ("[she winces] It's my side.", "It's my side.", ()),
+        # …but a bare clinical noun in brackets is kept (unwrapped) — not deleted
+        ("It's a [cough] that won't shift, worse at night.",
+         "It's a cough that won't shift, worse at night.", ()),
+        ("GCS 10 — a [nod] to command, no verbal.", "GCS 10 — a nod to command, no verbal.", ()),
+        # prose narration wrapping a quote is KEPT verbatim (markup-only sanitizer:
+        # lexical narration-collapse deletes real content, so it is left to the
+        # first-person prompt — see the module note in _speech_only)
+        ('She looks up. "I\'ve been so tired, doctor."',
+         'She looks up. "I\'ve been so tired, doctor."', ()),
+        (
+            'He sighs and says "It started last week." Then he adds, "Maybe earlier."',
+            'He sighs and says "It started last week." Then he adds, "Maybe earlier."',
+            (),
+        ),
+        # whole reply wrapped in quotes → unwrap
+        ('"My head is pounding."', "My head is pounding.", ()),
+        # markdown bold → unwrap, keep text (must NOT be eaten as a *…* action)
+        ("**It hurts** — a lot.", "It hurts — a lot.", ()),
+        # --- protections: these must pass through UNCHANGED ---
+        # first-person quote inside a sentence is speech, not narration
+        (
+            'The GP said "it\'s just stress" but I don\'t buy it.',
+            'The GP said "it\'s just stress" but I don\'t buy it.',
+            (),
+        ),
+        # parenthetical containing first person is speech → kept
+        (
+            "I've been sick all morning (since Tuesday, I think).",
+            "I've been sick all morning (since Tuesday, I think).",
+            (),
+        ),
+        # "Word:" that is NOT a known label is speech → kept
+        ("One thing: it really hurts.", "One thing: it really hurts.", ()),
+        # plain speech untouched
+        (
+            "My stomach's been killing me since last night.",
+            "My stomach's been killing me since last night.",
+            (),
+        ),
+        # --- regressions found by the adversarial review (executed on real code) ---
+        # over-strip: a patient recounting a third party keeps their OWN trailing clause
+        (
+            'The doctor said "rest" but it still hurts.',
+            'The doctor said "rest" but it still hurts.',
+            (),
+        ),
+        (
+            'The label just said "one at night" so that is what she gave the kids.',
+            'The label just said "one at night" so that is what she gave the kids.',
+            (),
+        ),
+        # prose narration is KEPT verbatim (markup-only sanitizer, see above)
+        (
+            'She grips the rail and blurts "It started this morning."',
+            'She grips the rail and blurts "It started this morning."',
+            (),
+        ),
+        # single-* emphasis on a real word is UNWRAPPED, not deleted (must not invert meaning)
+        (
+            "No, it does *not* go down my arm.",
+            "No, it does not go down my arm.",
+            (),
+        ),
+        ("It hurts *right* here.", "It hurts right here.", ()),
+        # inline action between commas → no orphaned ", ," artifact
+        ("Yes, *he nods*, exactly that.", "Yes, exactly that.", ()),
+        # clinical hedge parentheticals (no first person, no gesture) are KEPT
+        (
+            "The pain started three days ago (maybe four) and has not let up.",
+            "The pain started three days ago (maybe four) and has not let up.",
+            (),
+        ),
+        (
+            "It burns when it happens (mostly at night) and then it fades.",
+            "It burns when it happens (mostly at night) and then it fades.",
+            (),
+        ),
+        # single-underscore stage direction is stripped like its *…* sibling
+        ("_winces and clutches side_ It hurts here.", "It hurts here.", ()),
+        # a terse first-person-free reply is kept (no bare-narration blanker)
+        ("Everything looks blurry.", "Everything looks blurry.", ()),
+        # --- second-pass regression fixes (executed on real code) ---
+        # emphasis on a speech-common word is UNWRAPPED, never deleted
+        ("Can you *press* here? That's where it hurts.", "Can you press here? That's where it hurts.", ()),
+        ("Just *breathe*, that's what they told me.", "Just breathe, that's what they told me.", ()),
+        ("The pain does *shift* around a lot.", "The pain does shift around a lot.", ()),
+        # a leading stage word is still dropped
+        ("*mumbles* I dunno.", "I dunno.", ()),
+        ("*sniffles* I've had a runny nose too.", "I've had a runny nose too.", ()),
+        # a gesture NARRATED with a 3rd-person pronoun is dropped
+        ("Okay. (she winces)", "Okay.", ()),
+        # clinical hedge kept (first-person-free)
+        ("It's a seven out of ten (maybe eight).", "It's a seven out of ten (maybe eight).", ()),
+        # nurse speaking about the patient in third person is KEPT (no over-blank)
+        ("He looks stable now, breathing's better.", "He looks stable now, breathing's better.", ()),
+        ("The patient keeps clutching his side, go see him.", "The patient keeps clutching his side, go see him.", ()),
+        # prose narration wrapping a quote is KEPT verbatim (markup-only sanitizer)
+        ('She says "sit down" quietly.', 'She says "sit down" quietly.', ()),
+        # --- third-pass fixes: NEVER delete a real word governed by the speaker ---
+        # a stage-lexicon word governed by a 1st/2nd-person subject is kept
+        ("It only hurts when I *laugh*.", "It only hurts when I laugh.", ()),
+        ("I can't *gulp* the water down, it just won't go.", "I can't gulp the water down, it just won't go.", ()),
+        ("I've completely lost my *voice*.", "I've completely lost my voice.", ()),
+        ("I need a bit of *silence*, my head's pounding.", "I need a bit of silence, my head's pounding.", ()),
+        ("Just *nod* if you can hear me, love.", "Just nod if you can hear me, love.", ()),
+        ("It made me want to *gag*.", "It made me want to gag.", ()),
+        # a multi-word emphasised clinical value is kept, not dropped as "narration"
+        ("Her potassium is *dangerously high at 6.1*.", "Her potassium is dangerously high at 6.1.", ()),
+        # a leading stage word still drops; a 3rd-person subject OUTSIDE the span
+        # is kept (dropping just the verb would leave dangling text)
+        ("*sighs* Fine, whatever you say.", "Fine, whatever you say.", ()),
+        ("She *winces* and looks away.", "She winces and looks away.", ()),
+        # a longer clinical parenthetical survives even with a gesture word in it
+        ("Been sick all week (a dry cough that won't shift, worse at night).",
+         "Been sick all week (a dry cough that won't shift, worse at night).", ()),
+        ("Throat's raw (just a rasp when talking now).",
+         "Throat's raw (just a rasp when talking now).", ()),
+        # the speaker's own recounted account is NOT collapsed to the bare quote
+        ('Kept shouting "help me" again and again.', 'Kept shouting "help me" again and again.', ()),
+        # --- fourth-pass fixes: "the <noun>" / clinical parens / relayed requests ---
+        # an emphasised symptom noun phrase ("*the cough*") is kept, not narration
+        ("Nothing helps *the cough*, honestly.", "Nothing helps the cough, honestly.", ()),
+        ("Worse than *the wheeze* I had before.", "Worse than the wheeze I had before.", ()),
+        # subject-less clinical parentheticals with a stage-lexicon word are kept
+        ("She's not responding (no gag reflex).", "She's not responding (no gag reflex).", ()),
+        ("His breathing's noisy (audible wheeze).", "His breathing's noisy (audible wheeze).", ()),
+        # a quote that is the OBJECT of a desire/request verb is not collapsed
+        ('He wants "bloods and an ECG".', 'He wants "bloods and an ECG".', ()),
+    ],
+)
+def test_speech_only(raw, expected, names):
+    assert sim_patient._speech_only(raw, speaker_names=names) == expected
+
+
+def test_speech_only_all_action_returns_empty(monkeypatch):
+    # A reply that is ENTIRELY a stage direction has no spoken words: the
+    # sanitizer returns "" and the CALLER substitutes a canned in-character line
+    # (better than showing raw "*collapses...*" markup).
+    assert sim_patient._speech_only("*collapses back onto the pillow*") == ""
+
+    async def action_only(*args, **kwargs):
+        return "*collapses back onto the pillow*"
+
+    monkeypatch.setattr(sim_patient, "npc_reply", action_only)
+    result = _run(sim_patient.handle_question("how are you?", role="nurse"))
+    assert result["reply"] == sim_patient._EMPTY_REPLY_FALLBACK["nurse"]
+
+
+def test_speech_only_empty_input():
+    assert sim_patient._speech_only("") == ""
+    assert sim_patient._speech_only("   \n  ") == ""
+
+
+def test_handle_question_sanitizes_reply_at_choke_point(monkeypatch):
+    # Prove sanitization happens in handle_question for ALL replies: mock the LLM
+    # reply with narration and confirm the returned reply is speech only. Nurse
+    # role → the guess classifier is skipped, so no LLM stub needed for it.
+    async def fake_npc_reply(*args, **kwargs):
+        return "*sighs* The bloods aren't back yet, love."
+
+    monkeypatch.setattr(sim_patient, "npc_reply", fake_npc_reply)
+    result = _run(sim_patient.handle_question("bloods?", role="nurse"))
+    assert result["reply"] == "The bloods aren't back yet, love."
+
+
+def test_empty_model_reply_falls_back_to_canned_line(monkeypatch):
+    async def empty_reply(*args, **kwargs):
+        return ""
+
+    monkeypatch.setattr(sim_patient, "npc_reply", empty_reply)
+
+    nurse = _run(sim_patient.handle_question("bloods?", role="nurse"))
+    assert nurse["reply"] == sim_patient._EMPTY_REPLY_FALLBACK["nurse"]
+
+    # Patient role runs the classifier first — stub it to a non-guess so no LLM.
+    async def not_a_guess(_question):
+        return {"is_guess": False, "diagnosis": None}
+
+    monkeypatch.setattr(sim_patient, "classify_guess", not_a_guess)
+    patient = _run(sim_patient.handle_question("how are you feeling?", role="patient"))
+    assert patient["reply"] == sim_patient._EMPTY_REPLY_FALLBACK["patient"]
+
+
+def test_system_prompts_declare_speech_only():
+    # Contract-presence: guard against an accidental revert to the narrator prompt.
+    assert "SPEECH ONLY" in sim_patient._PATIENT_SYSTEM_PROMPT
+    assert "no stage directions" in sim_patient._PATIENT_SYSTEM_PROMPT.lower()
+    assert "speech only" in sim_patient._NURSE_SYSTEM_PROMPT.lower()
+    # The patient is now first-person, not the third-person PQM narrator.
+    assert "Patient Quest Master" not in sim_patient._PATIENT_SYSTEM_PROMPT
+    assert "narrate how they say it" not in sim_patient._PATIENT_SYSTEM_PROMPT


### PR DESCRIPTION
Follow-up to #181 that makes the health-hack ward NPC replies **speech-only** and wires the game to the live LLM.

## What
- **Patient prompt** rewritten from the third-person PQM narrator → a **first-person speaker** (results-type questions point to the nurse). Nurse prompt gains the same speech-only clause + an explicit anti-narration example.
- **`_speech_only()` sanitizer** at the `handle_question` choke point — **markup-only**: strips code fences, markdown bold, `*emphasis*`/`_underscore_` stage directions, `[brackets]`, `Speaker:` labels, and whole-message wrapping quotes; drops a span only on a high-confidence stage-direction signal (leading + new sentence, or a `he/she/they` narrator subject) and otherwise keeps the words. It deliberately does **not** attempt lexical prose-narration detection, which was proven to delete clinical content (e.g. `His sats are 92 but she says "…"`).
- **Empty-reply guard**: gpt-5 reasoning can consume the whole token budget and return empty content → `max_tokens` 700→1200 + a canned in-character fallback.

## Verification
- **73 unit tests** (was 16); a 29-case matrix spanning six adversarial-review passes, all executed against the real code.
- **Live-verified** against the OpenAI API (`gpt-5` + `gpt-4o-mini`): patient history, nurse investigation results, and the guess flow (correct → reveal, wrong → rebuff/no leak, guess-to-nurse → no adjudication) all return clean first-person speech; **0/14** narration slips on a fresh sample; the full health-hack proxy chain stamps `source:"live"`.

Secrets (diagnosis/acceptable_answers/hints) redaction is untouched; the web game never mutates Slack medhack state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)