### PR TITLE
Make Dr Snow and Nurse Paws AI-first

### DIFF
--- a/roo-standalone/requirements.txt
+++ b/roo-standalone/requirements.txt
@@ -14,7 +14,7 @@ alembic>=1.12.0
 slack-sdk>=3.21.0
 
 # LLM Providers
-openai>=1.3.0
+openai>=1.66.0
 anthropic>=0.18.0
 google-generativeai>=0.3.0
 

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -82,7 +82,7 @@ class Settings(BaseSettings):
     # unset (dev). The original Slack game used reasoning_effort="high"; the game
     # world defaults to "low" for latency (both overridable via env).
     SIM_PATIENT_API_KEY: Optional[str] = None
-    SIM_PATIENT_MODEL: str = "gpt-5"
+    SIM_PATIENT_MODEL: str = "gpt-5.6-terra"
     SIM_PATIENT_REASONING_EFFORT: str = "low"
     # The ward contest's active case (cases.yaml id). Pinned server-side so web
     # clients can never pick a case and farm tickets from cases not in play.

--- a/roo-standalone/roo/llm.py
+++ b/roo-standalone/roo/llm.py
@@ -4,9 +4,10 @@ Model-Agnostic LLM Client
 Supports multiple LLM providers with a unified async interface.
 """
 import json
+import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Callable
 from enum import Enum
 import base64
 
@@ -36,6 +37,16 @@ class ToolCall:
     model: str = ""
 
 
+@dataclass
+class AgentResponse:
+    """Final text plus the tool trace from a Responses API agent turn."""
+
+    content: str
+    model: str
+    usage: Optional[Dict[str, int]] = None
+    tool_calls: List[Dict[str, Any]] = field(default_factory=list)
+
+
 class ToolCallParseError(ValueError):
     """The model produced no tool call or unparsable arguments."""
 
@@ -63,6 +74,19 @@ class BaseLLMClient(ABC):
         raise NotImplementedError(
             f"{type(self).__name__} does not support tool calling yet; "
             "use an OpenAI-compatible provider (openai/gemini) for the router."
+        )
+
+    async def agent_with_tools(
+        self,
+        messages: List[Dict[str, str]],
+        tools: List[Dict[str, Any]],
+        execute_tool: Callable[[str, Dict[str, Any]], Any],
+        **kwargs,
+    ) -> AgentResponse:
+        """Run model → tool → model until the model emits final text."""
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support Responses API agents; "
+            "use the OpenAI provider for the ward NPCs."
         )
 
 
@@ -159,6 +183,93 @@ class OpenAIClient(BaseLLMClient):
                 f"tool arguments for {call.function.name} are not an object: {raw_arguments[:200]}"
             )
         return ToolCall(name=call.function.name, arguments=arguments, model=response.model)
+
+    async def agent_with_tools(
+        self,
+        messages: List[Dict[str, str]],
+        tools: List[Dict[str, Any]],
+        execute_tool: Callable[[str, Dict[str, Any]], Any],
+        **kwargs,
+    ) -> AgentResponse:
+        """Run a bounded Responses API function-calling loop.
+
+        Response output items (including GPT-5 reasoning items) are fed back
+        unchanged alongside each function result, as required by the API.
+        """
+        model = kwargs.get("model", self.model)
+        instructions = "\n\n".join(
+            message["content"] for message in messages if message.get("role") == "system"
+        )
+        input_items: List[Any] = [
+            {"role": message["role"], "content": message["content"]}
+            for message in messages
+            if message.get("role") != "system"
+        ]
+        prompt_tokens = 0
+        completion_tokens = 0
+        tool_trace: List[Dict[str, Any]] = []
+        max_tool_rounds = max(0, min(int(kwargs.get("max_tool_rounds", 2)), 4))
+
+        for round_index in range(max_tool_rounds + 1):
+            create_kwargs: Dict[str, Any] = {
+                "model": model,
+                "instructions": instructions,
+                "input": input_items,
+                "tools": tools,
+                "tool_choice": kwargs.get("tool_choice", "auto"),
+                "parallel_tool_calls": False,
+                "max_output_tokens": kwargs.get("max_tokens", 700),
+            }
+            reasoning_effort = kwargs.get("reasoning_effort")
+            if reasoning_effort:
+                create_kwargs["reasoning"] = {"effort": reasoning_effort}
+
+            response = await self.client.responses.create(**create_kwargs)
+            usage = getattr(response, "usage", None)
+            prompt_tokens += int(getattr(usage, "input_tokens", 0) or 0)
+            completion_tokens += int(getattr(usage, "output_tokens", 0) or 0)
+            model = getattr(response, "model", model)
+            function_calls = [
+                item for item in (getattr(response, "output", None) or [])
+                if getattr(item, "type", None) == "function_call"
+            ]
+            if not function_calls:
+                return AgentResponse(
+                    content=getattr(response, "output_text", "") or "",
+                    model=model,
+                    usage={
+                        "prompt_tokens": prompt_tokens,
+                        "completion_tokens": completion_tokens,
+                    },
+                    tool_calls=tool_trace,
+                )
+            if round_index >= max_tool_rounds:
+                raise RuntimeError("ward NPC exceeded the maximum tool-call rounds")
+
+            # Preserve all output items, especially reasoning items from GPT-5.
+            input_items.extend(response.output)
+            for call in function_calls:
+                try:
+                    arguments = json.loads(call.arguments or "{}")
+                except json.JSONDecodeError as exc:
+                    raise ToolCallParseError(
+                        f"unparsable tool arguments for {call.name}: {call.arguments!r:.200}"
+                    ) from exc
+                if not isinstance(arguments, dict):
+                    raise ToolCallParseError(
+                        f"tool arguments for {call.name} are not an object"
+                    )
+                tool_trace.append({"name": call.name, "arguments": arguments})
+                result = execute_tool(call.name, arguments)
+                if inspect.isawaitable(result):
+                    result = await result
+                input_items.append({
+                    "type": "function_call_output",
+                    "call_id": call.call_id,
+                    "output": json.dumps(result, ensure_ascii=False, default=str),
+                })
+
+        raise RuntimeError("ward NPC did not produce a final response")
 
     async def embed(self, text: str) -> List[float]:
         """Generate embeddings using OpenAI."""

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -2146,8 +2146,8 @@ async def api_sim_patient(request: Request, settings: Settings = Depends(get_set
 
     Runs the medhack "Guess the Diagnosis" case as an in-character narrator.
     Stateless: never touches medhack game state, points, or the guess lockout.
-    role="nurse" answers as the reception nurse (investigation results from the
-    same case file; never adjudicates guesses).
+    role="nurse" runs Dr Snow's results agent and role="clerk" runs Nurse
+    Paws' observations, examination, and final-guess preparation agent.
 
     Auth is bearer-only and applied ONLY when SIM_PATIENT_API_KEY is set (open in
     dev). Errors: 401 bad/missing token, 404 unknown case_id, 422 missing
@@ -2164,8 +2164,11 @@ async def api_sim_patient(request: Request, settings: Settings = Depends(get_set
         raise HTTPException(status_code=422, detail="question required")
 
     role = (payload.get("role") or "patient").strip().lower()
-    if role not in ("patient", "nurse"):
-        raise HTTPException(status_code=422, detail="role must be 'patient' or 'nurse'")
+    if role not in ("patient", "nurse", "clerk"):
+        raise HTTPException(
+            status_code=422,
+            detail="role must be 'patient', 'nurse', or 'clerk'",
+        )
 
     # Defensive caps: bound the question length and history depth server-side.
     question = question[:500]
@@ -2184,6 +2187,11 @@ async def api_sim_patient(request: Request, settings: Settings = Depends(get_set
             case_id=payload.get("case_id"),
             player_id=payload.get("player_id") or "web-anon",
             role=role,
+            contest_state=(
+                payload.get("contest_state")
+                if isinstance(payload.get("contest_state"), dict)
+                else None
+            ),
         )
     except KeyError as exc:
         raise HTTPException(status_code=404, detail=str(exc))

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -2248,10 +2248,11 @@ async def api_diagnosis_check(request: Request, settings: Settings = Depends(get
 
     already = bool(record.get("already_guessed"))
     stored_correct = bool(record.get("is_correct"))
+    is_first_solver = bool(record.get("is_first_solver"))
     winner_taken = bool(record.get("winner_taken"))
     if already:
         result = "already_guessed"
-    elif stored_correct and not winner_taken:
+    elif stored_correct and is_first_solver:
         result = "correct_first"
     elif stored_correct:
         result = "correct_beaten"
@@ -2261,6 +2262,7 @@ async def api_diagnosis_check(request: Request, settings: Settings = Depends(get
     return {
         "result": result,
         "outcome": record.get("outcome"),
+        "prize_kind": record.get("prize_kind"),
         "winner_taken": winner_taken,
         "case_id": case.get("id"),
         # The STORED verdict is authoritative (covers the already_guessed resume

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -2244,6 +2244,7 @@ async def api_diagnosis_check(request: Request, settings: Settings = Depends(get
         record = await record_web_guess(
             settings,
             case_id=case.get("id"),
+            case_title=str(case.get("title") or f"Case {case.get('id')}"),
             client_id=client_id,
             guess_text=guess,
             is_correct=is_correct,

--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -307,6 +307,123 @@ GAME RULES
 Your replies appear in a small in-game dialogue box: keep them under ~110 words."""
 
 
