### PR TITLE
Ward-clerk diagnosis contest endpoint; patient chat stops adjudicating guesses

### DIFF
--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -84,6 +84,9 @@ class Settings(BaseSettings):
     SIM_PATIENT_API_KEY: Optional[str] = None
     SIM_PATIENT_MODEL: str = "gpt-5"
     SIM_PATIENT_REASONING_EFFORT: str = "low"
+    # The ward contest's active case (cases.yaml id). Pinned server-side so web
+    # clients can never pick a case and farm tickets from cases not in play.
+    SIM_ACTIVE_CASE_ID: int = 1
 
     @property
     def default_llm_provider(self) -> str:

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -2194,6 +2194,81 @@ async def api_sim_patient(request: Request, settings: Settings = Depends(get_set
         raise HTTPException(status_code=502, detail="patient unavailable")
 
 
+@app.post("/api/diagnosis-check")
+async def api_diagnosis_check(request: Request, settings: Settings = Depends(get_settings)):
+    """Ward-clerk diagnosis contest: adjudicate ONE guess and record it.
+
+    Fully scripted — no LLM anywhere in this path. The active case is pinned
+    server-side (SIM_ACTIVE_CASE_ID); clients cannot pick a case. The verdict
+    comes from the same deterministic matcher as the Slack game (check_guess)
+    and is recorded to mlai-backend BEFORE being revealed: if recording fails
+    we return 503 with no verdict, so the guess is neither leaked nor burned
+    (the backend row is what burns the player's single guess).
+
+    Auth mirrors /api/sim-patient (bearer, open when SIM_PATIENT_API_KEY unset).
+    Errors: 401 bad token, 422 validation, 503 contest/record unavailable.
+    """
+    if settings.SIM_PATIENT_API_KEY:
+        auth = request.headers.get("Authorization", "")
+        if auth != f"Bearer {settings.SIM_PATIENT_API_KEY}":
+            raise HTTPException(status_code=401, detail="bad token")
+
+    payload = await request.json()
+    guess = str(payload.get("guess") or "").strip()
+    if not guess or len(guess) > 200:
+        raise HTTPException(status_code=422, detail="guess required (1-200 chars)")
+    client_id = str(payload.get("client_id") or "").strip()
+    if not re.fullmatch(r"[A-Za-z0-9-]{8,64}", client_id):
+        raise HTTPException(status_code=422, detail="client_id must be 8-64 chars [A-Za-z0-9-]")
+
+    from .sim_patient import check_guess, load_case, record_web_guess
+
+    try:
+        case = load_case(settings.SIM_ACTIVE_CASE_ID)
+    except KeyError as exc:
+        # Server misconfiguration (bad SIM_ACTIVE_CASE_ID), not a client error.
+        print(f"⚠️ diagnosis-check: active case unavailable: {exc}")
+        raise HTTPException(status_code=503, detail="contest unavailable")
+
+    is_correct = check_guess(guess, case)
+
+    try:
+        record = await record_web_guess(
+            settings,
+            case_id=case.get("id"),
+            client_id=client_id,
+            guess_text=guess,
+            is_correct=is_correct,
+        )
+    except Exception as exc:
+        # No verdict may leak when the registry is down (free-oracle otherwise),
+        # and the guess is NOT burned — nothing was recorded.
+        print(f"⚠️ diagnosis-check: record failed: {exc}")
+        raise HTTPException(status_code=503, detail="record_failed")
+
+    already = bool(record.get("already_guessed"))
+    stored_correct = bool(record.get("is_correct"))
+    winner_taken = bool(record.get("winner_taken"))
+    if already:
+        result = "already_guessed"
+    elif stored_correct and not winner_taken:
+        result = "correct_first"
+    elif stored_correct:
+        result = "correct_beaten"
+    else:
+        result = "incorrect"
+
+    return {
+        "result": result,
+        "outcome": record.get("outcome"),
+        "winner_taken": winner_taken,
+        "case_id": case.get("id"),
+        # The STORED verdict is authoritative (covers the already_guessed resume
+        # path); the primary diagnosis is no longer secret once earned.
+        "diagnosis": case.get("diagnosis") if stored_correct else None,
+    }
+
+
 def _format_tier_display(tier: str) -> str:
     """Format tier string for display with emoji."""
     tier_lower = tier.lower().replace("_", " ")

--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -6,11 +6,18 @@ up to a patient in the game world, asks a question, and this module produces an
 in-character reply using the medhack skill's clinical case files.
 
 Two personas share the endpoint via ``role``:
-  - "patient" (default): the PQM narrator voicing the patient in cubicle 3.
-    Guesses are classified and adjudicated.
+  - "patient" (default): the patient in cubicle 3, speaking first person.
+    Guesses are classified only to DEFLECT them to the ward clerk — chat
+    NEVER adjudicates (see below).
   - "nurse": the reception nurse who reads out investigation results (bloods,
     imaging, ECG, obs) from the same case file. Never adjudicates guesses —
     the classifier is skipped entirely for this role.
+
+Diagnosis adjudication lives EXCLUSIVELY in /api/diagnosis-check (the scripted
+ward-clerk contest endpoint): it runs check_guess() and records the verdict to
+mlai-backend before revealing anything. Chat must never return a verdict —
+otherwise the patient is a free correctness oracle players can probe before
+banking a guaranteed win on their single clerk guess.
 
 This module is deliberately independent of the Slack executor (whose patient
 simulator is currently DISABLED — see roo/skills/executor.py) and of the medhack
@@ -34,6 +41,7 @@ from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any, Optional
 
+import httpx
 import yaml
 
 from .config import get_settings
@@ -200,6 +208,48 @@ Respond with ONLY valid JSON, no markdown:
 
 
 # ---------------------------------------------------------------------------
+# Web ward contest: record adjudicated guesses to mlai-backend
+# ---------------------------------------------------------------------------
+
+async def record_web_guess(
+    settings,
+    *,
+    case_id: int,
+    client_id: str,
+    guess_text: str,
+    is_correct: bool,
+) -> dict:
+    """POST the adjudicated guess to mlai-backend's sim-guess registry.
+
+    The backend row is the contest's source of truth (one guess per client per
+    case via a unique constraint; single winner per case). Raises on ANY
+    failure — the caller must then withhold the verdict entirely (503):
+    revealing it unrecorded would turn backend-down into a free correctness
+    oracle. Because nothing was recorded, a failed attempt does NOT burn the
+    player's one guess.
+    """
+    if not settings.MLAI_BACKEND_URL:
+        raise RuntimeError("MLAI_BACKEND_URL not configured")
+    api_key = settings.ROO_API_KEY or settings.INTERNAL_API_KEY
+    if not api_key:
+        raise RuntimeError("no service API key configured for mlai-backend")
+    url = f"{settings.MLAI_BACKEND_URL.rstrip('/')}/api/v1/hackathons/hospital/sim-guess/record/"
+    async with httpx.AsyncClient(timeout=6.0) as client:
+        resp = await client.post(
+            url,
+            json={
+                "case_id": case_id,
+                "client_id": client_id,
+                "guess_text": guess_text,
+                "is_correct": is_correct,
+            },
+            headers={"X-API-Key": api_key},
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+# ---------------------------------------------------------------------------
 # In-character reply
 # ---------------------------------------------------------------------------
 
@@ -223,7 +273,7 @@ GAME RULES
 1) Only reveal information if asked. Do not volunteer findings.
 2) Stay internally consistent with the case file. Never contradict earlier answers.
 3) You do NOT know your own numbers. If asked for vitals or observations (blood pressure, heart rate, temperature, oxygen or sats, blood sugar or glucose) or any test result (bloods, imaging, ECG, scans), you can't recite figures — tell them the nurse at reception has those numbers. You CAN describe how you FEEL in your own words (dizzy, faint, short of breath, cramping, weak, hot/cold) — just never the measurements.
