### PR TITLE
Provision dedicated Roo registry key during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           SIM_PATIENT_API_KEY: ${{ secrets.SIM_PATIENT_API_KEY }}
           SIM_PATIENT_SAFETY_SALT: ${{ secrets.SIM_PATIENT_SAFETY_SALT }}
+          ROO_API_KEY: ${{ secrets.ROO_API_KEY }}
         run: |
           set -eu
           if [ "${#SIM_PATIENT_API_KEY}" -lt 32 ]; then
@@ -66,8 +67,12 @@ jobs:
             echo "SIM_PATIENT_SAFETY_SALT is missing or shorter than 32 characters" >&2
             exit 1
           fi
-          if [ "$SIM_PATIENT_API_KEY" = "$SIM_PATIENT_SAFETY_SALT" ]; then
-            echo "Roo API key and safety salt must be distinct" >&2
+          if [ "${#ROO_API_KEY}" -lt 32 ]; then
+            echo "ROO_API_KEY is missing or shorter than 32 characters" >&2
+            exit 1
+          fi
+          if [ "$SIM_PATIENT_API_KEY" = "$SIM_PATIENT_SAFETY_SALT" ] || [ "$SIM_PATIENT_API_KEY" = "$ROO_API_KEY" ] || [ "$SIM_PATIENT_SAFETY_SALT" = "$ROO_API_KEY" ]; then
+            echo "Roo service credentials must be distinct" >&2
             exit 1
           fi
 
@@ -76,24 +81,25 @@ jobs:
         env:
           SIM_PATIENT_API_KEY: ${{ secrets.SIM_PATIENT_API_KEY }}
           SIM_PATIENT_SAFETY_SALT: ${{ secrets.SIM_PATIENT_SAFETY_SALT }}
+          ROO_API_KEY: ${{ secrets.ROO_API_KEY }}
           ROO_PRIVATE_BASE_URL: ${{ vars.ROO_PRIVATE_BASE_URL }}
         with:
           host: ${{ secrets.DO_HOST }}
           username: ${{ secrets.DO_USERNAME }}
           key: ${{ secrets.DO_SSH_KEY }}
-          envs: SIM_PATIENT_API_KEY,SIM_PATIENT_SAFETY_SALT,ROO_PRIVATE_BASE_URL
+          envs: SIM_PATIENT_API_KEY,SIM_PATIENT_SAFETY_SALT,ROO_API_KEY,ROO_PRIVATE_BASE_URL
           script: |
             # Stop if any command fails
             set -eu
 
             # Fail before touching the existing environment if forwarding was
             # misconfigured. Values are intentionally never printed.
-            if [ "${#SIM_PATIENT_API_KEY}" -lt 32 ] || [ "${#SIM_PATIENT_SAFETY_SALT}" -lt 32 ]; then
+            if [ "${#SIM_PATIENT_API_KEY}" -lt 32 ] || [ "${#SIM_PATIENT_SAFETY_SALT}" -lt 32 ] || [ "${#ROO_API_KEY}" -lt 32 ]; then
               echo "Required Roo security secrets were not forwarded" >&2
               exit 1
             fi
-            if [ "$SIM_PATIENT_API_KEY" = "$SIM_PATIENT_SAFETY_SALT" ]; then
-              echo "Roo API key and safety salt must be distinct" >&2
+            if [ "$SIM_PATIENT_API_KEY" = "$SIM_PATIENT_SAFETY_SALT" ] || [ "$SIM_PATIENT_API_KEY" = "$ROO_API_KEY" ] || [ "$SIM_PATIENT_SAFETY_SALT" = "$ROO_API_KEY" ]; then
+              echo "Roo service credentials must be distinct" >&2
               exit 1
             fi
             
@@ -113,20 +119,6 @@ jobs:
             # Go to the sub-project directory
             cd "$DEPLOY_DIR/roo-standalone"
 