+def _result_line(title: str, values: list[tuple[str, Any]]) -> str:
+    rendered = [f"{label}: {value}" for label, value in values if value not in (None, "")]
+    return f"{title}: " + "; ".join(rendered) + "."
+
+
+def deterministic_nurse_reply(question: str, case: dict) -> Optional[str]:
+    """Read authored investigation results without spending an LLM turn.
+
+    The case YAML is the source of truth. Questions outside the known
+    investigation set return ``None`` so the nurse agent can handle them.
+    """
+    q = question.lower()
+    investigations = case.get("investigations") or {}
+    bloods = investigations.get("bloods") or {}
+    vitals = case.get("vitals") or {}
+
+    if re.search(
+        r"\b(is it|is this|could it be|could this be|i think it'?s|my diagnosis|"
+        r"diagnosis is|sounds like|what do you think|what'?s wrong with)\b",
+        q,
+    ):
+        return "That's your call, doc. I can give you the investigation results, but Nurse Paws takes the final diagnosis."
+
+    endocrine = investigations.get("endocrine_if_ordered") or {}
+    if "cortisol" in q and "acth" in q and endocrine:
+        return _result_line("Endocrine tests", [
+            ("random cortisol", endocrine.get("random_cortisol")),
+            ("ACTH", endocrine.get("acth")),
+        ])
+    if "cortisol" in q and endocrine.get("random_cortisol"):
+        return f"Random cortisol: {endocrine['random_cortisol']}."
+    if re.search(r"\bacth\b", q) and endocrine.get("acth"):
+        return f"ACTH: {endocrine['acth']}."
+    if re.search(r"\b(vbg|venous blood gas|blood gas)\b", q) and investigations.get("vbg"):
+        return f"VBG: {investigations['vbg']}."
+    if re.search(r"\b(ecg|ekg|electrocardiogram)\b", q) and investigations.get("ecg"):
+        return f"ECG: {investigations['ecg']}."
+    if re.search(r"\b(bgl|finger\s*stick|fingerstick|bedside glucose|blood glucose|glucose)\b", q):
+        return _result_line("Glucose", [
+            ("bedside", investigations.get("fingerstick_glucose")),
+            ("laboratory", bloods.get("glucose_lab")),
+        ])
+    if re.search(r"\b(fbc|full blood count|cbc|haemoglobin|hemoglobin|wcc|white cell|eosinophil)\b", q):
+        return _result_line("FBC", [
+            ("WCC", bloods.get("wcc")),
+            ("haemoglobin", bloods.get("haemoglobin")),
+            ("eosinophils", bloods.get("eosinophils")),
+        ])
+    if re.search(
+        r"\b(uec|euc|electrolytes?|sodium|potassium|chloride|bicarbonate|urea|"
+        r"creatinine|renal function|kidney function)\b|\bu\s*&\s*e(?:s|c)?\b",
+        q,
+    ):
+        return _result_line("Electrolytes and renal function", [
+            ("sodium", bloods.get("sodium")),
+            ("potassium", bloods.get("potassium")),
+            ("chloride", bloods.get("chloride")),
+            ("bicarbonate", bloods.get("bicarbonate")),
+            ("urea", bloods.get("urea")),
+            ("creatinine", bloods.get("creatinine")),
+        ])
+    if re.search(r"\b(crp|inflammatory markers?|lactate)\b", q):
+        return _result_line("Inflammatory markers", [
+            ("CRP", bloods.get("crp")),
+            ("lactate", bloods.get("lactate")),
+            ("WCC", bloods.get("wcc")),
+        ])
+    if re.search(r"\b(bloods?|labs?|laboratory tests?|blood tests?)\b", q) and bloods:
+        labels = {
+            "wcc": "WCC", "haemoglobin": "haemoglobin", "eosinophils": "eosinophils",
+            "crp": "CRP", "glucose_lab": "glucose",
+        }
+        return _result_line(
+            "Bloods",
+            [(labels.get(key, key.replace("_", " ")), value) for key, value in bloods.items()],
+        )
+    if re.search(r"\b(urinalysis|urine dip|urine|ua)\b", q) and investigations.get("urinalysis"):
+        return f"Urinalysis: {investigations['urinalysis']}."
+    if re.search(r"\b(pregnancy|hcg|β-hcg|beta.?hcg)\b", q) and investigations.get("pregnancy_test"):
+        return f"Pregnancy test: {investigations['pregnancy_test']}."
+    if re.search(
+        r"\b(observations?|vitals?|obs|blood pressure|bp|heart rate|pulse|"
+        r"respiratory rate|temperature|spo2|sats)\b",
+        q,
+    ) and vitals:
+        return _result_line(
+            "Observations",
+            [(key.replace("_", " "), value) for key, value in vitals.items()],
+        )
+
+    imaging = investigations.get("imaging_if_ordered") or {}
+    if re.search(r"abdo(?:minal)?\s*(?:ultrasound|uss)|ultrasound|\buss\b", q):
+        result = imaging.get("abdominal_ultrasound")
+        return f"Abdominal ultrasound: {result}." if result else None
+    if re.search(r"chest\s*x-?ray|\bcxr\b|chest film|lung film", q):
+        return "No chest X-ray was performed for this patient."
+    if re.search(r"\bct\b|computed tomography", q):
+        return "No CT was performed for this patient."
+    if re.search(r"\bmri\b|magnetic resonance", q):
+        return "No MRI was performed for this patient."
+
+    if re.search(
+        r"\b(all|available|list|which|what)\b.*\b(investigations?|tests?|studies|"
+        r"results?|workup|imaging)\b|\banything else\b|\bexamples?\b",
+        q,
+    ):
+        return (
+            "I have observations, ECG, bedside glucose, FBC, electrolytes and renal "
+            "function, inflammatory markers, VBG, urinalysis, pregnancy testing, "
+            "cortisol and ACTH, plus abdominal ultrasound. Name a panel or test and "
+            "I'll read the exact result."
+        )
+    if re.search(r"^(hi|hello|hey|g'?day)\b", q):
+        return "Dr Snow. I have the full investigation chart for cubicle 3. What result do you need?"
+    return None
+
+
 def _format_transcript(history: Optional[list[dict]], npc_label: str = "Patient") -> str:
     """Render prior turns as a plain transcript block (most recent last).
 
@@ -685,7 +802,18 @@ async def handle_question(
                 "reception desk. Do not repeat their theory back to them."
             )
 
-    raw_reply = await npc_reply(question, history, case, role=role, extra_instruction=extra_instruction)
+    response_source = "llm"
+    raw_reply = deterministic_nurse_reply(question, case) if is_nurse else None
+    if raw_reply is not None:
+        response_source = "deterministic"
+    else:
+        raw_reply = await npc_reply(
+            question,
+            history,
+            case,
+            role=role,
+            extra_instruction=extra_instruction,
+        )
 
     # Choke point: every reply is sanitized to spoken words only here (not inside
     # npc_reply), so any caller / future path is covered. Pass the speaker's known
@@ -710,4 +838,6 @@ async def handle_question(
         # endpoint owns verdicts). Always None; kept so PatientReply parses.
         "correct": None,
         "diagnosis": None,
+        "response_source": response_source,
+        "model": get_settings().SIM_PATIENT_MODEL if response_source == "llm" else "",
     }

--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -5,13 +5,13 @@ Powers the health-hack 3D ward "Guess the Diagnosis" interaction: a player walks
 up to a patient in the game world, asks a question, and this module produces an
 in-character reply using the medhack skill's clinical case files.
 
-Two personas share the endpoint via ``role``:
+Three personas share the endpoint via ``role``:
   - "patient" (default): the patient in cubicle 3, speaking first person.
     Guesses are classified only to DEFLECT them to the ward clerk — chat
     NEVER adjudicates (see below).
-  - "nurse": the reception nurse who reads out investigation results (bloods,
-    imaging, ECG, obs) from the same case file. Never adjudicates guesses —
-    the classifier is skipped entirely for this role.
+  - "nurse": AI-first Dr Snow, with tools for exact pathology and radiology.
+  - "clerk": AI-first Nurse Paws, with tools for observations, examination,
+    and preparing (but never submitting) an explicitly final diagnosis.
 
 Diagnosis adjudication lives EXCLUSIVELY in /api/diagnosis-check (the scripted
 ward-clerk contest endpoint): it runs check_guess() and records the verdict to
@@ -29,9 +29,8 @@ game state. It reuses ONLY pure, local logic:
     `git show 2427ff6^:roo-standalone/roo/skills/executor.py`)
   - the guess classifier prompt (copied from executor._classify_medhack_intent)
 
-The web game is stateless: it NEVER mutates medhack game state, never awards
-points, and never enforces the one-guess lockout (out of scope — there is no
-penalty for a wrong guess here).
+The conversational path never mutates contest state. The separate diagnosis
+endpoint records the one official guess before returning any verdict.
 """
 from __future__ import annotations
 
@@ -273,7 +272,7 @@ GAME RULES
 1) Only reveal information if asked. Do not volunteer findings.
 2) Stay internally consistent with the case file. Never contradict earlier answers.
 3) You do NOT know your own numbers. If asked for vitals or observations (blood pressure, heart rate, temperature, oxygen or sats, blood sugar or glucose) or any test result (bloods, imaging, ECG, scans), you can't recite figures — tell them the nurse at reception has those numbers. You CAN describe how you FEEL in your own words (dizzy, faint, short of breath, cramping, weak, hot/cold) — just never the measurements.