-4) NEVER reveal or hint at the diagnosis directly. The diagnosis is checked separately.
+4) NEVER reveal or hint at the diagnosis directly, and never confirm or deny a player's diagnosis theory — you genuinely don't know what's wrong with you. Making a diagnosis official happens with Reg, the ward clerk at the reception desk, not with you.
 5) If asked about something not in the case data, give a reasonable normal/unremarkable answer about yourself.
 6) Hidden information (backstory, concealed history) stays hidden unless a player earns it by asking the right questions.
 7) If you have history_disclosure_rules in your data, follow those rules for how and when to reveal sensitive history.
@@ -598,22 +648,24 @@ async def handle_question(
     player_id: str = "web-anon",
     role: str = "patient",
 ) -> dict:
-    """Orchestrate: load case → classify → reply (with guess verdict) → response dict.
+    """Orchestrate: load case → classify → deflect/reply → response dict.
 
-    Never mutates game state. On a correct guess the LLM is asked to celebrate and
-    reveal the diagnosis in-character; on a wrong guess it rebuffs clinically
-    without hinting. There is no one-guess lockout and no points here.
+    Never mutates game state and NEVER adjudicates a diagnosis guess: when the
+    classifier detects a guess, the patient deflects to the ward clerk instead.
+    The one-guess ticket contest is adjudicated + recorded exclusively by
+    /api/diagnosis-check — returning a verdict here would make the patient a
+    free correctness oracle players could probe before banking a guaranteed
+    win at the clerk. `correct`/`diagnosis` are always None (kept in the
+    response shape for frontend compatibility).
 
     role="nurse" answers as the reception nurse instead: the guess classifier is
