### PR TITLE
Parse patient targets out of final diagnoses; accept natural finality

### DIFF
--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -108,6 +108,26 @@ def load_case(case_id: Optional[int]) -> dict:
     raise KeyError(f"unknown case_id: {case_id}")
 
 
+def _open_cases_for_targeting(pinned_case: dict) -> list[dict]:
+    """The pinned case plus every other OPEN case, for patient-name targeting.
+
+    Lets Nurse Paws resolve "my final diagnosis for Leila is …" typed from
+    Sash's thread. Closed/unknown ids are skipped; the pinned case always
+    stays first so single-book deployments behave exactly as before.
+    """
+    cases = [pinned_case]
+    seen = {pinned_case.get("id")}
+    for case_id in sorted(get_settings().sim_open_case_ids):
+        if case_id in seen:
+            continue
+        try:
+            cases.append(load_case(case_id))
+        except KeyError:
+            continue
+        seen.add(case_id)
+    return cases
+
+
 def patient_knowable_context(case: dict) -> dict[str, Any]:
     """Return only authored facts a regular patient could reasonably know.
 
@@ -152,6 +172,13 @@ def check_guess(guess: str, case: dict) -> bool:
     and each acceptable answer. We do NOT import the executor or the client.
     """
     guess_clean = str(guess).strip().lower()
+    # Historical burnt-guess shape ("for sash is addisonian crisis"): a
+    # leading target clause must never drag a correct answer under the fuzzy
+    # threshold. The parser now strips these before recording, but stored or
+    # replayed strings keep working too.
+    guess_clean = re.sub(
+        r"^for\s+[a-z'’.-]{2,30}\s+(?:is\s+)?", "", guess_clean,
+    ).strip()
     # Coerce defensively: a malformed case (null/non-string values) must not
     # crash the whole turn.
     acceptable = [str(a).lower() for a in (case.get("acceptable_answers") or [])]