-4) NEVER reveal or hint at the diagnosis directly, and never confirm or deny a player's diagnosis theory — you genuinely don't know what's wrong with you. Making a diagnosis official happens with Reg, the ward clerk at the reception desk, not with you.
+4) NEVER reveal or hint at the diagnosis directly, and never confirm or deny a player's diagnosis theory — you genuinely don't know what's wrong with you. Making a diagnosis official happens with Nurse Paws at reception, not with you.
 5) If asked about something not in the case data, give a reasonable normal/unremarkable answer about yourself.
 6) Hidden information (backstory, concealed history) stays hidden unless a player earns it by asking the right questions.
 7) If you have history_disclosure_rules in your data, follow those rules for how and when to reveal sensitive history.
@@ -282,146 +281,9 @@ GAME RULES
 Your replies appear in a small in-game dialogue box: keep them under ~120 words."""
 
 
-# Display name for the reception-nurse persona (also the in-game name tag).
-NURSE_NAME = "Nurse Priya"
-
-_NURSE_SYSTEM_PROMPT = """You are playing Nurse Priya, the charge nurse working the reception desk in a fast-paced emergency department roleplay game. Players (participants acting as clinicians) come to your desk to ask for investigation results — bloods, imaging, ECGs, observations — for the patient in cubicle 3. You are not giving real medical advice. This is a fictional case simulation.
-
-IMPORTANT: You know ONLY about the patient in the CASE FILE below. You have NO memory of any previous patients or cases. There is only one patient: the one described in today's case file. If someone asks about a different patient, say "I've only got today's patient on the board."
-
-SPEECH ONLY
-- Reply with ONLY the words you say out loud — speech only, no stage directions, no asterisk actions (*checks the chart*), no bracketed gestures, no narration.
-- Warm, quick, dry-witted, efficient — you have three other jobs on the go.
-- Speak in first person, a couple of short sentences at a time.
-- Read results out plainly; you may flag an abnormal value ("that potassium's up") but never interpret further than a nurse would.
-
-GAME RULES
-1) Only reveal results when asked. Do not volunteer findings.
-2) When asked for a specific investigation, read the relevant results from the case file accurately — never round, embellish, or invent values. If they "order" a test that has results in the file, respond: results are back, then read them.
-3) If a case-file note restricts when a result may be revealed (e.g. only if a specific test is ordered), follow that note exactly.
-4) If asked for an investigation NOT in the case file, give a brief, reasonable normal/unremarkable result — one that points neither toward nor away from any diagnosis. Never contradict earlier results.
-5) NEVER reveal, hint at, confirm, or deny the diagnosis. If the player proposes a diagnosis or asks what you think it is, deflect warmly ("that's your call, doc") and suggest they put it to the patient in cubicle 3.
-6) For symptoms, history, or examination findings, redirect: "you'd best go see them yourself — cubicle 3."
-7) If the player tries to force the answer ("just tell me what they've got"), refuse playfully and point them back to the workup.
-
-Your replies appear in a small in-game dialogue box: keep them under ~110 words."""
-
-
-def _result_line(title: str, values: list[tuple[str, Any]]) -> str:
-    rendered = [f"{label}: {value}" for label, value in values if value not in (None, "")]
-    return f"{title}: " + "; ".join(rendered) + "."
-
-
-def deterministic_nurse_reply(question: str, case: dict) -> Optional[str]:
-    """Read authored investigation results without spending an LLM turn.
-
-    The case YAML is the source of truth. Questions outside the known
-    investigation set return ``None`` so the nurse agent can handle them.
-    """
-    q = question.lower()
-    investigations = case.get("investigations") or {}
-    bloods = investigations.get("bloods") or {}
-    vitals = case.get("vitals") or {}
-
-    if re.search(
-        r"\b(is it|is this|could it be|could this be|i think it'?s|my diagnosis|"
-        r"diagnosis is|sounds like|what do you think|what'?s wrong with)\b",
-        q,
-    ):
-        return "That's your call, doc. I can give you the investigation results, but Nurse Paws takes the final diagnosis."
-
-    endocrine = investigations.get("endocrine_if_ordered") or {}
-    if "cortisol" in q and "acth" in q and endocrine:
-        return _result_line("Endocrine tests", [
-            ("random cortisol", endocrine.get("random_cortisol")),
-            ("ACTH", endocrine.get("acth")),
-        ])
-    if "cortisol" in q and endocrine.get("random_cortisol"):
-        return f"Random cortisol: {endocrine['random_cortisol']}."
-    if re.search(r"\bacth\b", q) and endocrine.get("acth"):
-        return f"ACTH: {endocrine['acth']}."
-    if re.search(r"\b(vbg|venous blood gas|blood gas)\b", q) and investigations.get("vbg"):
-        return f"VBG: {investigations['vbg']}."
-    if re.search(r"\b(ecg|ekg|electrocardiogram)\b", q) and investigations.get("ecg"):
-        return f"ECG: {investigations['ecg']}."
-    if re.search(r"\b(bgl|finger\s*stick|fingerstick|bedside glucose|blood glucose|glucose)\b", q):
-        return _result_line("Glucose", [
-            ("bedside", investigations.get("fingerstick_glucose")),
-            ("laboratory", bloods.get("glucose_lab")),
-        ])
-    if re.search(r"\b(fbc|full blood count|cbc|haemoglobin|hemoglobin|wcc|white cell|eosinophil)\b", q):
-        return _result_line("FBC", [
-            ("WCC", bloods.get("wcc")),
-            ("haemoglobin", bloods.get("haemoglobin")),
-            ("eosinophils", bloods.get("eosinophils")),
-        ])
-    if re.search(
-        r"\b(uec|euc|electrolytes?|sodium|potassium|chloride|bicarbonate|urea|"
-        r"creatinine|renal function|kidney function)\b|\bu\s*&\s*e(?:s|c)?\b",
-        q,
-    ):
-        return _result_line("Electrolytes and renal function", [
-            ("sodium", bloods.get("sodium")),
-            ("potassium", bloods.get("potassium")),
-            ("chloride", bloods.get("chloride")),
-            ("bicarbonate", bloods.get("bicarbonate")),
-            ("urea", bloods.get("urea")),
-            ("creatinine", bloods.get("creatinine")),
-        ])
-    if re.search(r"\b(crp|inflammatory markers?|lactate)\b", q):
-        return _result_line("Inflammatory markers", [
-            ("CRP", bloods.get("crp")),
-            ("lactate", bloods.get("lactate")),
-            ("WCC", bloods.get("wcc")),
-        ])
-    if re.search(r"\b(bloods?|labs?|laboratory tests?|blood tests?)\b", q) and bloods:
-        labels = {
-            "wcc": "WCC", "haemoglobin": "haemoglobin", "eosinophils": "eosinophils",
-            "crp": "CRP", "glucose_lab": "glucose",
-        }
-        return _result_line(
-            "Bloods",
-            [(labels.get(key, key.replace("_", " ")), value) for key, value in bloods.items()],
-        )
-    if re.search(r"\b(urinalysis|urine dip|urine|ua)\b", q) and investigations.get("urinalysis"):
-        return f"Urinalysis: {investigations['urinalysis']}."
-    if re.search(r"\b(pregnancy|hcg|β-hcg|beta.?hcg)\b", q) and investigations.get("pregnancy_test"):
-        return f"Pregnancy test: {investigations['pregnancy_test']}."
-    if re.search(
-        r"\b(observations?|vitals?|obs|blood pressure|bp|heart rate|pulse|"
-        r"respiratory rate|temperature|spo2|sats)\b",
-        q,
-    ) and vitals:
-        return _result_line(
-            "Observations",
-            [(key.replace("_", " "), value) for key, value in vitals.items()],
-        )
-
-    imaging = investigations.get("imaging_if_ordered") or {}
-    if re.search(r"abdo(?:minal)?\s*(?:ultrasound|uss)|ultrasound|\buss\b", q):
-        result = imaging.get("abdominal_ultrasound")
-        return f"Abdominal ultrasound: {result}." if result else None
-    if re.search(r"chest\s*x-?ray|\bcxr\b|chest film|lung film", q):
-        return "No chest X-ray was performed for this patient."
-    if re.search(r"\bct\b|computed tomography", q):
-        return "No CT was performed for this patient."
-    if re.search(r"\bmri\b|magnetic resonance", q):
-        return "No MRI was performed for this patient."
-
-    if re.search(
-        r"\b(all|available|list|which|what)\b.*\b(investigations?|tests?|studies|"
-        r"results?|workup|imaging)\b|\banything else\b|\bexamples?\b",
-        q,
-    ):
-        return (
-            "I have observations, ECG, bedside glucose, FBC, electrolytes and renal "
-            "function, inflammatory markers, VBG, urinalysis, pregnancy testing, "
-            "cortisol and ACTH, plus abdominal ultrasound. Name a panel or test and "
-            "I'll read the exact result."
-        )
-    if re.search(r"^(hi|hello|hey|g'?day)\b", q):
-        return "Dr Snow. I have the full investigation chart for cubicle 3. What result do you need?"
-    return None
+# Display names returned to the game UI.
+NURSE_NAME = "Dr Snow"
+CLERK_NAME = "Nurse Paws"
 
 
 def _format_transcript(history: Optional[list[dict]], npc_label: str = "Patient") -> str:
@@ -546,7 +408,7 @@ _ROLE_LABELS = ("patient", "nurse", "narrator", "pqm")
 def _label_tokens(speaker_names: tuple[str, ...]) -> list[str]:
     """Known speaker labels (role words + names/name-parts), longest-first.
 