-    skipped entirely (guesses go to the patient), so is_guess is always False and
-    the diagnosis can never be revealed through this persona.
+    skipped entirely, so is_guess is always False and the diagnosis can never be
+    revealed through this persona.
     """
     history = (history or [])[-MAX_HISTORY_TURNS:]
     case = load_case(case_id)
     is_nurse = role == "nurse"
 
-    correct: Optional[bool] = None
-    diagnosis: Optional[str] = None
     extra_instruction = ""
     is_guess = False
 
@@ -622,20 +674,16 @@ async def handle_question(
         is_guess = bool(classification.get("is_guess"))
 
         if is_guess:
-            correct = check_guess(classification.get("diagnosis") or question, case)
-            if correct:
-                diagnosis = case.get("diagnosis")
-                extra_instruction = (
-                    f"The player just guessed correctly: {diagnosis}. Celebrate warmly, "
-                    "reveal the diagnosis, and stay in narrator character."
-                )
-            else:
-                # Wording adapted from the disabled _handle_guess_result wrong-guess branch.
-                extra_instruction = (
-                    "The player just made an INCORRECT diagnosis guess. Respond clinically: "
-                    "let them know their guess was wrong and suggest they review the findings "
-                    "again. Do NOT reveal the correct diagnosis or hint at it."
-                )
+            # ORACLE NEUTRALIZED: check_guess() is deliberately NOT consulted
+            # in the chat path. The patient doesn't know their diagnosis and
+            # steers the player to the clerk, where the contest is recorded.
+            extra_instruction = (
+                "The doctor just told you what they think is wrong with you. Do NOT "
+                "confirm or deny it — you genuinely don't know what's wrong with you. "
+                "Tell them, in character, that if they want to make their diagnosis "
+                "official they should log it with Reg, the ward clerk at the "
+                "reception desk. Do not repeat their theory back to them."
+            )
 
     raw_reply = await npc_reply(question, history, case, role=role, extra_instruction=extra_instruction)
 
@@ -658,6 +706,8 @@ async def handle_question(
         "patient_name": display_name,
         "presenting_complaint": (case.get("presenting_complaint") or "").strip(),
         "is_guess": is_guess,
-        "correct": correct,          # true/false only when is_guess
-        "diagnosis": diagnosis,      # set ONLY when is_guess && correct
+        # Deprecated pair: chat NEVER adjudicates guesses any more (the clerk
+        # endpoint owns verdicts). Always None; kept so PatientReply parses.
+        "correct": None,
+        "diagnosis": None,
     }

--- a/roo-standalone/roo/tests/test_diagnosis_check.py
+++ b/roo-standalone/roo/tests/test_diagnosis_check.py
@@ -1,0 +1,206 @@
+"""Hermetic tests for POST /api/diagnosis-check (the ward-clerk contest).
+
+No real LLM (the endpoint must never touch one), no network (the mlai-backend
+recorder is monkeypatched). Invariants under test:
+
+  - deterministic adjudication via check_guess, recorded BEFORE any reveal
+  - result mapping: correct_first / correct_beaten / incorrect / already_guessed
+  - the STORED verdict is authoritative on the already_guessed resume path
+  - record failure → 503 with NO verdict fields (no free oracle, guess not burned)
+  - the active case is pinned server-side (client case_id ignored)
+  - bearer auth mirrors /api/sim-patient
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from fastapi.testclient import TestClient
+
+from roo import config, sim_patient
+from roo.main import app
+
+
+VALID_CLIENT = "aaaaaaaa-1111-4111-8111-111111111111"
+
+
+def _client(monkeypatch, *, api_key=None, active_case=1):
+    """TestClient with a pinned Settings singleton (no lifespan — bare client)."""
+    real = config.get_settings()
+    monkeypatch.setattr(real, "SIM_PATIENT_API_KEY", api_key, raising=False)
+    monkeypatch.setattr(real, "SIM_ACTIVE_CASE_ID", active_case, raising=False)
+    monkeypatch.setattr(config, "get_settings", lambda: real)
+    return TestClient(app)
+
+
+def _install_recorder(monkeypatch, response=None, error=None):
+    """Replace record_web_guess; returns the list of recorded call kwargs."""
+    calls: list[dict] = []
+
+    async def fake_record(settings, **kwargs):
+        calls.append(kwargs)
+        if error is not None:
+            raise error
+        return response
+
+    monkeypatch.setattr(sim_patient, "record_web_guess", fake_record)
+    return calls
+
+
+def _install_llm_bomb(monkeypatch):
+    """The clerk path is scripted — any LLM call is a bug."""
+    def bomb(provider=None):
+        raise AssertionError("diagnosis-check must never call the LLM")
+    monkeypatch.setattr(sim_patient, "get_llm_client", bomb)
+
+
+def test_correct_first_records_then_reveals(monkeypatch):
+    _install_llm_bomb(monkeypatch)
+    calls = _install_recorder(monkeypatch, response={
+        "already_guessed": False, "is_correct": True,
+        "outcome": "pending_claim", "winner_taken": False,
+    })
+    client = _client(monkeypatch)
+
+    resp = client.post("/api/diagnosis-check",
+                       json={"guess": "adrenal crisis", "client_id": VALID_CLIENT})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"] == "correct_first"
+    assert body["outcome"] == "pending_claim"
+    assert body["winner_taken"] is False
+    assert body["case_id"] == 1
+    assert body["diagnosis"] == "Adrenal Crisis"
+    # Adjudicated deterministically and recorded with the pinned case.
+    assert calls == [{
+        "case_id": 1, "client_id": VALID_CLIENT,
+        "guess_text": "adrenal crisis", "is_correct": True,
+    }]
+
+
+def test_correct_beaten_when_winner_taken(monkeypatch):
+    _install_recorder(monkeypatch, response={
+        "already_guessed": False, "is_correct": True,
+        "outcome": "pending_claim", "winner_taken": True,
+    })
+    client = _client(monkeypatch)
+
+    body = client.post("/api/diagnosis-check",
+                       json={"guess": "addisonian crisis", "client_id": VALID_CLIENT}).json()
+
+    assert body["result"] == "correct_beaten"
+    assert body["winner_taken"] is True
+    assert body["diagnosis"] == "Adrenal Crisis"
+
+
+def test_incorrect_guess_reveals_nothing(monkeypatch):
+    calls = _install_recorder(monkeypatch, response={
+        "already_guessed": False, "is_correct": False,
+        "outcome": "incorrect", "winner_taken": False,
+    })
+    client = _client(monkeypatch)
+
+    body = client.post("/api/diagnosis-check",
+                       json={"guess": "banana allergy", "client_id": VALID_CLIENT}).json()
+
+    assert body["result"] == "incorrect"
+    assert body["diagnosis"] is None
+    assert calls[0]["is_correct"] is False
+
+
+def test_already_guessed_resume_uses_stored_verdict(monkeypatch):
+    # The NEW text is wrong, but the STORED guess was correct (player resuming
+    # after losing local state) — the stored verdict wins and the dx re-reveals.
+    _install_recorder(monkeypatch, response={
+        "already_guessed": True, "is_correct": True,
+        "outcome": "pending_claim", "winner_taken": True,
+    })
+    client = _client(monkeypatch)
+
+    body = client.post("/api/diagnosis-check",
+                       json={"guess": "banana allergy", "client_id": VALID_CLIENT}).json()
+
+    assert body["result"] == "already_guessed"
+    assert body["outcome"] == "pending_claim"
+    assert body["diagnosis"] == "Adrenal Crisis"
+
+
+def test_record_failure_503_leaks_no_verdict_and_burns_nothing(monkeypatch):
+    _install_recorder(monkeypatch, error=RuntimeError("backend down"))
+    client = _client(monkeypatch)
+
+    resp = client.post("/api/diagnosis-check",
+                       json={"guess": "adrenal crisis", "client_id": VALID_CLIENT})
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body == {"detail": "record_failed"}  # no result/outcome/diagnosis keys
+    for verdict_key in ("result", "outcome", "diagnosis", "winner_taken"):
+        assert verdict_key not in body
+
+
+def test_client_cannot_pick_the_case(monkeypatch):
+    # A payload case_id must be ignored — the server pin decides.
+    calls = _install_recorder(monkeypatch, response={
+        "already_guessed": False, "is_correct": False,
+        "outcome": "incorrect", "winner_taken": False,
+    })
+    client = _client(monkeypatch, active_case=1)
+
+    body = client.post("/api/diagnosis-check", json={
+        "guess": "cerebral venous sinus thrombosis",
+        "client_id": VALID_CLIENT,
+        "case_id": 7,  # attempted farm of a case not in play
+    }).json()
+
+    assert calls[0]["case_id"] == 1
+    assert body["case_id"] == 1
+    # Correct for case 7, but adjudicated against case 1 → incorrect here.
+    assert body["result"] == "incorrect"
+
+
+def test_misconfigured_active_case_503s(monkeypatch):
+    _install_recorder(monkeypatch, response={})
+    client = _client(monkeypatch, active_case=999)
+
+    resp = client.post("/api/diagnosis-check",
+                       json={"guess": "adrenal crisis", "client_id": VALID_CLIENT})
+
+    assert resp.status_code == 503
+    assert resp.json() == {"detail": "contest unavailable"}
+
+
+def test_auth_mirrors_sim_patient(monkeypatch):
+    _install_recorder(monkeypatch, response={
+        "already_guessed": False, "is_correct": False,
+        "outcome": "incorrect", "winner_taken": False,
+    })
+    client = _client(monkeypatch, api_key="secret-key")
+
+    payload = {"guess": "gastro", "client_id": VALID_CLIENT}
+    assert client.post("/api/diagnosis-check", json=payload).status_code == 401
+    assert client.post("/api/diagnosis-check", json=payload,
+                       headers={"Authorization": "Bearer wrong"}).status_code == 401
+    assert client.post("/api/diagnosis-check", json=payload,
+                       headers={"Authorization": "Bearer secret-key"}).status_code == 200
+
+
+@pytest.mark.parametrize("payload", [
+    {"client_id": VALID_CLIENT},                              # guess missing
+    {"guess": "   ", "client_id": VALID_CLIENT},              # guess blank
+    {"guess": "x" * 201, "client_id": VALID_CLIENT},          # guess too long
+    {"guess": "gastro"},                                      # client_id missing
+    {"guess": "gastro", "client_id": "short"},                # client_id too short
+    {"guess": "gastro", "client_id": "bad chars!" + "a" * 8}, # client_id bad chars
+])
+def test_validation_422(monkeypatch, payload):
+    calls = _install_recorder(monkeypatch, response={})
+    client = _client(monkeypatch)
+
+    resp = client.post("/api/diagnosis-check", json=payload)
+
+    assert resp.status_code == 422
+    assert calls == []  # nothing recorded on validation failure

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -1,10 +1,11 @@
 """Hermetic tests for the simulated-patient endpoint logic (no real LLM, no network).
 
-Covers plan §2.5:
+Covers plan §2.5 (updated for the ward-clerk contest):
   (a) case loads + secrets stripped from the prompt payload
   (b) a non-guess question returns is_guess: false
-  (c) a guess matching acceptable_answers/fuzzy diagnosis returns correct: true + diagnosis
-  (d) a wrong guess returns correct: false and no diagnosis
+  (c) a guess is NEVER adjudicated in chat: deflected to the ward clerk,
+      correct/diagnosis always None (/api/diagnosis-check owns verdicts)
+  (d) right or wrong, the real answer never enters the reply prompt
   (e) 401 when SIM_PATIENT_API_KEY is set and the bearer header is missing (TestClient)
 """
 import asyncio
