### PR TITLE
Reopen gateway case selection within an explicit open-case allowlist

### DIFF
--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -94,6 +94,28 @@ class Settings(BaseSettings):
     # The ward contest's active case (cases.yaml id). Pinned server-side so web
     # clients can never pick a case and farm tickets from cases not in play.
     SIM_ACTIVE_CASE_ID: int = 1
+    # Contest cases the authenticated gateway may target (comma-separated
+    # cases.yaml ids). Two wards run concurrently, so the gateway forwards the
+    # player's chosen case; anything outside this set is refused so hidden or
+    # retired cases can never leak dialogue or verdicts. Mirrors MLAI
+    # Backend's HEALTH_HACK_OPEN_CASE_IDS default.
+    SIM_OPEN_CASE_IDS: str = "1,2"
+
+    @property
+    def sim_open_case_ids(self) -> frozenset[int]:
+        """Open contest cases. Malformed tokens are skipped and the active
+        case is always included, so a bad env value narrows the set at worst —
+        it can never brick the default (active-case) path."""
+        ids = {self.SIM_ACTIVE_CASE_ID}
+        for token in self.SIM_OPEN_CASE_IDS.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            try:
+                ids.add(int(token))
+            except ValueError:
+                continue
+        return frozenset(ids)
 
     @property
     def is_production(self) -> bool:

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -2241,6 +2241,25 @@ def _validated_contest_state(value: Any) -> Optional[dict[str, Optional[str]]]:
     return {"state": state, "outcome": outcome}
 
 
+def _validated_case_id(value: Any, settings: Settings) -> int:
+    """Resolve which contest case this request plays.
+
+    Two wards run concurrently, so the authenticated gateway forwards the
+    player's chosen case. Roo stays a second boundary: only cases in
+    SIM_OPEN_CASE_IDS are selectable, and anything else is refused exactly
+    like an unknown id, so hidden or retired cases can never leak dialogue
+    or verdicts. An absent field keeps the pinned active case (older
+    gateway payloads).
+    """
+    if value is None:
+        return settings.SIM_ACTIVE_CASE_ID
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise HTTPException(status_code=422, detail="case_id must be an integer")
+    if value not in settings.sim_open_case_ids:
+        raise HTTPException(status_code=404, detail="unknown case_id")
+    return value
+
+
 # The legacy /api/mention endpoint was intentionally removed. Repository-wide
 # caller inventory found no consumer, and accepting a JSON user_id let an
 # unauthenticated caller exercise Roo's broader, privileged agent. Verified