@@ -949,9 +976,12 @@ async def handle_question(
     tool_calls: list[dict[str, Any]] = []
     suggested_action = None
     if is_nurse or is_clerk:
-        from .ward_agents import _explicit_final_diagnosis, run_ward_agent
+        from .ward_agents import parse_final_diagnosis, run_ward_agent
 
-        is_explicit_final = bool(_explicit_final_diagnosis(question))
+        open_cases = _open_cases_for_targeting(case)
+        is_explicit_final = (
+            parse_final_diagnosis(question, open_cases, history) is not None
+        )
 
         agent_result = await run_ward_agent(
             role=role,
@@ -960,6 +990,7 @@ async def handle_question(
             case=case,
             player_id=player_id,
             contest_state=contest_state,
+            open_cases=open_cases,
         )
         raw_reply = agent_result.reply
         model_name = agent_result.model
@@ -1050,6 +1081,16 @@ async def handle_question(
             {
                 "type": "confirm_diagnosis",
                 "diagnosis": str(suggested_action.get("diagnosis") or "")[:200],
+                # Which open one-guess book the player named ("for Leila").
+                # Only ever a member of the open-case allowlist.
+                **(
+                    {"case_id": suggested_action["case_id"]}
+                    if isinstance(suggested_action.get("case_id"), int)
+                    and not isinstance(suggested_action.get("case_id"), bool)
+                    and suggested_action["case_id"]
+                    in get_settings().sim_open_case_ids
+                    else {}
+                ),
             }
             if isinstance(suggested_action, dict)
             and suggested_action.get("type") == "confirm_diagnosis"

--- a/roo-standalone/roo/tests/test_final_diagnosis_parser.py
+++ b/roo-standalone/roo/tests/test_final_diagnosis_parser.py
@@ -1,0 +1,116 @@
+"""parse_final_diagnosis: the deterministic gate between chat and the one-shot
+contest. Table-driven over real phrasings from the 2026-07-14 prod transcript
+where "for sash is addisonian crisis" was recorded verbatim and burnt a
+correct answer. No LLM anywhere in these paths.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from roo.sim_patient import check_guess
+from roo.ward_agents import parse_final_diagnosis
+
+SASH = {"id": 1, "patient": {"name": "Sasha 'Sash' Nguyen"}}
+LEILA = {"id": 2, "patient": {"name": "Leila Farouk"}}
+OPEN_CASES = [SASH, LEILA]
+
+
+@pytest.mark.parametrize("question,diagnosis,case_id", [
+    # The two messages that burnt real books — now clean and targeted.
+    ("My final diagnosis for leila is crohns disease", "crohns disease", 2),
+    ("my final diagnosis for sash is addisonian crisis", "addisonian crisis", 1),
+    # Natural finality that used to deflect forever.
+    ("my diagnosis is gastritis", "gastritis", None),
+    ("for sash i diagnose addisonian crisis", "addisonian crisis", 1),
+    # Original supported phrasings keep working (regression).
+    ("My final answer is adrenal crisis.", "adrenal crisis", None),
+    ("final diagnosis: methemoglobinemia", "methemoglobinemia", None),
+    ("I'm going with salicylate toxicity", "salicylate toxicity", None),
+    ("submit my diagnosis as lupus", "lupus", None),
+    ("lock in adrenal crisis", "adrenal crisis", None),
+    ("please record my final diagnosis: appendicitis", "appendicitis", None),
+    # Reverse frame.
+    ("addisonian crisis is my final answer", "addisonian crisis", None),
+    # Target variants.
+    ("final diagnosis for Leila: acute intermittent porphyria",
+     "acute intermittent porphyria", 2),
+    ("my final answer is sash has adrenal crisis", "adrenal crisis", 1),
+    ("my final diagnosis is crohns disease for leila", "crohns disease", 2),
+    # Typo in the name still resolves (fuzzy ≥ 0.8).
+    ("my final diagnosis for leela is crohns disease", "crohns disease", 2),
+])
+def test_final_declarations_parse_clean(question, diagnosis, case_id):
+    parsed = parse_final_diagnosis(question, OPEN_CASES)
+    assert parsed is not None, question
+    assert parsed["diagnosis"] == diagnosis
+    assert parsed["case_id"] == case_id
+
+
+@pytest.mark.parametrize("question", [
+    # Theories must never arm the one-shot confirmation.
+    "i guess leila has gastritis",
+    "I think it's Addison's disease",
+    "Is it adrenal crisis?",
+    "Could it be lupus?",
+    "what do leilas bloods look like?",
+    "whats leilas obs?",
+    "",
+    "final",
+])
+def test_non_final_messages_do_not_parse(question):
+    assert parse_final_diagnosis(question, OPEN_CASES) is None
+
+
+def test_unknown_name_stays_in_the_diagnosis():
+    # "for" clauses that do not name an open patient are left untouched.
+    parsed = parse_final_diagnosis(
+        "my final diagnosis is nausea for weeks", OPEN_CASES,
+    )
+    assert parsed == {"diagnosis": "nausea for weeks", "case_id": None}
+
+
+def test_anaphora_resolves_from_the_latest_theory():
+    history = [
+        {"role": "player", "text": "whats leilas obs?"},
+        {"role": "patient", "text": "Heart rate 128."},
+        {"role": "player", "text": "for sash i diagnose addisonian crisis"},
+        {"role": "patient", "text": "If that's your final diagnosis, say so."},
+    ]
+    parsed = parse_final_diagnosis(
+        "thats my final diagnosis", OPEN_CASES, history,
+    )
+    assert parsed == {"diagnosis": "addisonian crisis", "case_id": 1}
+
+
+def test_anaphora_resolves_theory_phrasings_too():
+    history = [
+        {"role": "player", "text": "i guess leila has gastritis"},
+        {"role": "patient", "text": "I can't confirm or rule out a theory."},
+    ]
+    parsed = parse_final_diagnosis(
+        "that is my final answer", OPEN_CASES, history,
+    )
+    assert parsed == {"diagnosis": "gastritis", "case_id": 2}
+
+
+def test_anaphora_without_antecedent_stays_unparsed():
+    assert parse_final_diagnosis("thats my final diagnosis", OPEN_CASES, []) is None
+    assert parse_final_diagnosis(
+        "thats my final diagnosis",
+        OPEN_CASES,
+        [{"role": "player", "text": "hello"}],
+    ) is None
+
+
+def test_check_guess_ignores_historical_target_pollution():
+    case = {
+        "diagnosis": "Adrenal Crisis",
+        "acceptable_answers": ["adrenal crisis", "addisonian crisis"],
+    }
+    # The exact burnt string from prod — must now match.
+    assert check_guess("for sash is addisonian crisis", case) is True
+    assert check_guess("addisonian crisis", case) is True
+    assert check_guess("gastroenteritis", case) is False

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -498,6 +498,32 @@ def test_nurse_paws_prepares_but_never_submits_final_guess(monkeypatch):
     assert result["diagnosis"] is None
 
 
+def test_nurse_paws_resolves_named_patient_into_case_target(monkeypatch):
+    # The 2026-07-14 burnt-guess transcript: naming Leila from Sash's pinned
+    # thread must produce a CLEAN diagnosis targeted at Leila's open book.
+    fake = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="Review it, then press the confirmation button if you're sure.",
+        agent_tool=("prepare_final_guess", {"diagnosis": "ignored model arg"}),
+    )
+
+    result = _run(sim_patient.handle_question(
+        "My final diagnosis for leila is crohns disease",
+        role="clerk",
+        case_id=1,
+        contest_state={"state": "eligible", "outcome": None},
+    ))
+
+    assert result["suggested_action"] == {
+        "type": "confirm_diagnosis",
+        "diagnosis": "crohns disease",
+        "case_id": 2,
+    }
+    assert fake.tool_results[0]["prepared"] is True
+    assert fake.tool_results[0]["diagnosis"] == "crohns disease"
+
+
 def test_nurse_paws_cannot_prepare_when_contest_is_locked(monkeypatch):
     fake = _install_fake(
         monkeypatch,

--- a/roo-standalone/roo/ward_agents.py
+++ b/roo-standalone/roo/ward_agents.py
@@ -12,6 +12,8 @@ import re
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from difflib import SequenceMatcher
+
 from .ai_security import make_safety_identifier
 from .config import get_settings
 from .llm import get_llm_client
@@ -286,22 +288,209 @@ def _requested_result_list_category(question: str) -> Optional[str]:
     return "all"
 
 
-_FINAL_DIAGNOSIS_RE = re.compile(
+# The declaration frame. Target clauses ("for Leila", "Sash has") are peeled
+# off separately by parse_final_diagnosis so they can resolve which one-guess
+# book the player means instead of polluting the recorded guess text — the
+# exact failure that burnt both books on 2026-07-14 ("for sash is addisonian
+# crisis" missed the 0.75 fuzzy threshold that "addisonian crisis" clears).
+_FINAL_INTENT_RE = re.compile(
     r"""^\s*(?:
         (?:my\s+)?final\s+(?:answer|diagnosis|guess)(?:\s+is)?
-      | (?:please\s+)?(?:submit|record|lock\s+in)\s+(?:my\s+)?(?:diagnosis\s+as\s+)?
+      | my\s+diagnosis\s+is
+      | (?:please\s+)?(?:submit|record|lock\s+in)\s+(?:my\s+)?
+        (?:(?:final\s+)?(?:diagnosis|answer|guess)\b\s*(?:as|of|is|[:,-])?\s*)?
+      | i\s+diagnose
       | i(?:'|’)?m\s+going\s+(?:to\s+go\s+)?with
     )\s*[:,-]?\s*(?P<diagnosis>.{2,200}?)\s*[.!?]*\s*$""",
     re.IGNORECASE | re.VERBOSE,
 )
 
+# "<diagnosis> is my final answer[, for <patient>]".
+_FINAL_INTENT_REVERSE_RE = re.compile(
+    r"^\s*(?P<diagnosis>.{2,200}?)\s+is\s+my\s+final\s+(?:answer|diagnosis|guess)\s*[.!?]*\s*$",
+    re.IGNORECASE,
+)
+
+_ANAPHORIC_DIAGNOSIS_RE = re.compile(r"^(?:that|this|it)(?:\s+one)?$", re.IGNORECASE)
+
+_TARGET_NAME = r"(?P<name>[A-Za-z][A-Za-z'’.-]{1,30})"
+_LEADING_TARGET_RE = re.compile(
+    rf"^(?:for|of)\s+{_TARGET_NAME}\s*[,:]?\s*(?:is\s+|it'?s\s+|i\s+diagnose\s+)?",
+    re.IGNORECASE,
+)
+# Question-level variant: peel "for Sash," off the front of the whole message
+# WITHOUT consuming the declaration verb ("for sash i diagnose …").
+_QUESTION_LEAD_TARGET_RE = re.compile(
+    rf"^(?:for|of)\s+{_TARGET_NAME}\s*[,:]?\s+", re.IGNORECASE,
+)
+_LEADING_HAS_RE = re.compile(
+    rf"^(?:that\s+)?{_TARGET_NAME}\s+has\s+", re.IGNORECASE,
+)
+_TRAILING_TARGET_RE = re.compile(
+    rf"\s+(?:for|of)\s+{_TARGET_NAME}\s*$", re.IGNORECASE,
+)
+
+# Theory phrasings mined for the anaphora path ("that's my final diagnosis").
+_THEORY_EXTRACT_RES = (
+    re.compile(
+        r"^\s*i\s+(?:guess|think|suspect|reckon|believe)\s+(?:it\s+is\s+|it'?s\s+|that\s+)?(?P<rest>.+?)\s*[.!?]*\s*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^\s*(?:is\s+(?:it|this)|could\s+(?:it|this)\s+be|might\s+(?:it\s+)?be)\s+(?P<rest>.+?)\s*\??\s*$",
+        re.IGNORECASE,
+    ),
+    re.compile(r"^\s*it'?s\s+(?P<rest>.+?)\s*[.!?]*\s*$", re.IGNORECASE),
+)
+
+
+def _case_name_index(open_cases: Optional[list[dict]]) -> dict[str, int]:
+    """Lowercased patient-name tokens -> case id, for every open book."""
+    index: dict[str, int] = {}
+    for entry in open_cases or []:
+        case_id = entry.get("id") if isinstance(entry, dict) else None
+        if not isinstance(case_id, int) or isinstance(case_id, bool):
+            continue
+        name = str(((entry.get("patient") or {}).get("name")) or "")
+        for token in re.split(r"[^a-z]+", name.lower()):
+            if len(token) >= 3:
+                index.setdefault(token, case_id)
+    return index
+
+
+def _match_case_token(raw: str, index: dict[str, int]) -> Optional[int]:
+    token = re.sub(r"[^a-z]", "", str(raw or "").lower())
+    if len(token) < 3:
+        return None
+    if token in index:
+        return index[token]
+    for known, case_id in index.items():
+        if SequenceMatcher(None, token, known).ratio() >= 0.8:
+            return case_id
+    return None
+
+
+def _strip_target_clauses(
+    diagnosis: str, index: dict[str, int], target: Optional[int],
+) -> tuple[str, Optional[int]]:
+    """Peel patient-target clauses off the edges of a captured diagnosis.
+
+    Only clauses whose name resolves to an open case are removed, so ordinary
+    words after "for"/"of" ("pain for weeks") stay part of the diagnosis.
+    """
+    for _ in range(3):
+        changed = False
+        for pattern, trailing in (
+            (_LEADING_TARGET_RE, False),
+            (_LEADING_HAS_RE, False),
+            (_TRAILING_TARGET_RE, True),
+        ):
+            match = pattern.search(diagnosis) if trailing else pattern.match(diagnosis)
+            if not match:
+                continue
+            case_id = _match_case_token(match.group("name"), index)
+            if case_id is None:
+                continue
+            if target is None:
+                target = case_id
+            diagnosis = (
+                diagnosis[: match.start()] if trailing else diagnosis[match.end():]
+            ).strip()
+            changed = True
+        if not changed:
+            break
+    return diagnosis, target
+
+
+def _recover_theory_from_history(
+    history: Optional[list[dict]], open_cases: Optional[list[dict]],
+) -> Optional[dict]:
+    """Resolve "that's my final diagnosis" from the player's latest theory."""
+    for turn in reversed(history or []):
+        if not isinstance(turn, dict) or turn.get("role") != "player":
+            continue
+        text = re.sub(r"\s+", " ", str(turn.get("text") or "")).strip()
+        if not text:
+            continue
+        parsed = parse_final_diagnosis(text, open_cases, history=None)
+        if parsed:
+            return parsed
+        index = _case_name_index(open_cases)
+        for pattern in _THEORY_EXTRACT_RES:
+            match = pattern.match(text)
+            if not match:
+                continue
+            rest, target = _strip_target_clauses(
+                match.group("rest").strip(" \"'“”"), index, None,
+            )
+            rest = rest.strip(" \"'“”")
+            if len(rest) >= 2 and not _ANAPHORIC_DIAGNOSIS_RE.match(rest):
+                return {"diagnosis": rest[:200], "case_id": target}
+    return None
+
+
+def parse_final_diagnosis(
+    question: str,
+    open_cases: Optional[list[dict]] = None,
+    history: Optional[list[dict]] = None,
+) -> Optional[dict]:
+    """Deterministically parse an explicit final-diagnosis declaration.
+
+    Returns {"diagnosis": <clean text>, "case_id": <open case id or None>} or
+    None when the message is not an unmistakably final declaration. Never
+    consults the model: this feeds the recorded one-shot guess.
+    """
+    text = re.sub(r"\s+", " ", str(question or "")).strip()
+    if not text:
+        return None
+    # Normalise the contraction so the reverse frame can see the anaphor.
+    text = re.sub(r"^(?:that|this)'?s\b", "that is", text, flags=re.IGNORECASE)
+    index = _case_name_index(open_cases)
+    target: Optional[int] = None
+
+    # A leading "for <patient>," frame before the declaration itself.
+    lead = _QUESTION_LEAD_TARGET_RE.match(text)
+    if lead:
+        case_id = _match_case_token(lead.group("name"), index)
+        if case_id is not None:
+            target = case_id
+            text = text[lead.end():].strip()
+
+    match = _FINAL_INTENT_RE.match(text)
+    diagnosis = match.group("diagnosis") if match else None
+    if diagnosis is None:
+        reverse = _FINAL_INTENT_REVERSE_RE.match(text)
+        if reverse:
+            diagnosis = reverse.group("diagnosis")
+    if diagnosis is None:
+        return None
+
+    diagnosis = diagnosis.strip(" \"'“”")
+    diagnosis, target = _strip_target_clauses(diagnosis, index, target)
+    diagnosis = re.sub(r"^(?:is|as)\s+", "", diagnosis, flags=re.IGNORECASE)
+    diagnosis = diagnosis.strip(" \"'“”:,-")
+
+    if not diagnosis or _ANAPHORIC_DIAGNOSIS_RE.match(diagnosis):
+        recovered = _recover_theory_from_history(history, open_cases)
+        if recovered is None:
+            return None
+        diagnosis = recovered["diagnosis"]
+        if target is None:
+            target = recovered["case_id"]
+
+    diagnosis = diagnosis[:200].strip()
+    if len(diagnosis) < 2:
+        return None
+    return {"diagnosis": diagnosis, "case_id": target}
+
+
+_UNSET = object()
+
 
 def _explicit_final_diagnosis(question: str) -> Optional[str]:
-    match = _FINAL_DIAGNOSIS_RE.match(str(question or "").strip())
-    if not match:
-        return None
-    diagnosis = re.sub(r"\s+", " ", match.group("diagnosis")).strip(" \"'“”")
-    return diagnosis[:200] or None
+    """Back-compat shim: the bare diagnosis text of a final declaration."""
+    parsed = parse_final_diagnosis(question)
+    return parsed["diagnosis"] if parsed else None
 
 
 def _authorized_examination_systems(question: str, case: dict) -> set[str]:
@@ -407,6 +596,7 @@ def _execute_paws_tool(
     contest_state: dict[str, Any],
     action_holder: dict[str, Any],
     question: str = "",
+    parsed_final: Any = _UNSET,
 ) -> dict[str, Any]:
     if name == "get_observations":
         if not _observations_requested(question):
@@ -429,27 +619,36 @@ def _execute_paws_tool(
 
     if name == "prepare_final_guess":
         # Never trust the model-proposed tool argument as authority. The only
-        # permitted diagnosis is extracted directly from an unmistakably final
-        # raw player message.
-        diagnosis = _explicit_final_diagnosis(question)
+        # permitted diagnosis is parsed directly from an unmistakably final
+        # raw player message (with any patient-target clause peeled off).
+        parsed = (
+            parse_final_diagnosis(question, [case])
+            if parsed_final is _UNSET
+            else parsed_final
+        )
         if contest_state.get("state") != "eligible":
             return {
                 "prepared": False,
                 "contest_state": contest_state.get("state", "unavailable"),
                 "reason": "The one-shot contest is not eligible for a new submission.",
             }
-        if not diagnosis:
+        if not parsed:
             return {
                 "prepared": False,
                 "reason": "The player did not explicitly declare a final diagnosis.",
             }
         action_holder["value"] = {
             "type": "confirm_diagnosis",
-            "diagnosis": diagnosis,
+            "diagnosis": parsed["diagnosis"],
+            **(
+                {"case_id": parsed["case_id"]}
+                if parsed.get("case_id") is not None
+                else {}
+            ),
         }
         return {
             "prepared": True,
-            "diagnosis": diagnosis,
+            "diagnosis": parsed["diagnosis"],
             "instruction": "Ask the player to review and press the confirmation button.",
         }
 
@@ -479,11 +678,14 @@ async def run_ward_agent(
     case: dict,
     player_id: str = "00000000-0000-4000-8000-000000000000",
     contest_state: Optional[dict[str, Any]] = None,
+    open_cases: Optional[list[dict]] = None,
 ) -> WardAgentResult:
     """Run one AI-first Dr Snow or Nurse Paws turn."""
     settings = get_settings()
     client = get_llm_client("openai")
     action_holder: dict[str, Any] = {}
+    # Parsed once per turn: the executor and the no-tool fallback must agree.
+    parsed_final = parse_final_diagnosis(question, open_cases or [case], history)
 
     if role == "nurse":
         npc_name = DR_SNOW_NAME
@@ -503,7 +705,8 @@ async def run_ward_agent(
 
         def execute(name: str, arguments: dict[str, Any]):
             return _execute_paws_tool(
-                name, arguments, case, state, action_holder, question
+                name, arguments, case, state, action_holder, question,
+                parsed_final,
             )
     else:
         raise ValueError(f"unsupported ward agent role: {role}")
@@ -548,12 +751,16 @@ async def run_ward_agent(
         timeout=settings.SIM_PATIENT_OPENAI_TIMEOUT_SECONDS,
     )
     if role == "clerk" and not action_holder.get("value"):
-        diagnosis = _explicit_final_diagnosis(question)
         state = contest_state or {"state": "unavailable"}
-        if diagnosis and state.get("state") == "eligible":
+        if parsed_final and state.get("state") == "eligible":
             action_holder["value"] = {
                 "type": "confirm_diagnosis",
-                "diagnosis": diagnosis,
+                "diagnosis": parsed_final["diagnosis"],
+                **(
+                    {"case_id": parsed_final["case_id"]}
+                    if parsed_final.get("case_id") is not None
+                    else {}
+                ),
             }
     return WardAgentResult(
         reply=response.content,


### PR DESCRIPTION
Phase 1 (producer, deploys **last**) of the ward-clerk targeting fix. Companions: MLAI-AUS-Inc/mlai-backend#583 (validator passthrough) and MLAI-AUS-Inc/health-hack#15 (Paws patient selector + targeted confirm button) — both must deploy before this.

## What broke (prod transcript, 2026-07-14)

- "my diagnosis is gastritis" → deflected ("tell me your final diagnosis explicitly")
- "My final diagnosis for leila is crohns disease" → confirm armed with diagnosis **"for leila is crohns disease"**
- "for sash i diagnose addisonian crisis" → deflected
- "thats my final diagnosis" → unresolvable by design
- "my final diagnosis for sash is addisonian crisis" → confirm armed with **"for sash is addisonian crisis"** → recorded → **incorrect** (0.739 < 0.75 fuzzy vs a correct answer)

Both of the player's one-guess books burnt on polluted strings (since cleared server-side).

## Fix

`parse_final_diagnosis(question, open_cases, history)` — deterministic, zero LLM:

- strips `for <patient>` / `<patient> has` clauses from either edge, resolving them against open cases' name tokens (fuzzy ≥0.8 for typos) into `suggested_action.case_id` (allowlist-validated again in the response envelope)
- unrecognized names stay in the diagnosis ("nausea for weeks" untouched)
- accepts natural finality ("my diagnosis is X", "i diagnose X", "X is my final answer") plus all previously supported frames (regression-tested)
- anaphora resolves from the latest player theory in history; no antecedent → no confirmation
- `check_guess` neutralizes the historical "for <name> is" pollution shape

## Tests

- New `test_final_diagnosis_parser.py`: 28 table-driven cases including the exact burnt transcript strings
- End-to-end clerk test: named cross-case target → clean diagnosis + `case_id: 2`
- Full affected suite: **196 passed** (parser + sim_patient + diagnosis_check + ai_security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