@@ -110,42 +111,42 @@ def test_non_guess_question(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# (c) correct guess (via acceptable_answers / fuzzy) → correct true + diagnosis
+# (c) guesses are NEVER adjudicated in chat — deflected to the ward clerk
 # ---------------------------------------------------------------------------
 
-def test_correct_guess_reveals_diagnosis(monkeypatch):
+def test_correct_guess_is_not_adjudicated_and_deflects_to_clerk(monkeypatch):
+    """Even a spot-on guess gets no verdict from the patient — the chat path
+    would otherwise be a free correctness oracle for the one-guess contest."""
     fake = _install_fake(
         monkeypatch,
         '{"is_guess": true, "diagnosis": "addisonian crisis"}',
-        reply_text="Sash grins weakly. \"Yeah… that's it.\"",
     )
 
     result = _run(sim_patient.handle_question("is it addisonian crisis?"))
 
     assert result["is_guess"] is True
-    assert result["correct"] is True
-    assert result["diagnosis"] == "Adrenal Crisis"
+    assert result["correct"] is None
+    assert result["diagnosis"] is None
 
-    # The reply prompt should carry the celebratory extra instruction with the dx.
+    # The reply prompt deflects to the clerk and never sees the real answer.
     reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
     user_prompt = reply_calls[0]["messages"][1]["content"]
-    assert "guessed correctly" in user_prompt
-    assert "Adrenal Crisis" in user_prompt  # revealed to the LLM only on a correct guess
+    assert "ward clerk" in user_prompt
+    assert "confirm or deny" in user_prompt
+    assert "Adrenal Crisis" not in user_prompt
 
 
-def test_correct_guess_via_fuzzy_match(monkeypatch):
-    # "adrenal crises" (typo) fuzzy-matches "adrenal crisis" at >= 0.75.
-    _install_fake(monkeypatch, '{"is_guess": true, "diagnosis": "adrenal crises"}')
-
-    result = _run(sim_patient.handle_question("adrenal crises?"))
-
-    assert result["is_guess"] is True
-    assert result["correct"] is True
-    assert result["diagnosis"] == "Adrenal Crisis"
+def test_check_guess_still_matches_for_the_clerk_endpoint(monkeypatch):
+    # The matcher itself stays available (the clerk endpoint uses it):
+    # exact acceptable answer, >=0.75 fuzzy typo, and a near-miss reject.
+    case = sim_patient.load_case(1)
+    assert sim_patient.check_guess("addisonian crisis", case) is True
+    assert sim_patient.check_guess("adrenal crises", case) is True  # typo, fuzzy
+    assert sim_patient.check_guess("appendicitis", case) is False
 
 
 # ---------------------------------------------------------------------------
-# (d) wrong guess → correct false, no diagnosis
+# (d) wrong guess → same deflection, answer never in the prompt
 # ---------------------------------------------------------------------------
 
 def test_wrong_guess_no_diagnosis(monkeypatch):
@@ -154,13 +155,14 @@ def test_wrong_guess_no_diagnosis(monkeypatch):
     result = _run(sim_patient.handle_question("is it appendicitis?"))
 
     assert result["is_guess"] is True
-    assert result["correct"] is False
+    assert result["correct"] is None
     assert result["diagnosis"] is None
 
-    # Wrong-guess reply prompt must NOT contain the real answer.
+    # Deflection prompt must NOT contain the real answer or a verdict.
     reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
     user_prompt = reply_calls[0]["messages"][1]["content"]
-    assert "INCORRECT" in user_prompt
+    assert "ward clerk" in user_prompt
+    assert "INCORRECT" not in user_prompt
     assert "Adrenal Crisis" not in user_prompt
 
 
@@ -262,10 +264,9 @@ def test_non_string_classifier_diagnosis_does_not_crash(monkeypatch):
     _install_fake(monkeypatch, '{"is_guess": true, "diagnosis": ["adrenal crisis"]}')
     result = _run(sim_patient.handle_question("is it adrenal crisis?"))
     assert result["is_guess"] is True
-    # diagnosis coerced to None → check_guess falls back to the raw question,
-    # which fuzzy-matches "adrenal crisis" → correct.
-    assert result["correct"] is True
-    assert result["diagnosis"] == "Adrenal Crisis"
+    # Chat never adjudicates any more — a detected guess only deflects.
+    assert result["correct"] is None
+    assert result["diagnosis"] is None
 
 
 def test_string_case_id_resolves(monkeypatch):


### PR DESCRIPTION
Roo half of the health-hack **ward-clerk diagnosis contest** (depends on mlai-backend #537 for the record/claim endpoints; health-hack UI stacks on top).

## What's here
- **`POST /api/diagnosis-check`** (`roo/main.py`) — the scripted clerk contest. **No LLM anywhere in this path.** Adjudicates ONE guess with the existing deterministic `check_guess` matcher (exact `acceptable_answers` + `SequenceMatcher ≥ 0.75`, same fairness as the Slack game), then records the verdict to mlai-backend **before** revealing it. Maps to `correct_first` / `correct_beaten` / `incorrect` / `already_guessed`. Active case is pinned server-side (`SIM_ACTIVE_CASE_ID`) so clients can't pick a case and farm tickets.
- **Backend-down safety** (`record_web_guess` in `roo/sim_patient.py`): if recording fails, the endpoint returns **`503` with no verdict fields** — an unrecorded reveal would make backend-down a free correctness oracle, and because nothing was recorded the player's one guess isn't burned.
- **Oracle neutralized** (`handle_question`): the patient chat previously adjudicated guesses and returned `correct`/`diagnosis` (shipped in #181). It now **deflects** every detected guess in-character to "Reg, the ward clerk at reception" and returns `correct`/`diagnosis` as `null` always. Otherwise players could probe the patient until correct, then bank a guaranteed win on their single clerk guess. Nurse path unchanged (already never adjudicated).

## Auth / secrets
No new secrets — bearer auth mirrors `/api/sim-patient` (`SIM_PATIENT_API_KEY`), and the roo→backend call reuses `ROO_API_KEY`/`INTERNAL_API_KEY`.

## Verification
87/87 tests pass (rewritten `test_sim_patient.py` sections c/d + new `test_diagnosis_check.py`, 14 cases incl. the 503-no-verdict and case-pinning invariants). Live-verified against a local backend AND the real OpenAI API: the patient deflects guesses to the clerk with the actual gpt-5 (`is_guess=true, correct=null`), and the full guess→record→claim chain produced a single winner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)