### PR TITLE
Accept MLAI_API_KEY when recording ward-game guesses (fixes prod guess 502s)

### DIFF
--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -230,7 +230,9 @@ async def record_web_guess(
     """
     if not settings.MLAI_BACKEND_URL:
         raise RuntimeError("MLAI_BACKEND_URL not configured")
-    api_key = settings.ROO_API_KEY or settings.INTERNAL_API_KEY
+    # Deployments hold the shared backend secret under MLAI_API_KEY (the other
+    # two names may be absent) — same fallback chain as every other backend call.
+    api_key = settings.ROO_API_KEY or settings.INTERNAL_API_KEY or settings.MLAI_API_KEY
     if not api_key:
         raise RuntimeError("no service API key configured for mlai-backend")
     url = f"{settings.MLAI_BACKEND_URL.rstrip('/')}/api/v1/hackathons/hospital/sim-guess/record/"

--- a/roo-standalone/roo/tests/test_diagnosis_check.py
+++ b/roo-standalone/roo/tests/test_diagnosis_check.py
@@ -9,10 +9,14 @@ recorder is monkeypatched). Invariants under test:
   - record failure → 503 with NO verdict fields (no free oracle, guess not burned)
   - the active case is pinned server-side (client case_id ignored)
   - bearer auth mirrors /api/sim-patient
+  - the recorder authenticates with ROO_API_KEY → INTERNAL_API_KEY →
+    MLAI_API_KEY (deployments may set only MLAI_API_KEY)
 """
+import asyncio
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -204,3 +208,86 @@ def test_validation_422(monkeypatch, payload):
 
     assert resp.status_code == 422
     assert calls == []  # nothing recorded on validation failure
+
+
+def _recorder_settings(monkeypatch, **keys):
+    """The real Settings singleton with only the given service keys set.
+
+    Mutates the real object (not a stub) so a renamed settings field fails
+    here instead of silently passing against attributes that no longer exist.
+    """
+    real = config.get_settings()
+    monkeypatch.setattr(real, "MLAI_BACKEND_URL", "http://mlai-backend.test")
+    for name in ("ROO_API_KEY", "INTERNAL_API_KEY", "MLAI_API_KEY"):
+        monkeypatch.setattr(real, name, keys.get(name))
+    return real
+
+
+def _install_fake_httpx(monkeypatch):
+    """Replace httpx.AsyncClient; returns the captured outbound POST."""
+    sent: dict = {}
+
+    class FakeAsyncClient:
+        def __init__(self, **_kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            sent.update({"url": url, "json": json, "headers": headers})
+            return httpx.Response(
+                200,
+                json={"already_guessed": False},
+                request=httpx.Request("POST", url),
+            )
+
+    monkeypatch.setattr(sim_patient.httpx, "AsyncClient", FakeAsyncClient)
+    return sent
+
+
+def test_recorder_falls_back_to_mlai_api_key(monkeypatch):
+    # Regression: deployments holding the shared backend secret only under
+    # MLAI_API_KEY must still authenticate the record call — this config shape
+    # made every prod guess submission 503 ("record_failed") → 502 to the game.
+    sent = _install_fake_httpx(monkeypatch)
+    settings = _recorder_settings(monkeypatch, MLAI_API_KEY="mlai-secret")
+
+    result = asyncio.run(sim_patient.record_web_guess(
+        settings, case_id=1, client_id=VALID_CLIENT,
+        guess_text="adrenal crisis", is_correct=True,
+    ))
+
+    assert sent["headers"] == {"X-API-Key": "mlai-secret"}
+    assert sent["url"].endswith("/api/v1/hackathons/hospital/sim-guess/record/")
+    assert result == {"already_guessed": False}
+
+
+def test_recorder_prefers_roo_key_over_mlai_key(monkeypatch):
+    sent = _install_fake_httpx(monkeypatch)
+    settings = _recorder_settings(
+        monkeypatch, ROO_API_KEY="roo-secret", MLAI_API_KEY="mlai-secret",
+    )
+
+    asyncio.run(sim_patient.record_web_guess(
+        settings, case_id=1, client_id=VALID_CLIENT,
+        guess_text="gastro", is_correct=False,
+    ))
+
+    assert sent["headers"] == {"X-API-Key": "roo-secret"}
+
+
+def test_recorder_with_no_key_raises_without_posting(monkeypatch):
+    sent = _install_fake_httpx(monkeypatch)
+    settings = _recorder_settings(monkeypatch)
+
+    with pytest.raises(RuntimeError, match="no service API key"):
+        asyncio.run(sim_patient.record_web_guess(
+            settings, case_id=1, client_id=VALID_CLIENT,
+            guess_text="gastro", is_correct=False,
+        ))
+
+    assert sent == {}  # never reached the network


### PR DESCRIPTION
## Problem

Every final-diagnosis submission in the health-hack ward game fails with Nurse Paws' "My AI connection dropped" line. Reproduced in prod: `POST /api/guess` → **502 in 0.26s** (fast fail, not a timeout), while NPC chat through the same Worker→backend→roo path works fine.

## Root cause

`record_web_guess` reads only `ROO_API_KEY or INTERNAL_API_KEY`, but the roo deployment holds the shared mlai-backend secret under **`MLAI_API_KEY`** (verified: its value matches the backend's `ROO_API_KEY` exactly). Every other roo→backend call site (quests.py, agent.py, link_love.py, coworking_booking_intents.py, main.py ×4) already falls back to `MLAI_API_KEY`; this one call site missed the chain. Net effect:

```
record_web_guess → RuntimeError("no service API key configured")
→ /api/diagnosis-check 503 record_failed
→ backend sim-guess/check 502
→ worker /api/guess 502
→ "My AI connection dropped for a moment…"
```

By design nothing is recorded on this path, so no player's one-shot guess was burned.

## Fix

One line: extend the recorder's key selection to `ROO_API_KEY → INTERNAL_API_KEY → MLAI_API_KEY`, matching the house convention.

## Tests

New hermetic tests for the recorder's key selection (fake `httpx.AsyncClient`, real `Settings` singleton so a renamed field fails loudly):

- only `MLAI_API_KEY` set → record call authenticates with it (**red on main**: reproduces the exact prod RuntimeError)
- `ROO_API_KEY` still wins when both set
- no key at all → RuntimeError before any network call

`pytest roo/tests/test_diagnosis_check.py roo/tests/test_sim_patient.py` → **98 passed**.

## Post-merge verification (auto-deploys on merge to main)

1. `POST https://health-hack.mlai-530.workers.dev/api/guess` with a throwaway `client_id` + wrong guess → expect `200 {"result":"incorrect",…,"source":"live"}`
2. `GET /api/contest?client_id=<same>` → state flips to `locked`
3. Real players' clients remain `eligible` — nothing was ever recorded for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)