@@ -2277,6 +2296,10 @@ async def api_sim_patient(request: Request, settings: Settings = Depends(get_set
 
     history = _validated_history(payload.get("history"))
     contest_state = _validated_contest_state(payload.get("contest_state"))
+    # Roo stays a second boundary: the gateway's case_id is honored only
+    # within SIM_OPEN_CASE_IDS, so a payload cannot select a hidden/old
+    # contest case.
+    case_id = _validated_case_id(payload.get("case_id"), settings)
 
     from .sim_patient import handle_question
 
@@ -2284,9 +2307,7 @@ async def api_sim_patient(request: Request, settings: Settings = Depends(get_set
         return await handle_question(
             question=question,
             history=history,
-            # The active case is pinned at Roo as a second boundary. A gateway
-            # payload cannot select a hidden/old contest case.
-            case_id=settings.SIM_ACTIVE_CASE_ID,
+            case_id=case_id,
             player_id=player_id,
             role=role,
             contest_state=contest_state,
@@ -2307,15 +2328,18 @@ async def api_sim_patient(request: Request, settings: Settings = Depends(get_set
 async def api_diagnosis_check(request: Request, settings: Settings = Depends(get_settings)):
     """Ward-clerk diagnosis contest: adjudicate ONE guess and record it.
 
-    Fully scripted — no LLM anywhere in this path. The active case is pinned
-    server-side (SIM_ACTIVE_CASE_ID); clients cannot pick a case. The verdict
+    Fully scripted — no LLM anywhere in this path. The playable cases are
+    pinned server-side (the SIM_OPEN_CASE_IDS allowlist): the gateway forwards
+    the player's chosen open case, defaulting to SIM_ACTIVE_CASE_ID, and
+    hidden/retired cases are refused before anything is recorded. The verdict
     comes from the same deterministic matcher as the Slack game (check_guess)
     and is recorded to mlai-backend BEFORE being revealed: if recording fails
     we return 503 with no verdict, so the guess is neither leaked nor burned
     (the backend row is what burns the player's single guess).
 
     Auth mirrors /api/sim-patient (mandatory in production).
-    Errors: 401 bad token, 422 validation, 503 contest/record unavailable.
+    Errors: 401 bad token, 404 non-open case_id, 422 validation, 503
+    contest/record unavailable.
     """
     _require_sim_patient_bearer(request, settings)
     payload = await _read_internal_json(request)
@@ -2326,14 +2350,16 @@ async def api_diagnosis_check(request: Request, settings: Settings = Depends(get
     if not guess or len(guess) > 200:
         raise HTTPException(status_code=422, detail="guess required (1-200 chars)")
     client_id = _validated_player_id(payload.get("client_id"))
+    case_id = _validated_case_id(payload.get("case_id"), settings)
 
     from .sim_patient import check_guess, load_case, record_web_guess
 
     try:
-        case = load_case(settings.SIM_ACTIVE_CASE_ID)
+        case = load_case(case_id)
     except KeyError as exc:
-        # Server misconfiguration (bad SIM_ACTIVE_CASE_ID), not a client error.
-        print(f"⚠️ diagnosis-check: active case unavailable: {exc}")
+        # Server misconfiguration (an open case missing from cases.yaml), not
+        # a client error.
+        print(f"⚠️ diagnosis-check: case unavailable: {exc}")
         raise HTTPException(status_code=503, detail="contest unavailable")
 
     is_correct = check_guess(guess, case)

--- a/roo-standalone/roo/tests/test_ai_security.py
+++ b/roo-standalone/roo/tests/test_ai_security.py
@@ -162,24 +162,38 @@ def test_internal_body_limit_is_enforced(monkeypatch):
     assert response.status_code == 413
 
 
-def test_client_case_selection_is_ignored_and_history_is_canonicalized(monkeypatch):
-    _settings(monkeypatch, key=None)
+def test_client_case_selection_is_bounded_and_history_is_canonicalized(monkeypatch):
+    settings = _settings(monkeypatch, key=None)
+    monkeypatch.setattr(settings, "SIM_ACTIVE_CASE_ID", 1, raising=False)
+    monkeypatch.setattr(settings, "SIM_OPEN_CASE_IDS", "1,2", raising=False)
     seen = {}
 
     async def fake_handle_question(**kwargs):
         seen.update(kwargs)
-        return {"reply": "Hello", "case_id": 1}
+        return {"reply": "Hello", "case_id": kwargs.get("case_id")}
 
     monkeypatch.setattr(sim_patient, "handle_question", fake_handle_question)
-    response = TestClient(app).post("/api/sim-patient", json={
+    client = TestClient(app)
+
+    # A hidden/retired case is refused outright — stronger than ignored: the
+    # narrator is never invoked for it.
+    response = client.post("/api/sim-patient", json={
+        "question": "hello", "player_id": PLAYER_ID, "case_id": 99,
+    })
+    assert response.status_code == 404
+    assert seen == {}
+
+    # An open case is honored; unknown fields are discarded and the gateway
+    # transcript is canonicalized.
+    response = client.post("/api/sim-patient", json={
         "question": "hello",
         "player_id": PLAYER_ID,
-        "case_id": 99,
+        "case_id": 2,
         "unknown": "discard me",
         "history": [{"role": "player", "text": " prior ", "hidden": "discard"}],
     })
     assert response.status_code == 200
-    assert seen["case_id"] == 1
+    assert seen["case_id"] == 2
     assert seen["history"] == [{"role": "player", "text": "prior"}]
 
 

--- a/roo-standalone/roo/tests/test_diagnosis_check.py
+++ b/roo-standalone/roo/tests/test_diagnosis_check.py
@@ -7,7 +7,8 @@ recorder is monkeypatched). Invariants under test:
   - result mapping: correct_first / correct_beaten / incorrect / already_guessed
   - the STORED verdict is authoritative on the already_guessed resume path
   - record failure → 503 with NO verdict fields (no free oracle, guess not burned)
-  - the active case is pinned server-side (client case_id ignored)
+  - only SIM_OPEN_CASE_IDS are playable: the gateway's case_id picks among
+    open cases (absent = the pinned active case); hidden cases 404 unrecorded
   - bearer auth mirrors /api/sim-patient
   - the recorder authenticates only with the dedicated ROO_API_KEY
 """
@@ -29,11 +30,12 @@ from roo.main import app
 VALID_CLIENT = "aaaaaaaa-1111-4111-8111-111111111111"
 
 
-def _client(monkeypatch, *, api_key=None, active_case=1):
+def _client(monkeypatch, *, api_key=None, active_case=1, open_cases="1,2"):
     """TestClient with a pinned Settings singleton (no lifespan — bare client)."""
     real = config.get_settings()
     monkeypatch.setattr(real, "SIM_PATIENT_API_KEY", api_key, raising=False)
     monkeypatch.setattr(real, "SIM_ACTIVE_CASE_ID", active_case, raising=False)
+    monkeypatch.setattr(real, "SIM_OPEN_CASE_IDS", open_cases, raising=False)
     monkeypatch.setattr(config, "get_settings", lambda: real)
     return TestClient(app)
 
@@ -151,8 +153,11 @@ def test_record_failure_503_leaks_no_verdict_and_burns_nothing(monkeypatch):
         assert verdict_key not in body
 
 
-def test_client_cannot_pick_the_case(monkeypatch):
-    # A payload case_id must be ignored — the server pin decides.
+def test_gateway_picks_an_open_case(monkeypatch):
+    # Two wards run concurrently: case_id=2 must adjudicate AND record case 2.
+    # The guess is case 1's correct answer, so a pass proves the verdict came
+    # from case 2's matcher, not the active-case pin.
+    _install_llm_bomb(monkeypatch)
     calls = _install_recorder(monkeypatch, response={
         "already_guessed": False, "is_correct": False,
         "outcome": "incorrect", "prize_kind": "none",
@@ -161,15 +166,56 @@ def test_client_cannot_pick_the_case(monkeypatch):
     client = _client(monkeypatch, active_case=1)
 
     body = client.post("/api/diagnosis-check", json={
-        "guess": "cerebral venous sinus thrombosis",
+        "guess": "adrenal crisis",
         "client_id": VALID_CLIENT,
-        "case_id": 7,
+        "case_id": 2,
     }).json()
 
-    assert calls[0]["case_id"] == 1
-    assert calls[0]["is_correct"] is False
-    assert body["case_id"] == 1
+    assert calls == [{
+        "case_id": 2, "case_title": "The Violet Trial", "client_id": VALID_CLIENT,
+        "guess_text": "adrenal crisis", "is_correct": False,
+    }]
+    assert body["case_id"] == 2
     assert body["result"] == "incorrect"
+    assert body["diagnosis"] is None
+
+
+def test_hidden_case_is_refused_and_unrecorded(monkeypatch):
+    # Cases that exist in cases.yaml but are not open must 404 with nothing
+    # recorded — indistinguishable from ids that do not exist at all, so the
+    # endpoint never confirms which future cases are authored.
+    calls = _install_recorder(monkeypatch, response={})
+    client = _client(monkeypatch, active_case=1)
+
+    for hidden in (3, 7):
+        resp = client.post("/api/diagnosis-check", json={
+            "guess": "adrenal crisis", "client_id": VALID_CLIENT, "case_id": hidden,
+        })
+        assert resp.status_code == 404
+        assert resp.json() == {"detail": "unknown case_id"}
+    assert calls == []
+
+
+def test_case_id_type_is_strict(monkeypatch):
+    calls = _install_recorder(monkeypatch, response={})
+    client = _client(monkeypatch)
+
+    for bad in ("2", 2.5, True, [2]):
+        resp = client.post("/api/diagnosis-check", json={
+            "guess": "adrenal crisis", "client_id": VALID_CLIENT, "case_id": bad,
+        })
+        assert resp.status_code == 422, f"case_id={bad!r} should 422"
+    assert calls == []
+
+
+def test_open_case_ids_parse_leniently(monkeypatch):
+    real = config.get_settings()
+    monkeypatch.setattr(real, "SIM_ACTIVE_CASE_ID", 1, raising=False)
+    monkeypatch.setattr(real, "SIM_OPEN_CASE_IDS", " 1, 2 ,banana,", raising=False)
+    assert real.sim_open_case_ids == frozenset({1, 2})
+    # A misconfigured empty list still keeps the active case playable.
+    monkeypatch.setattr(real, "SIM_OPEN_CASE_IDS", "", raising=False)
+    assert real.sim_open_case_ids == frozenset({1})
 
 
 def test_misconfigured_active_case_503s(monkeypatch):

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -1103,6 +1103,54 @@ def test_endpoint_accepts_clerk_role_and_passes_contest_state(monkeypatch):
     assert resp.status_code == 422
 
 
+def test_endpoint_honors_open_case_id(monkeypatch):
+    """Two wards run concurrently: the gateway's case_id is honored within
+    SIM_OPEN_CASE_IDS, absent keeps the active pin, and hidden or malformed
+    cases never reach the narrator."""
+    from fastapi.testclient import TestClient
+    from roo import config
+    from roo.main import app
+
+    real = config.get_settings()
+    monkeypatch.setattr(real, "SIM_PATIENT_API_KEY", None, raising=False)  # auth open
+    monkeypatch.setattr(real, "SIM_ACTIVE_CASE_ID", 1, raising=False)
+    monkeypatch.setattr(real, "SIM_OPEN_CASE_IDS", "1,2", raising=False)
+    monkeypatch.setattr(config, "get_settings", lambda: real)
+
+    seen = {}
+
+    async def fake_handle_question(**kwargs):
+        seen.update(kwargs)
+        return {
+            "reply": "ok",
+            "case_id": kwargs.get("case_id"),
+            "case_title": "t",
+            "patient_name": "Leila Farouk",
+            "presenting_complaint": "p",
+            "is_guess": False,
+            "correct": None,
+            "diagnosis": None,
+        }
+
+    monkeypatch.setattr(sim_patient, "handle_question", fake_handle_question)
+
+    client = TestClient(app)
+    base = {"question": "hello", "player_id": "aaaaaaaa-1111-4111-8111-111111111111"}
+
+    resp = client.post("/api/sim-patient", json={**base, "case_id": 2})
+    assert resp.status_code == 200
+    assert seen["case_id"] == 2
+
+    resp = client.post("/api/sim-patient", json=base)
+    assert resp.status_code == 200
+    assert seen["case_id"] == 1
+
+    seen.clear()
+    assert client.post("/api/sim-patient", json={**base, "case_id": 3}).status_code == 404
+    assert client.post("/api/sim-patient", json={**base, "case_id": "2"}).status_code == 422
+    assert seen == {}  # refused requests never reached handle_question
+
+
 # ---------------------------------------------------------------------------
 # Persona contract: historian dial, one-question-at-a-time, injection immunity
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Prod incident this fixes (live now)

The #189 hardening pinned `/api/sim-patient` and `/api/diagnosis-check` to `SIM_ACTIVE_CASE_ID`, dropping the `case_id` the Django gateway forwards. With two wards live concurrently (backend #579/#580, game #11):

- **Case-2 chat 502s** — roo answers as case 1, the gateway's echo validation rejects the mismatch (`sim_patient_views._project_roo_reply`), players see "Leila's AI service is unavailable".
- **Case-2 guesses burn the player's case-1 book** — the guess is adjudicated against case 1 and **recorded** (`record_web_guess(case_id=1)`) before the gateway rejects the reply, so the player gets a 502 *and* silently loses their one Sash guess. Verified live with a probe participant: guess sent with `case_id: 2` → 502 → `/api/contest` shows case 1 `locked/incorrect`.

## Fix

Restore case selection without reopening the pre-#189 hole:

- New `SIM_OPEN_CASE_IDS` allowlist (default `"1,2"", mirroring MLAI Backend's `HEALTH_HACK_OPEN_CASE_IDS`) bounds which cases the **authenticated gateway** may target. Lenient parse; the active case is always included so a bad env value can never brick the default path.
- `_validated_case_id`: absent → the pinned active case (older gateway payloads keep working); non-int/bool → 422; **not in the open set → 404 before anything is recorded**, indistinguishable from ids that don't exist — hidden/retired cases (3, 4, …) still can never leak dialogue or verdicts.

No droplet env change needed — the default opens exactly the two cases in play.

## Tests

`test_diagnosis_check.py` (cross-case adjudication proof: case 1's correct answer judged **incorrect** against case 2; hidden cases 404 unrecorded; strict types; allowlist parsing), `test_sim_patient.py` endpoint passthrough, and the `test_ai_security.py` case-boundary test updated from "ignored" to the stronger "refused before the narrator runs". Full suite: **483 passed**; the 2 failures (`test_jobs_scheduler_trigger_uses_x_api_key`, `test_coworking_report_trends…gpt54`) fail identically on clean main in my venv — pre-existing, untouched areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)