-    Longest-first so a two-word name ("Nurse Priya") is matched before its
+    Longest-first so a two-word name ("Nurse Paws") is matched before its
     parts ("Nurse") in the regex alternation.
     """
     toks: set[str] = set(_ROLE_LABELS)
@@ -707,6 +569,7 @@ def _speech_only(text: str, speaker_names: tuple[str, ...] = ()) -> str:
 _EMPTY_REPLY_FALLBACK = {
     "patient": "Sorry doc — I lost my train of thought there. What did you want to ask?",
     "nurse": "Sorry doc — swamped for a sec. What did you need?",
+    "clerk": "Sorry, doc — lost the thread for a second. What did you want to ask?",
 }
 
 
@@ -714,19 +577,16 @@ async def npc_reply(
     question: str,
     history: Optional[list[dict]],
     case: dict,
-    role: str = "patient",
     extra_instruction: str = "",
 ) -> str:
-    """Generate an in-character reply (PQM narrator, or the reception nurse).
+    """Generate an in-character patient reply through the legacy chat path.
 
     The user prompt embeds the stripped case yaml + transcript + player's message
     exactly like the original _medhack_llm_response, plus an optional
     extra_instruction (used for correct/incorrect guess handling).
     """
     case_str = _redact_answer(yaml.dump(case_for_prompt(case), default_flow_style=False), case)
-    is_nurse = role == "nurse"
-    transcript = _format_transcript(history, npc_label="Nurse" if is_nurse else "Patient")
-    persona = "the reception nurse" if is_nurse else "the PQM narrator"
+    transcript = _format_transcript(history, npc_label="Patient")
 
     prompt = f"""CASE FILE (INTERNAL TRUTH - use this to answer questions):
 {case_str}
@@ -738,13 +598,13 @@ Previous conversation in this thread:
 
 Player's message: "{question}"
 
-Respond in character as {persona}. Remember: only reveal what was asked for."""
+Respond in character as the PQM narrator. Remember: only reveal what was asked for."""
 
     settings = get_settings()
     openai_client = get_llm_client("openai")
     response = await openai_client.chat(
         [
-            {"role": "system", "content": _NURSE_SYSTEM_PROMPT if is_nurse else _PATIENT_SYSTEM_PROMPT},
+            {"role": "system", "content": _PATIENT_SYSTEM_PROMPT},
             {"role": "user", "content": prompt},
         ],
         model=settings.SIM_PATIENT_MODEL,
@@ -764,6 +624,7 @@ async def handle_question(
     case_id: Optional[int] = None,
     player_id: str = "web-anon",
     role: str = "patient",
+    contest_state: Optional[dict[str, Any]] = None,
 ) -> dict:
     """Orchestrate: load case → classify → deflect/reply → response dict.
 
