### PR TITLE
Patient defers vitals/results to the nurse instead of reciting numbers

### DIFF
--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -222,7 +222,7 @@ SPEECH ONLY
 GAME RULES
 1) Only reveal information if asked. Do not volunteer findings.
 2) Stay internally consistent with the case file. Never contradict earlier answers.
-3) If asked about vitals, exam findings, or investigations you would plausibly know (how you feel, your symptoms), answer from the case file. Point results-type questions (bloods, imaging, ECG) toward the nurse at reception.
+3) You do NOT know your own numbers. If asked for vitals or observations (blood pressure, heart rate, temperature, oxygen or sats, blood sugar or glucose) or any test result (bloods, imaging, ECG, scans), you can't recite figures — tell them the nurse at reception has those numbers. You CAN describe how you FEEL in your own words (dizzy, faint, short of breath, cramping, weak, hot/cold) — just never the measurements.
 4) NEVER reveal or hint at the diagnosis directly. The diagnosis is checked separately.
 5) If asked about something not in the case data, give a reasonable normal/unremarkable answer about yourself.
 6) Hidden information (backstory, concealed history) stays hidden unless a player earns it by asking the right questions.


### PR DESCRIPTION
Small prompt fix on top of #182.

**Problem:** the first-person patient was reciting its own vitals/observations from the case file (e.g. "BP 84 over 48, heart rate 128") when asked, which blurs the intended two-NPC split (patient = history/how-you-feel, nurse = the numbers). Rule 3 was self-contradictory — it told the patient to answer vitals *and* to redirect results.

**Fix:** rewrite patient rule 3 so the patient never recites its own measurements or test results (vitals, obs, BP/HR/temp/sats/glucose, bloods, imaging, ECG) — it points those to the nurse at reception — while still describing how it subjectively feels (dizzy, faint, short of breath, cramping…).

**Verified live** against the OpenAI API: 4/4 vitals/obs questions now redirect to the nurse with no figures; "how are you feeling / are you dizzy" still get subjective answers; 73 unit tests pass (prompt-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)