-            # The Roo -> MLAI Backend contest-registry direction has a
-            # dedicated credential that already lives on the Droplet. Validate
-            # it before restarting so a missing/stale bootstrap cannot turn
-            # final diagnoses into an outage. Never print the value.
-            ROO_API_KEY="$(sed -n 's/^ROO_API_KEY=//p' .env 2>/dev/null | tail -n 1)"
-            if [ "${#ROO_API_KEY}" -lt 32 ]; then
-              echo "ROO_API_KEY is missing or shorter than 32 characters" >&2
-              exit 1
-            fi
-            if [ "$ROO_API_KEY" = "$SIM_PATIENT_API_KEY" ] || [ "$ROO_API_KEY" = "$SIM_PATIENT_SAFETY_SALT" ]; then
-              echo "Roo service credentials must be distinct" >&2
-              exit 1
-            fi
-
             # Update security settings without printing secret values. Rebuild
             # the file atomically so duplicate/stale keys cannot win.
             umask 077
@@ -143,6 +135,7 @@ jobs:
             upsert_env "ROO_ENVIRONMENT" "production"
             upsert_env "SIM_PATIENT_API_KEY" "$SIM_PATIENT_API_KEY"
             upsert_env "SIM_PATIENT_SAFETY_SALT" "$SIM_PATIENT_SAFETY_SALT"
+            upsert_env "ROO_API_KEY" "$ROO_API_KEY"
             
             # Restart the app
             docker compose up -d --build --remove-orphans

--- a/roo-standalone/roo/tests/test_ai_security.py
+++ b/roo-standalone/roo/tests/test_ai_security.py
@@ -401,14 +401,15 @@ def test_deploy_workflow_requires_and_secretly_upserts_security_values():
     assert "nginx:1.28.3-alpine nginx -t" in workflow
     assert "secrets.SIM_PATIENT_API_KEY" in workflow
     assert "secrets.SIM_PATIENT_SAFETY_SALT" in workflow
+    assert "secrets.ROO_API_KEY" in workflow
     assert "envs: SIM_PATIENT_API_KEY,SIM_PATIENT_SAFETY_SALT" in workflow
-    assert "envs: SIM_PATIENT_API_KEY,SIM_PATIENT_SAFETY_SALT,ROO_PRIVATE_BASE_URL" in workflow
+    assert "envs: SIM_PATIENT_API_KEY,SIM_PATIENT_SAFETY_SALT,ROO_API_KEY,ROO_PRIVATE_BASE_URL" in workflow
     assert 'upsert_env "ROO_ENVIRONMENT" "production"' in workflow
     assert 'upsert_env "SIM_PATIENT_API_KEY" "$SIM_PATIENT_API_KEY"' in workflow
     assert 'upsert_env "SIM_PATIENT_SAFETY_SALT" "$SIM_PATIENT_SAFETY_SALT"' in workflow
-    assert 'ROO_API_KEY="$(sed -n' in workflow
+    assert 'upsert_env "ROO_API_KEY" "$ROO_API_KEY"' in workflow
     assert 'if [ "${#ROO_API_KEY}" -lt 32 ]' in workflow
-    assert workflow.index('ROO_API_KEY="$(sed -n') < workflow.index("docker compose up")
+    assert workflow.index('upsert_env "ROO_API_KEY"') < workflow.index("docker compose up")
     assert workflow.index("upsert_env \"SIM_PATIENT_API_KEY\"") < workflow.index("docker compose up")
     assert 'echo "$SIM_PATIENT_API_KEY"' not in workflow
     assert 'echo "$SIM_PATIENT_SAFETY_SALT"' not in workflow


### PR DESCRIPTION
## Summary
- require the dedicated Roo -> MLAI Backend registry credential in GitHub Actions
- forward and atomically upsert it on the Droplet without printing it
- validate all three Roo security values are strong and pairwise distinct before restart

This unblocks the fail-closed hardened Roo release. The corresponding rotation key is already configured in the repository secret store.

## Validation
- 168 focused security/AI tests passed
- `git diff --check` passed