@@ -775,18 +636,19 @@ async def handle_question(
     win at the clerk. `correct`/`diagnosis` are always None (kept in the
     response shape for frontend compatibility).
 
-    role="nurse" answers as the reception nurse instead: the guess classifier is
-    skipped entirely, so is_guess is always False and the diagnosis can never be
-    revealed through this persona.
+    Dr Snow and Nurse Paws are AI-first tool agents. Their tools can retrieve
+    authored facts or prepare a non-mutating confirmation action, but never
+    adjudicate a diagnosis.
     """
     history = (history or [])[-MAX_HISTORY_TURNS:]
     case = load_case(case_id)
     is_nurse = role == "nurse"
+    is_clerk = role == "clerk"
 
     extra_instruction = ""
     is_guess = False
 
-    if not is_nurse:
+    if not is_nurse and not is_clerk:
         classification = await classify_guess(question)
         is_guess = bool(classification.get("is_guess"))
 
@@ -798,20 +660,35 @@ async def handle_question(
                 "The doctor just told you what they think is wrong with you. Do NOT "
                 "confirm or deny it — you genuinely don't know what's wrong with you. "
                 "Tell them, in character, that if they want to make their diagnosis "
-                "official they should log it with Reg, the ward clerk at the "
-                "reception desk. Do not repeat their theory back to them."
+                "official they should discuss it with Nurse Paws at reception. "
+                "Do not repeat their theory back to them."
             )
 
     response_source = "llm"
-    raw_reply = deterministic_nurse_reply(question, case) if is_nurse else None
-    if raw_reply is not None:
-        response_source = "deterministic"
+    model_name = get_settings().SIM_PATIENT_MODEL
+    usage: dict[str, int] = {}
+    tool_calls: list[dict[str, Any]] = []
+    suggested_action = None
+    if is_nurse or is_clerk:
+        from .ward_agents import run_ward_agent
+
+        agent_result = await run_ward_agent(
+            role=role,
+            question=question,
+            history=history,
+            case=case,
+            contest_state=contest_state,
+        )
+        raw_reply = agent_result.reply
+        model_name = agent_result.model
+        usage = agent_result.usage
+        tool_calls = agent_result.tool_calls
+        suggested_action = agent_result.suggested_action
     else:
         raw_reply = await npc_reply(
             question,
             history,
             case,
-            role=role,
             extra_instruction=extra_instruction,
         )
 
@@ -820,11 +697,17 @@ async def handle_question(
     # names so their own name label ("Sash:") is stripped. When nothing spoken
     # remains (reply was pure stage direction / empty model output) substitute a
     # short in-character line rather than showing an empty or markup-only box.
-    display_name = NURSE_NAME if is_nurse else (case.get("patient") or {}).get("name")
-    speaker_names = tuple(n for n in (display_name, NURSE_NAME) if n)
+    display_name = (
+        NURSE_NAME
+        if is_nurse
+        else CLERK_NAME
+        if is_clerk
+        else (case.get("patient") or {}).get("name")
+    )
+    speaker_names = tuple(n for n in (display_name, NURSE_NAME, CLERK_NAME) if n)
     reply = _speech_only(raw_reply, speaker_names=speaker_names)
     if not reply:
-        reply = _EMPTY_REPLY_FALLBACK["nurse" if is_nurse else "patient"]
+        reply = _EMPTY_REPLY_FALLBACK[role]
 
     return {
         "reply": reply,
@@ -839,5 +722,8 @@ async def handle_question(
         "correct": None,
         "diagnosis": None,
         "response_source": response_source,
-        "model": get_settings().SIM_PATIENT_MODEL if response_source == "llm" else "",
+        "model": model_name,
+        "usage": usage,
+        "tool_calls": tool_calls,
+        "suggested_action": suggested_action,
     }

--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -214,6 +214,7 @@ async def record_web_guess(
     settings,
     *,
     case_id: int,
+    case_title: str,
     client_id: str,
     guess_text: str,
     is_correct: bool,
@@ -238,6 +239,7 @@ async def record_web_guess(
             url,
             json={
                 "case_id": case_id,
+                "case_title": case_title,
                 "client_id": client_id,
                 "guess_text": guess_text,
                 "is_correct": is_correct,

--- a/roo-standalone/roo/tests/test_diagnosis_check.py
+++ b/roo-standalone/roo/tests/test_diagnosis_check.py
@@ -78,7 +78,7 @@ def test_correct_first_records_then_reveals(monkeypatch):
     assert body["diagnosis"] == "Adrenal Crisis"
     # Adjudicated deterministically and recorded with the pinned case.
     assert calls == [{
-        "case_id": 1, "client_id": VALID_CLIENT,
+        "case_id": 1, "case_title": "Salt & Static", "client_id": VALID_CLIENT,
         "guess_text": "adrenal crisis", "is_correct": True,
     }]
 

--- a/roo-standalone/roo/tests/test_diagnosis_check.py
+++ b/roo-standalone/roo/tests/test_diagnosis_check.py
@@ -60,7 +60,8 @@ def test_correct_first_records_then_reveals(monkeypatch):
     _install_llm_bomb(monkeypatch)
     calls = _install_recorder(monkeypatch, response={
         "already_guessed": False, "is_correct": True,
-        "outcome": "pending_claim", "winner_taken": False,
+        "outcome": "pending_claim", "prize_kind": "free_ticket",
+        "is_first_solver": True, "winner_taken": True,
     })
     client = _client(monkeypatch)
 
@@ -71,7 +72,8 @@ def test_correct_first_records_then_reveals(monkeypatch):
     body = resp.json()
     assert body["result"] == "correct_first"
     assert body["outcome"] == "pending_claim"
-    assert body["winner_taken"] is False
+    assert body["prize_kind"] == "free_ticket"
+    assert body["winner_taken"] is True
     assert body["case_id"] == 1
     assert body["diagnosis"] == "Adrenal Crisis"
     # Adjudicated deterministically and recorded with the pinned case.
@@ -81,10 +83,11 @@ def test_correct_first_records_then_reveals(monkeypatch):
     }]
 
 
-def test_correct_beaten_when_winner_taken(monkeypatch):
+def test_correct_beaten_when_backend_assigns_discount(monkeypatch):
     _install_recorder(monkeypatch, response={
         "already_guessed": False, "is_correct": True,
-        "outcome": "pending_claim", "winner_taken": True,
+        "outcome": "pending_claim", "prize_kind": "discount_30",
+        "is_first_solver": False, "winner_taken": True,
     })
     client = _client(monkeypatch)
 
@@ -92,6 +95,7 @@ def test_correct_beaten_when_winner_taken(monkeypatch):
                        json={"guess": "addisonian crisis", "client_id": VALID_CLIENT}).json()
 
     assert body["result"] == "correct_beaten"
+    assert body["prize_kind"] == "discount_30"
     assert body["winner_taken"] is True
     assert body["diagnosis"] == "Adrenal Crisis"
 
@@ -99,7 +103,8 @@ def test_correct_beaten_when_winner_taken(monkeypatch):
 def test_incorrect_guess_reveals_nothing(monkeypatch):
     calls = _install_recorder(monkeypatch, response={
         "already_guessed": False, "is_correct": False,
-        "outcome": "incorrect", "winner_taken": False,
+        "outcome": "incorrect", "prize_kind": "none",
+        "is_first_solver": False, "winner_taken": False,
     })
     client = _client(monkeypatch)
 
@@ -116,7 +121,8 @@ def test_already_guessed_resume_uses_stored_verdict(monkeypatch):
     # after losing local state) — the stored verdict wins and the dx re-reveals.
     _install_recorder(monkeypatch, response={
         "already_guessed": True, "is_correct": True,
-        "outcome": "pending_claim", "winner_taken": True,
+        "outcome": "pending_claim", "prize_kind": "free_ticket",
+        "is_first_solver": True, "winner_taken": True,
     })
     client = _client(monkeypatch)
 
@@ -146,7 +152,8 @@ def test_client_cannot_pick_the_case(monkeypatch):
     # A payload case_id must be ignored — the server pin decides.
     calls = _install_recorder(monkeypatch, response={
         "already_guessed": False, "is_correct": False,
-        "outcome": "incorrect", "winner_taken": False,
+        "outcome": "incorrect", "prize_kind": "none",
+        "is_first_solver": False, "winner_taken": False,
     })
     client = _client(monkeypatch, active_case=1)
 
@@ -176,7 +183,8 @@ def test_misconfigured_active_case_503s(monkeypatch):
 def test_auth_mirrors_sim_patient(monkeypatch):
     _install_recorder(monkeypatch, response={
         "already_guessed": False, "is_correct": False,
-        "outcome": "incorrect", "winner_taken": False,
+        "outcome": "incorrect", "prize_kind": "none",
+        "is_first_solver": False, "winner_taken": False,
     })
     client = _client(monkeypatch, api_key="secret-key")
 

--- a/roo-standalone/roo/tests/test_llm_agent_tools.py
+++ b/roo-standalone/roo/tests/test_llm_agent_tools.py
@@ -1,0 +1,74 @@
+"""Unit tests for the bounded Responses API ward-agent loop."""
+
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from roo.llm import OpenAIClient
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class FakeResponses:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+
+    async def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+def test_agent_with_tools_executes_and_returns_final_text():
+    reasoning = SimpleNamespace(type="reasoning")
+    tool_call = SimpleNamespace(
+        type="function_call",
+        name="get_observations",
+        arguments="{}",
+        call_id="call-1",
+    )
+    first = SimpleNamespace(
+        output=[reasoning, tool_call],
+        output_text="",
+        model="gpt-5.6-terra",
+        usage=SimpleNamespace(input_tokens=12, output_tokens=4),
+    )
+    second = SimpleNamespace(
+        output=[SimpleNamespace(type="message")],
+        output_text="Heart rate 128.",
+        model="gpt-5.6-terra",
+        usage=SimpleNamespace(input_tokens=18, output_tokens=6),
+    )
+    client = OpenAIClient.__new__(OpenAIClient)
+    client.model = "gpt-5.6-terra"
+    fake = FakeResponses([first, second])
+    client.client = SimpleNamespace(responses=fake)
+    executed = []
+
+    result = _run(client.agent_with_tools(
+        [
+            {"role": "system", "content": "Use exact tool data."},
+            {"role": "user", "content": "Observations please."},
+        ],
+        [{"type": "function", "name": "get_observations"}],
+        lambda name, arguments: executed.append((name, arguments)) or {"heart_rate": 128},
+        reasoning_effort="low",
+    ))
+
+    assert result.content == "Heart rate 128."
+    assert result.usage == {"prompt_tokens": 30, "completion_tokens": 10}
+    assert result.tool_calls == [{"name": "get_observations", "arguments": {}}]
+    assert executed == [("get_observations", {})]
+    assert fake.calls[0]["tool_choice"] == "auto"
+    assert fake.calls[0]["parallel_tool_calls"] is False
+    assert reasoning in fake.calls[1]["input"]
+    assert {
+        "type": "function_call_output",
+        "call_id": "call-1",
+        "output": '{"heart_rate": 128}',
+    } in fake.calls[1]["input"]

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -308,22 +308,31 @@ def test_nurse_role_skips_classifier_and_never_adjudicates(monkeypatch):
     classifier_calls = [c for c in fake.calls if c["kwargs"].get("model") == "gpt-4o-mini"]
     assert not classifier_calls, "nurse role must never invoke the guess classifier"
 
-    # The reply call uses the nurse persona, not the PQM narrator.
+    # Diagnosis deflection is deterministic and never spends an LLM call.
     reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
-    assert len(reply_calls) == 1
-    system_prompt = reply_calls[0]["messages"][0]["content"]
-    assert "Nurse Priya" in system_prompt
-    assert "Patient Quest Master" not in system_prompt
+    assert not reply_calls
+    assert result["response_source"] == "deterministic"
 
 
-def test_nurse_prompt_carries_case_but_no_secrets(monkeypatch):
+def test_known_nurse_investigation_is_deterministic(monkeypatch):
     fake = _install_fake(monkeypatch, "{}", reply_text='"Bloods are back: sodium 122."')
 
     result = _run(sim_patient.handle_question("can I get the bloods?", role="nurse"))
-    # The speech-only sanitizer unwraps the model's wrapping quotes.
-    assert result["reply"] == "Bloods are back: sodium 122."
+    assert result["reply"].startswith("Bloods:")
+    assert "122 mmol/L" in result["reply"]
+    assert "6.1 mmol/L" in result["reply"]
+    assert result["response_source"] == "deterministic"
+    assert fake.calls == []
+
+
+def test_unmatched_nurse_conversation_uses_redacted_agent_context(monkeypatch):
+    fake = _install_fake(monkeypatch, "{}", reply_text="Busy, but surviving. What result do you need?")
+
+    result = _run(sim_patient.handle_question("How is your day going?", role="nurse"))
+    assert result["response_source"] == "llm"
 
     reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
+    assert len(reply_calls) == 1
     user_prompt = reply_calls[0]["messages"][1]["content"]
     # Case content present (so she can actually read results out)…
     assert "CASE FILE" in user_prompt
@@ -539,7 +548,7 @@ def test_handle_question_sanitizes_reply_at_choke_point(monkeypatch):
         return "*sighs* The bloods aren't back yet, love."
 
     monkeypatch.setattr(sim_patient, "npc_reply", fake_npc_reply)
-    result = _run(sim_patient.handle_question("bloods?", role="nurse"))
+    result = _run(sim_patient.handle_question("How is your shift going?", role="nurse"))
     assert result["reply"] == "The bloods aren't back yet, love."
 
 
@@ -549,7 +558,7 @@ def test_empty_model_reply_falls_back_to_canned_line(monkeypatch):
 
     monkeypatch.setattr(sim_patient, "npc_reply", empty_reply)
 
-    nurse = _run(sim_patient.handle_question("bloods?", role="nurse"))
+    nurse = _run(sim_patient.handle_question("How is your shift going?", role="nurse"))
     assert nurse["reply"] == sim_patient._EMPTY_REPLY_FALLBACK["nurse"]
 
     # Patient role runs the classifier first — stub it to a non-guess so no LLM.

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -16,7 +16,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from roo import sim_patient
+from roo import sim_patient, ward_agents
+from roo.llm import AgentResponse
 
 
 class _FakeLLMResponse:
@@ -32,10 +33,18 @@ class _FakeLLMClient:
     fake serves both: gpt-4o-mini → the classifier JSON, anything else → reply.
     """
 
-    def __init__(self, classifier_json: str, reply_text: str = "I feel awful, honestly."):
+    def __init__(
+        self,
+        classifier_json: str,
+        reply_text: str = "I feel awful, honestly.",
+        agent_tool: tuple[str, dict] | None = None,
+    ):
         self.classifier_json = classifier_json
         self.reply_text = reply_text
+        self.agent_tool = agent_tool
         self.calls: list[dict] = []
+        self.agent_calls: list[dict] = []
+        self.tool_results: list[object] = []
 
     async def chat(self, messages, **kwargs):
         self.calls.append({"messages": messages, "kwargs": kwargs})
@@ -43,11 +52,31 @@ class _FakeLLMClient:
             return _FakeLLMResponse(self.classifier_json)
         return _FakeLLMResponse(self.reply_text)
 
+    async def agent_with_tools(self, messages, tools, execute_tool, **kwargs):
+        self.agent_calls.append({"messages": messages, "tools": tools, "kwargs": kwargs})
+        trace = []
+        if self.agent_tool is not None:
+            name, arguments = self.agent_tool
+            self.tool_results.append(execute_tool(name, arguments))
+            trace.append({"name": name, "arguments": arguments})
+        return AgentResponse(
+            content=self.reply_text,
+            model=kwargs.get("model", "gpt-5.6-terra"),
+            usage={"prompt_tokens": 20, "completion_tokens": 8},
+            tool_calls=trace,
+        )
 
-def _install_fake(monkeypatch, classifier_json, reply_text="I feel awful, honestly."):
-    fake = _FakeLLMClient(classifier_json, reply_text)
+
+def _install_fake(
+    monkeypatch,
+    classifier_json,
+    reply_text="I feel awful, honestly.",
+    agent_tool=None,
+):
+    fake = _FakeLLMClient(classifier_json, reply_text, agent_tool)
     # sim_patient imports get_llm_client into its own namespace.
     monkeypatch.setattr(sim_patient, "get_llm_client", lambda provider=None: fake)
+    monkeypatch.setattr(ward_agents, "get_llm_client", lambda provider=None: fake)
     return fake
 
 
@@ -131,7 +160,7 @@ def test_correct_guess_is_not_adjudicated_and_deflects_to_clerk(monkeypatch):
     # The reply prompt deflects to the clerk and never sees the real answer.
     reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
     user_prompt = reply_calls[0]["messages"][1]["content"]
-    assert "ward clerk" in user_prompt
+    assert "Nurse Paws" in user_prompt
     assert "confirm or deny" in user_prompt
     assert "Adrenal Crisis" not in user_prompt
 
@@ -161,7 +190,7 @@ def test_wrong_guess_no_diagnosis(monkeypatch):
     # Deflection prompt must NOT contain the real answer or a verdict.
     reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
     user_prompt = reply_calls[0]["messages"][1]["content"]
-    assert "ward clerk" in user_prompt
+    assert "Nurse Paws" in user_prompt
     assert "INCORRECT" not in user_prompt
     assert "Adrenal Crisis" not in user_prompt
 
@@ -308,21 +337,50 @@ def test_nurse_role_skips_classifier_and_never_adjudicates(monkeypatch):
     classifier_calls = [c for c in fake.calls if c["kwargs"].get("model") == "gpt-4o-mini"]
     assert not classifier_calls, "nurse role must never invoke the guess classifier"
 
-    # Diagnosis deflection is deterministic and never spends an LLM call.
-    reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
-    assert not reply_calls
-    assert result["response_source"] == "deterministic"
+    assert fake.calls == []
+    assert len(fake.agent_calls) == 1
+    assert fake.agent_calls[0]["kwargs"]["model"] == "gpt-5.6-terra"
+    assert result["response_source"] == "llm"
 
 
-def test_known_nurse_investigation_is_deterministic(monkeypatch):
-    fake = _install_fake(monkeypatch, "{}", reply_text='"Bloods are back: sodium 122."')
+def test_known_nurse_investigation_is_ai_first_and_tool_grounded(monkeypatch):
+    fake = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="Bloods are back: sodium 122 and potassium 6.1.",
+        agent_tool=("get_results", {"test_ids": ["bloods"]}),
+    )
 
     result = _run(sim_patient.handle_question("can I get the bloods?", role="nurse"))
-    assert result["reply"].startswith("Bloods:")
-    assert "122 mmol/L" in result["reply"]
-    assert "6.1 mmol/L" in result["reply"]
-    assert result["response_source"] == "deterministic"
+    assert "sodium 122" in result["reply"]
+    assert result["response_source"] == "llm"
+    assert result["tool_calls"] == [
+        {"name": "get_results", "arguments": {"test_ids": ["bloods"]}},
+    ]
     assert fake.calls == []
+    assert len(fake.agent_calls) == 1
+    tool_results = fake.tool_results[0]["results"]
+    assert any(item["id"] == "bloods.sodium" and "122 mmol/L" in item["value"] for item in tool_results)
+    assert any(item["id"] == "bloods.potassium" and "6.1 mmol/L" in item["value"] for item in tool_results)
+
+
+def test_dr_snow_catalog_includes_case_specific_tests_but_not_history_clues():
+    case = {
+        "investigations": {
+            "bloods": {"sodium": "118 mmol/L"},
+            "key_diagnostic_test": {"ct_venogram": "Venous sinus thrombosis", "note": "secret routing note"},
+            "confirmatory_test_if_ordered": {"urine_porphobilinogen": "Markedly elevated"},
+            "substance_history_if_asked_nonjudgmentally": {"cannabis_use": "Daily use"},
+        }
+    }
+
+    catalog = ward_agents.investigation_catalog(case)
+
+    assert catalog["bloods.sodium"]["category"] == "pathology"
+    assert catalog["confirmatory_test_if_ordered.urine_porphobilinogen"]["category"] == "pathology"
+    assert catalog["key_diagnostic_test.ct_venogram"]["category"] == "radiology"
+    assert all("note" not in identifier for identifier in catalog)
+    assert all("substance_history" not in identifier for identifier in catalog)
 
 
 def test_unmatched_nurse_conversation_uses_redacted_agent_context(monkeypatch):
@@ -331,17 +389,100 @@ def test_unmatched_nurse_conversation_uses_redacted_agent_context(monkeypatch):
     result = _run(sim_patient.handle_question("How is your day going?", role="nurse"))
     assert result["response_source"] == "llm"
 
-    reply_calls = [c for c in fake.calls if c["kwargs"].get("model") != "gpt-4o-mini"]
-    assert len(reply_calls) == 1
-    user_prompt = reply_calls[0]["messages"][1]["content"]
-    # Case content present (so she can actually read results out)…
-    assert "CASE FILE" in user_prompt
-    assert "122 mmol/L" in user_prompt
-    # …but never the secret answer, keys, or hints.
-    assert "Adrenal Crisis" not in user_prompt
-    assert "acceptable_answers" not in user_prompt
-    assert "addisonian" not in user_prompt.lower()
-    assert "hints" not in user_prompt
+    assert len(fake.agent_calls) == 1
+    serialized = repr(fake.agent_calls[0])
+    assert "122 mmol/L" not in serialized
+    assert "Adrenal Crisis" not in serialized
+    assert "acceptable_answers" not in serialized
+    assert "hints" not in serialized
+
+
+def test_dr_snow_can_offer_one_authored_scan_when_player_is_stuck(monkeypatch):
+    fake = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="One useful clue: the abdominal ultrasound is unremarkable.",
+        agent_tool=("offer_imaging_clue", {}),
+    )
+
+    result = _run(sim_patient.handle_question("I'm stuck. Give me a useful scan.", role="nurse"))
+
+    assert result["response_source"] == "llm"
+    clue = fake.tool_results[0]
+    assert clue["available"] is True
+    assert clue["result"]["id"] == "imaging_if_ordered.abdominal_ultrasound"
+
+
+def test_nurse_paws_observations_and_examination_are_tool_grounded(monkeypatch):
+    observations = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="Heart rate 128, blood pressure 84 over 48.",
+        agent_tool=("get_observations", {}),
+    )
+    result = _run(sim_patient.handle_question(
+        "Can I have all the observations?",
+        role="clerk",
+        contest_state={"state": "eligible", "outcome": None},
+    ))
+    assert result["patient_name"] == "Nurse Paws"
+    assert observations.tool_results[0]["observations"]["heart_rate"] == 128
+    assert observations.tool_results[0]["observations"]["blood_pressure"] == "84/48"
+
+    examination = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="The abdomen is soft and mildly tender diffusely.",
+        agent_tool=("get_examination", {"system": "abdominal"}),
+    )
+    result = _run(sim_patient.handle_question(
+        "What did you find on abdominal examination?",
+        role="clerk",
+        contest_state={"state": "eligible", "outcome": None},
+    ))
+    assert "mildly tender" in examination.tool_results[0]["examination"]["abdominal"]
+    assert result["suggested_action"] is None
+
+
+def test_nurse_paws_prepares_but_never_submits_final_guess(monkeypatch):
+    fake = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="Review that carefully, then press the confirmation button if you're sure.",
+        agent_tool=("prepare_final_guess", {"diagnosis": "adrenal crisis"}),
+    )
+
+    result = _run(sim_patient.handle_question(
+        "My final diagnosis is adrenal crisis.",
+        role="clerk",
+        contest_state={"state": "eligible", "outcome": None},
+    ))
+
+    assert result["suggested_action"] == {
+        "type": "confirm_diagnosis",
+        "diagnosis": "adrenal crisis",
+    }
+    assert fake.tool_results[0]["prepared"] is True
+    assert result["correct"] is None
+    assert result["diagnosis"] is None
+
+
+def test_nurse_paws_cannot_prepare_when_contest_is_locked(monkeypatch):
+    fake = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="The diagnosis book is already closed for this case.",
+        agent_tool=("prepare_final_guess", {"diagnosis": "adrenal crisis"}),
+    )
+
+    result = _run(sim_patient.handle_question(
+        "Submit adrenal crisis.",
+        role="clerk",
+        contest_state={"state": "locked", "outcome": "incorrect"},
+    ))
+
+    assert result["suggested_action"] is None
+    assert fake.tool_results[0]["prepared"] is False
 
 
 def test_nurse_transcript_labels_prior_npc_lines_as_nurse():
@@ -368,6 +509,34 @@ def test_422_when_role_invalid(monkeypatch):
     client = TestClient(app)
     resp = client.post("/api/sim-patient", json={"question": "hi", "role": "doctor"})
     assert resp.status_code == 422
+
+
+def test_clerk_http_role_forwards_contest_state(monkeypatch):
+    from fastapi.testclient import TestClient
+    from roo import config
+    from roo.main import app
+
+    _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="Review it, then press confirm.",
+        agent_tool=("prepare_final_guess", {"diagnosis": "adrenal crisis"}),
+    )
+    real = config.get_settings()
+    monkeypatch.setattr(real, "SIM_PATIENT_API_KEY", None, raising=False)
+    monkeypatch.setattr(config, "get_settings", lambda: real)
+
+    response = TestClient(app).post("/api/sim-patient", json={
+        "question": "My final diagnosis is adrenal crisis.",
+        "role": "clerk",
+        "contest_state": {"state": "eligible", "outcome": None},
+    })
+
+    assert response.status_code == 200
+    assert response.json()["suggested_action"] == {
+        "type": "confirm_diagnosis",
+        "diagnosis": "adrenal crisis",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -527,10 +696,7 @@ def test_speech_only_all_action_returns_empty(monkeypatch):
     # (better than showing raw "*collapses...*" markup).
     assert sim_patient._speech_only("*collapses back onto the pillow*") == ""
 
-    async def action_only(*args, **kwargs):
-        return "*collapses back onto the pillow*"
-
-    monkeypatch.setattr(sim_patient, "npc_reply", action_only)
+    _install_fake(monkeypatch, "{}", reply_text="*collapses back onto the pillow*")
     result = _run(sim_patient.handle_question("how are you?", role="nurse"))
     assert result["reply"] == sim_patient._EMPTY_REPLY_FALLBACK["nurse"]
 
@@ -544,19 +710,13 @@ def test_handle_question_sanitizes_reply_at_choke_point(monkeypatch):
     # Prove sanitization happens in handle_question for ALL replies: mock the LLM
     # reply with narration and confirm the returned reply is speech only. Nurse
     # role → the guess classifier is skipped, so no LLM stub needed for it.
-    async def fake_npc_reply(*args, **kwargs):
-        return "*sighs* The bloods aren't back yet, love."
-
-    monkeypatch.setattr(sim_patient, "npc_reply", fake_npc_reply)
+    _install_fake(monkeypatch, "{}", reply_text="*sighs* The bloods aren't back yet, love.")
     result = _run(sim_patient.handle_question("How is your shift going?", role="nurse"))
     assert result["reply"] == "The bloods aren't back yet, love."
 
 
 def test_empty_model_reply_falls_back_to_canned_line(monkeypatch):
-    async def empty_reply(*args, **kwargs):
-        return ""
-
-    monkeypatch.setattr(sim_patient, "npc_reply", empty_reply)
+    _install_fake(monkeypatch, "{}", reply_text="")
 
     nurse = _run(sim_patient.handle_question("How is your shift going?", role="nurse"))
     assert nurse["reply"] == sim_patient._EMPTY_REPLY_FALLBACK["nurse"]
@@ -574,7 +734,8 @@ def test_system_prompts_declare_speech_only():
     # Contract-presence: guard against an accidental revert to the narrator prompt.
     assert "SPEECH ONLY" in sim_patient._PATIENT_SYSTEM_PROMPT
     assert "no stage directions" in sim_patient._PATIENT_SYSTEM_PROMPT.lower()
-    assert "speech only" in sim_patient._NURSE_SYSTEM_PROMPT.lower()
+    assert "only dr snow's spoken words" in ward_agents.DR_SNOW_PROMPT.lower()
+    assert "only nurse paws' spoken words" in ward_agents.NURSE_PAWS_PROMPT.lower()
     # The patient is now first-person, not the third-person PQM narrator.
     assert "Patient Quest Master" not in sim_patient._PATIENT_SYSTEM_PROMPT
     assert "narrate how they say it" not in sim_patient._PATIENT_SYSTEM_PROMPT

--- a/roo-standalone/roo/ward_agents.py
+++ b/roo-standalone/roo/ward_agents.py
@@ -1,0 +1,395 @@
+"""AI-first tool agents for Dr Snow and Nurse Paws.
+
+The model always receives the player's message first. Clinical facts remain in
+local code and are exposed only through allowlisted tools backed by cases.yaml.
+No tool in this module can adjudicate or persist a diagnosis guess.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from .config import get_settings
+from .llm import get_llm_client
+
+
+DR_SNOW_NAME = "Dr Snow"
+NURSE_PAWS_NAME = "Nurse Paws"
+
+
+DR_SNOW_PROMPT = """You are Dr Snow, the radiology registrar at the hospital results desk. You can access both pathology and radiology results for the patient in cubicle 3.
+
+You are the first conversational responder for every message. For greetings or ordinary conversation, answer directly. Whenever you state a clinical result, you MUST obtain it from one of your tools in this turn or from the supplied prior conversation. Never invent, normalize, round, or assume an unperformed result.
+
+Use list_available_results when the player asks what is available. Use get_results for requested bloods, pathology, ECG, gases, urine, endocrine tests, or imaging. If the player explicitly says they are stuck, seems lost after repeated vague questions, or asks for a useful clue, you may call offer_imaging_clue and share one real scan that has not already been discussed.
+
+You do not know the hidden diagnosis and must never confirm or reject a proposed diagnosis. Nurse Paws takes final diagnoses. Redirect requests for observations or physical examination to Nurse Paws, and history or symptoms to the patient.
+
+Speak warmly and efficiently in one or two short paragraphs. Return only Dr Snow's spoken words: no labels, narration, stage directions, markdown, JSON, or tool names."""
+
+
+NURSE_PAWS_PROMPT = """You are Nurse Paws, the senior ward nurse at reception. You help the player synthesize the case, provide the complete observations and physical examination, and prepare their ONE official diagnosis for explicit confirmation.
+
+You are the first conversational responder for every message. Clinical observations and examination findings MUST come from your tools in this turn or from the supplied prior conversation. Never invent or round a finding. You may reason with the player about patterns and differentials using only facts already disclosed, but you do not know the hidden diagnosis or acceptable answers and must never say whether a proposed diagnosis is correct.
+
+Use get_observations for vital signs and get_examination for physical findings. Call prepare_final_guess only when the player clearly declares a final diagnosis or explicitly asks to submit it. Never call it for tentative language such as "could it be" or "what about". prepare_final_guess does not submit anything; after it succeeds, tell the player to review and press the confirmation button. If the contest is not eligible, do not invite another submission.
+
+Speak like a warm, quick, slightly playful senior nurse in one or two short paragraphs. Return only Nurse Paws' spoken words: no labels, narration, stage directions, markdown, JSON, or tool names."""
+
+
+@dataclass
+class WardAgentResult:
+    reply: str
+    model: str
+    usage: dict[str, int] = field(default_factory=dict)
+    tool_calls: list[dict[str, Any]] = field(default_factory=list)
+    suggested_action: Optional[dict[str, str]] = None
+
+
+def _strict_tool(
+    name: str,
+    description: str,
+    properties: dict[str, Any],
+    required: list[str],
+) -> dict[str, Any]:
+    return {
+        "type": "function",
+        "name": name,
+        "description": description,
+        "parameters": {
+            "type": "object",
+            "properties": properties,
+            "required": required,
+            "additionalProperties": False,
+        },
+        "strict": True,
+    }
+
+
+def _human_label(identifier: str) -> str:
+    return identifier.replace("_", " ").replace(".", " · ").strip().title()
+
+
+_NON_RESULT_ROOTS = {
+    "exposure_details_if_asked_calmly",
+    "medication_clue_if_asked_properly",
+    "medication_history_reveals",
+    "substance_history_if_asked_nonjudgmentally",
+}
+_RADIOLOGY_MARKERS = {
+    "ct",
+    "cxr",
+    "imaging",
+    "mri",
+    "mrv",
+    "radiograph",
+    "ultrasound",
+    "venogram",
+    "xray",
+}
+
+
+def _investigation_category(path: tuple[str, ...]) -> str:
+    tokens = {
+        token
+        for segment in path
+        for token in segment.lower().replace("-", "_").split("_")
+    }
+    return "radiology" if tokens & _RADIOLOGY_MARKERS else "pathology"
+
+
+def investigation_catalog(case: dict) -> dict[str, dict[str, Any]]:
+    """Flatten every authored clinical test into stable, non-secret result ids.
+
+    Case files use both common blocks (``bloods`` and ``imaging_if_ordered``)
+    and case-specific blocks such as ``confirmatory_test`` or
+    ``key_diagnostic_test``. Recursing prevents those authored results from
+    silently disappearing. Narrative medication/exposure clues remain with the
+    patient, and author notes are instructions rather than reportable results.
+    """
+    investigations = case.get("investigations") or {}
+    catalog: dict[str, dict[str, Any]] = {}
+
+    def visit(value: Any, path: tuple[str, ...]) -> None:
+        if not path or path[0] in _NON_RESULT_ROOTS or path[-1] == "note":
+            return
+        if isinstance(value, dict):
+            for key, child in value.items():
+                visit(child, (*path, str(key)))
+            return
+        if value in (None, ""):
+            return
+        identifier = ".".join(path)
+        catalog[identifier] = {
+            "label": _human_label(identifier),
+            "category": _investigation_category(path),
+            "value": value,
+        }
+
+    if isinstance(investigations, dict):
+        for key, value in investigations.items():
+            visit(value, (str(key),))
+    return catalog
+
+
+def _dr_snow_tools(case: dict) -> list[dict[str, Any]]:
+    ids = sorted(investigation_catalog(case))
+    selectable_ids = ids + ["bloods", "pathology", "radiology", "imaging", "all"]
+    return [
+        _strict_tool(
+            "list_available_results",
+            "List the authored pathology and/or radiology results available for this patient without revealing their values.",
+            {
+                "category": {
+                    "type": "string",
+                    "enum": ["pathology", "radiology", "all"],
+                    "description": "Which result category to list.",
+                },
+            },
+            ["category"],
+        ),
+        _strict_tool(
+            "get_results",
+            "Retrieve exact authored result values. Use bloods/pathology/radiology/imaging/all to retrieve a complete group.",
+            {
+                "test_ids": {
+                    "type": "array",
+                    "items": {"type": "string", "enum": selectable_ids},
+                    "minItems": 1,
+                    "maxItems": 20,
+                    "description": "Stable test ids or group aliases to retrieve.",
+                },
+            },
+            ["test_ids"],
+        ),
+        _strict_tool(
+            "offer_imaging_clue",
+            "Return one real, not-yet-discussed authored scan when the player appears to be struggling. Do not use merely to answer a normal specific request.",
+            {},
+            [],
+        ),
+    ]
+
+
+def _paws_tools(case: dict) -> list[dict[str, Any]]:
+    systems = sorted((case.get("examination") or {}).keys())
+    return [
+        _strict_tool(
+            "get_observations",
+            "Retrieve the complete authored vital signs and observations for the patient.",
+            {},
+            [],
+        ),
+        _strict_tool(
+            "get_examination",
+            "Retrieve exact authored physical examination findings for one system or the complete examination.",
+            {
+                "system": {
+                    "type": "string",
+                    "enum": ["all", *systems],
+                    "description": "The examination system to retrieve, or all.",
+                },
+            },
+            ["system"],
+        ),
+        _strict_tool(
+            "prepare_final_guess",
+            "Prepare an explicitly final diagnosis for a separate player confirmation. This never submits, adjudicates, or burns the attempt.",
+            {
+                "diagnosis": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 200,
+                    "description": "The diagnosis the player explicitly declared as final.",
+                },
+            },
+            ["diagnosis"],
+        ),
+    ]
+
+
+def _execute_dr_snow_tool(
+    name: str,
+    arguments: dict[str, Any],
+    case: dict,
+    history: list[dict],
+) -> dict[str, Any]:
+    catalog = investigation_catalog(case)
+    if name == "list_available_results":
+        category = arguments.get("category")
+        results = [
+            {"id": identifier, "label": item["label"], "category": item["category"]}
+            for identifier, item in catalog.items()
+            if category == "all" or item["category"] == category
+        ]
+        return {"results": results}
+
+    if name == "get_results":
+        requested = arguments.get("test_ids") or []
+        expanded: list[str] = []
+        for identifier in requested:
+            if identifier in {"bloods"}:
+                expanded.extend(key for key in catalog if key.startswith("bloods."))
+            elif identifier in {"pathology", "radiology", "imaging", "all"}:
+                target = "radiology" if identifier in {"radiology", "imaging"} else identifier
+                expanded.extend(
+                    key for key, item in catalog.items()
+                    if target == "all" or item["category"] == target
+                )
+            else:
+                expanded.append(identifier)
+        unique = list(dict.fromkeys(expanded))[:30]
+        return {
+            "results": [
+                {
+                    "id": identifier,
+                    "label": catalog[identifier]["label"],
+                    "value": catalog[identifier]["value"],
+                }
+                for identifier in unique
+                if identifier in catalog
+            ],
+            "unavailable": [identifier for identifier in unique if identifier not in catalog],
+        }
+
+    if name == "offer_imaging_clue":
+        transcript = " ".join(
+            str(turn.get("text") or "") for turn in history if isinstance(turn, dict)
+        ).lower()
+        for identifier, item in catalog.items():
+            if item["category"] != "radiology":
+                continue
+            label = str(item["label"])
+            if identifier.lower() in transcript or label.lower() in transcript:
+                continue
+            return {
+                "available": True,
+                "result": {
+                    "id": identifier,
+                    "label": label,
+                    "value": item["value"],
+                },
+            }
+        return {"available": False, "reason": "No undisclosed authored scan remains."}
+
+    return {"error": f"Unknown Dr Snow tool: {name}"}
+
+
+def _execute_paws_tool(
+    name: str,
+    arguments: dict[str, Any],
+    case: dict,
+    contest_state: dict[str, Any],
+    action_holder: dict[str, Any],
+) -> dict[str, Any]:
+    if name == "get_observations":
+        return {"observations": case.get("vitals") or {}}
+
+    if name == "get_examination":
+        examination = case.get("examination") or {}
+        system = arguments.get("system")
+        if system == "all":
+            return {"examination": examination}
+        if system not in examination:
+            return {"available": False, "system": system}
+        return {"examination": {system: examination[system]}}
+
+    if name == "prepare_final_guess":
+        diagnosis = str(arguments.get("diagnosis") or "").strip()[:200]
+        if contest_state.get("state") != "eligible":
+            return {
+                "prepared": False,
+                "contest_state": contest_state.get("state", "unavailable"),
+                "reason": "The one-shot contest is not eligible for a new submission.",
+            }
+        if not diagnosis:
+            return {"prepared": False, "reason": "No diagnosis was supplied."}
+        action_holder["value"] = {
+            "type": "confirm_diagnosis",
+            "diagnosis": diagnosis,
+        }
+        return {
+            "prepared": True,
+            "diagnosis": diagnosis,
+            "instruction": "Ask the player to review and press the confirmation button.",
+        }
+
+    return {"error": f"Unknown Nurse Paws tool: {name}"}
+
+
+def _format_history(history: list[dict], npc_name: str) -> str:
+    if not history:
+        return "None"
+    lines = []
+    for turn in history[-12:]:
+        if not isinstance(turn, dict):
+            continue
+        text = str(turn.get("text") or "").strip()
+        if not text:
+            continue
+        speaker = "Player" if turn.get("role") == "player" else npc_name
+        lines.append(f"{speaker}: {text}")
+    return "\n".join(lines) if lines else "None"
+
+
+async def run_ward_agent(
+    *,
+    role: str,
+    question: str,
+    history: list[dict],
+    case: dict,
+    contest_state: Optional[dict[str, Any]] = None,
+) -> WardAgentResult:
+    """Run one AI-first Dr Snow or Nurse Paws turn."""
+    settings = get_settings()
+    client = get_llm_client("openai")
+    action_holder: dict[str, Any] = {}
+
+    if role == "nurse":
+        npc_name = DR_SNOW_NAME
+        system_prompt = DR_SNOW_PROMPT
+        tools = _dr_snow_tools(case)
+
+        def execute(name: str, arguments: dict[str, Any]):
+            return _execute_dr_snow_tool(name, arguments, case, history)
+    elif role == "clerk":
+        npc_name = NURSE_PAWS_NAME
+        state = contest_state or {"state": "unavailable", "outcome": None}
+        system_prompt = (
+            NURSE_PAWS_PROMPT
+            + f"\n\nAuthoritative contest state for this player: {state.get('state')}."
+        )
+        tools = _paws_tools(case)
+
+        def execute(name: str, arguments: dict[str, Any]):
+            return _execute_paws_tool(name, arguments, case, state, action_holder)
+    else:
+        raise ValueError(f"unsupported ward agent role: {role}")
+
+    prompt = f"""Previous conversation with {npc_name}:
+{_format_history(history, npc_name)}
+
+Player's latest message: {question}
+
+Respond in character. Use tools whenever clinical facts or a final-guess action are required."""
+    response = await client.agent_with_tools(
+        [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": prompt},
+        ],
+        tools,
+        execute,
+        model=settings.SIM_PATIENT_MODEL,
+        reasoning_effort=settings.SIM_PATIENT_REASONING_EFFORT,
+        max_tokens=700,
+        max_tool_rounds=2,
+        tool_choice="auto",
+    )
+    return WardAgentResult(
+        reply=response.content,
+        model=response.model,
+        usage=response.usage or {},
+        tool_calls=response.tool_calls,
+        suggested_action=action_holder.get("value"),
+    )


### PR DESCRIPTION
## What changed
- Route Dr Snow and Nurse Paws through GPT-5.6 Terra first, with strict tool schemas.
- Let Dr Snow retrieve every authored pathology and radiology result and offer one grounded scan clue.
- Let Nurse Paws retrieve observations and examination findings, coach a differential, and prepare—but never submit—a diagnosis.
- Record the challenge title with the adjudicated guess so prize emails are tied to the correct simulation.
- Keep one-guess adjudication exclusively in the diagnosis endpoint.

## Validation
- Focused Roo suite: 95 tests passing.