### PR TITLE
Nurse Paws AI-first lock-in: the model understands, determinism verifies

### DIFF
--- a/roo-standalone/roo/sim_patient.py
+++ b/roo-standalone/roo/sim_patient.py
@@ -179,6 +179,12 @@ def check_guess(guess: str, case: dict) -> bool:
     guess_clean = re.sub(
         r"^for\s+[a-z'’.-]{2,30}\s+(?:is\s+)?", "", guess_clean,
     ).strip()
+    guess_clean = re.sub(
+        r"\s+(?:as|is)?\s*(?:my\s+|the\s+)?(?:one\s+)?(?:official\s+|final\s+)+"
+        r"(?:diagnosis|answer|guess)\s*$",
+        "",
+        guess_clean,
+    ).strip()
     # Coerce defensively: a malformed case (null/non-string values) must not
     # crash the whole turn.
     acceptable = [str(a).lower() for a in (case.get("acceptable_answers") or [])]
@@ -328,51 +334,22 @@ _DIAGNOSIS_NEUTRAL_REPLY = {
         "That's your call, doc. Nurse Paws handles final diagnoses — tell me "
         "which investigation result you need."
     ),
-    "clerk_tentative": (
-        "I can't confirm or rule out a theory, doc. When you've decided, tell "
-        "me your final diagnosis explicitly."
-    ),
-    "clerk_final_eligible": (
-        "I've written down the final diagnosis you chose. Review it, then press "
-        "the confirmation button if you're sure."
-    ),
-    "clerk_final_closed": (
-        "The diagnosis book is already closed for this case, doc."
-    ),
-    "clerk_final_unavailable": (
-        "I can't open the diagnosis book right now, doc. Please try again shortly."
-    ),
 }
 
 
-def _diagnosis_neutral_reply(
-    *,
-    role: str,
-    is_theory: bool,
-    is_explicit_final: bool,
-    contest_state: Optional[dict[str, Any]],
-) -> Optional[str]:
-    """Return a model-independent reply for any diagnosis-theory path.
+def _diagnosis_neutral_reply(*, role: str, is_theory: bool) -> Optional[str]:
+    """Return a model-independent reply for a bedside diagnosis-theory turn.
 
-    The choice depends only on the raw request classification and the supplied
-    contest state. It deliberately does not inspect the case, the model output,
-    or whether the player's theory is correct.
+    Patient and nurse theory turns stay scripted (in character, and those
+    personas must never engage with a diagnosis at all). Nurse Paws' replies
+    are AI-authored: answer-independence there rests on the model never
+    knowing the hidden diagnosis plus the output leakage guard, and the
+    recorded guess text is validated separately from anything the model says.
     """
     if role == "patient" and is_theory:
         return _DIAGNOSIS_NEUTRAL_REPLY["patient"]
     if role == "nurse" and is_theory:
         return _DIAGNOSIS_NEUTRAL_REPLY["nurse"]
-    if role != "clerk":
-        return None
-    if is_explicit_final:
-        state = str((contest_state or {}).get("state") or "unavailable")
-        if state == "eligible":
-            return _DIAGNOSIS_NEUTRAL_REPLY["clerk_final_eligible"]
-        if state in {"locked", "awaiting_redemption", "completed"}:
-            return _DIAGNOSIS_NEUTRAL_REPLY["clerk_final_closed"]
-        return _DIAGNOSIS_NEUTRAL_REPLY["clerk_final_unavailable"]
-    if is_theory:
-        return _DIAGNOSIS_NEUTRAL_REPLY["clerk_tentative"]
     return None
 
 
@@ -788,6 +765,17 @@ def _reply_leaks_diagnosis(reply: str, case: dict) -> bool:
     return bool(_leaked_diagnosis_terms(reply, case))
 
 
+def _term_in_player_text(term: str, player_texts: tuple[str, ...]) -> bool:
+    term_words, term_compact = _guard_normalized(term)
+    for text in player_texts:
+        text_words, text_compact = _guard_normalized(text)
+        if _guard_phrase_present(text_words, term_words):
+            return True
+        if len(term_compact) >= 6 and term_compact in text_compact:
+            return True
+    return False
+
+
 def _guard_phrase_present(haystack_words: str, needle_words: str) -> bool:
     return bool(
         needle_words
@@ -795,11 +783,21 @@ def _guard_phrase_present(haystack_words: str, needle_words: str) -> bool:
     )
 
 
-def _leaked_diagnosis_terms(reply: str, case: dict) -> list[str]:
-    """Return authored answer terms present in output, including short aliases."""
+def _leaked_diagnosis_terms(
+    reply: str, case: dict, player_texts: tuple[str, ...] = (),
+) -> list[str]:
+    """Return authored answer terms present in output, including short aliases.
+
+    Terms the PLAYER has already typed (player_texts) are exempt: echoing the
+    player's own words back reveals nothing they don't know — and scrubbing
+    only-correct terms would itself become a correctness oracle (the reply
+    style would flip exactly when the player names a right answer).
+    """
     reply_words, reply_compact = _guard_normalized(reply)
     leaked: list[str] = []
     for term in _diagnosis_terms(case):
+        if player_texts and _term_in_player_text(term, player_texts):
+            continue
         term_words, term_compact = _guard_normalized(term)
         complete_phrase = _guard_phrase_present(reply_words, term_words)
         obfuscated_long_form = bool(
@@ -950,7 +948,6 @@ async def handle_question(
     is_nurse = role == "nurse"
     is_clerk = role == "clerk"
     is_theory = looks_like_diagnosis_guess(question)
-    is_explicit_final = False
 
     extra_instruction = ""
     is_guess = False
@@ -976,13 +973,9 @@ async def handle_question(
     tool_calls: list[dict[str, Any]] = []
     suggested_action = None
     if is_nurse or is_clerk:
-        from .ward_agents import parse_final_diagnosis, run_ward_agent
+        from .ward_agents import run_ward_agent
 
         open_cases = _open_cases_for_targeting(case)
-        is_explicit_final = (
-            parse_final_diagnosis(question, open_cases, history) is not None
-        )
-
         agent_result = await run_ward_agent(
             role=role,
             question=question,
@@ -1024,12 +1017,7 @@ async def handle_question(
         else (case.get("patient") or {}).get("name")
     )
     speaker_names = tuple(n for n in (display_name, NURSE_NAME, CLERK_NAME) if n)
-    fixed_reply = _diagnosis_neutral_reply(
-        role=role,
-        is_theory=is_theory,
-        is_explicit_final=is_explicit_final,
-        contest_state=contest_state,
-    )
+    fixed_reply = _diagnosis_neutral_reply(role=role, is_theory=is_theory)
     if fixed_reply is not None:
         reply = fixed_reply
     else:
@@ -1037,11 +1025,20 @@ async def handle_question(
         if not reply:
             reply = _EMPTY_REPLY_FALLBACK[role]
 
-    # Hidden answer terms are never permitted in model-authored speech, including
-    # Paws' pre-confirmation turn. The separately validated suggested_action can
-    # carry exactly what the player typed without letting the model choose among
-    # multiple candidates and accidentally become a correctness oracle.
-    leaked_terms = _leaked_diagnosis_terms(reply, case)
+    # Hidden answer terms are never permitted in model-authored speech UNLESS
+    # the player already typed them (echoing their own words back is not a
+    # leak, and selective scrubbing would itself signal correctness). The
+    # separately validated suggested_action carries exactly what the player
+    # typed either way.
+    player_texts = (
+        question,
+        *(
+            str(turn.get("text") or "")
+            for turn in history
+            if isinstance(turn, dict) and turn.get("role") == "player"
+        ),
+    )
+    leaked_terms = _leaked_diagnosis_terms(reply, case, player_texts)
     if leaked_terms:
         print(
             "⚠️ sim-patient output leakage guard "

--- a/roo-standalone/roo/tests/test_final_diagnosis_parser.py
+++ b/roo-standalone/roo/tests/test_final_diagnosis_parser.py
@@ -41,6 +41,11 @@ OPEN_CASES = [SASH, LEILA]
     ("my final diagnosis is crohns disease for leila", "crohns disease", 2),
     # Typo in the name still resolves (fuzzy ≥ 0.8).
     ("my final diagnosis for leela is crohns disease", "crohns disease", 2),
+    # The 2026-07-14 second burn: trailing declaration frames must be shaved.
+    ("submit addisonian crisis as final diagnosis for sash", "addisonian crisis", 1),
+    ("lock in crohns disease as my final answer", "crohns disease", None),
+    # Same-message anaphora: the declaration's antecedent is one sentence back.
+    ("I think sash has addisonian crisis. submit that", "addisonian crisis", 1),
 ])
 def test_final_declarations_parse_clean(question, diagnosis, case_id):
     parsed = parse_final_diagnosis(question, OPEN_CASES)
@@ -110,7 +115,8 @@ def test_check_guess_ignores_historical_target_pollution():
         "diagnosis": "Adrenal Crisis",
         "acceptable_answers": ["adrenal crisis", "addisonian crisis"],
     }
-    # The exact burnt string from prod — must now match.
+    # The exact burnt strings from prod — both pollution shapes must match.
     assert check_guess("for sash is addisonian crisis", case) is True
+    assert check_guess("addisonian crisis as final diagnosis", case) is True
     assert check_guess("addisonian crisis", case) is True
     assert check_guess("gastroenteritis", case) is False

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -492,6 +492,7 @@ def test_nurse_paws_prepares_but_never_submits_final_guess(monkeypatch):
     assert result["suggested_action"] == {
         "type": "confirm_diagnosis",
         "diagnosis": "adrenal crisis",
+        "case_id": 1,
     }
     assert fake.tool_results[0]["prepared"] is True
     assert result["correct"] is None
@@ -522,6 +523,114 @@ def test_nurse_paws_resolves_named_patient_into_case_target(monkeypatch):
     }
     assert fake.tool_results[0]["prepared"] is True
     assert fake.tool_results[0]["diagnosis"] == "crohns disease"
+
+
+def test_clerk_model_extraction_is_grounded_and_trimmed(monkeypatch):
+    # The 2026-07-14 second burn: the model judges INTENT ("submit that"),
+    # grounding forces the recorded text to be the player's own words, and the
+    # frame trim keeps declaration vocabulary out of the guess.
+    fake = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="It's on the button below when you're ready, doc.",
+        agent_tool=("prepare_final_guess", {
+            "diagnosis": "addisonian crisis as final diagnosis",
+            "patient": "sash",
+        }),
+    )
+    result = _run(sim_patient.handle_question(
+        "I think sash has Addisonian crisis. submit that",
+        role="clerk",
+        contest_state=_ELIGIBLE,
+    ))
+    assert result["suggested_action"] == {
+        "type": "confirm_diagnosis",
+        "diagnosis": "addisonian crisis",
+        "case_id": 1,
+    }
+    assert fake.tool_results[0]["prepared"] is True
+
+
+def test_clerk_model_cannot_invent_a_diagnosis(monkeypatch):
+    # A proposal the player never typed (and no parsable declaration in the
+    # message) must never arm the confirmation.
+    fake = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="Tell me the diagnosis in your own words first, doc.",
+        agent_tool=("prepare_final_guess", {"diagnosis": "lupus", "patient": ""}),
+    )
+    result = _run(sim_patient.handle_question(
+        "go ahead and put it in the book",
+        role="clerk",
+        contest_state=_ELIGIBLE,
+    ))
+    assert result["suggested_action"] is None
+    assert fake.tool_results[0]["prepared"] is False
+
+
+def test_clerk_grounding_reaches_recent_player_history(monkeypatch):
+    # "submit that" with the actual diagnosis two turns back: the model
+    # resolves the anaphor; grounding verifies it against player history.
+    fake = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="Check the button below, doc.",
+        agent_tool=("prepare_final_guess", {
+            "diagnosis": "methemoglobinemia",
+            "patient": "",
+        }),
+    )
+    result = _run(sim_patient.handle_question(
+        "submit that",
+        role="clerk",
+        history=[
+            {"role": "player", "text": "i reckon it's methemoglobinemia"},
+            {"role": "patient", "text": "That is your call to make, doc."},
+        ],
+        contest_state=_ELIGIBLE,
+    ))
+    assert result["suggested_action"] == {
+        "type": "confirm_diagnosis",
+        "diagnosis": "methemoglobinemia",
+        "case_id": 1,
+    }
+    assert fake.tool_results[0]["prepared"] is True
+
+
+def test_clerk_tentative_question_never_arms_even_via_the_tool(monkeypatch):
+    # Defense in depth: if the model calls the tool for an obvious question,
+    # the executor still declines.
+    fake = _install_fake(
+        monkeypatch,
+        "{}",
+        reply_text="I can't confirm theories, doc — but you can lock it in any time.",
+        agent_tool=("prepare_final_guess", {
+            "diagnosis": "adrenal crisis",
+            "patient": "sash",
+        }),
+    )
+    result = _run(sim_patient.handle_question(
+        "Could it be adrenal crisis?",
+        role="clerk",
+        contest_state=_ELIGIBLE,
+    ))
+    assert result["suggested_action"] is None
+    assert fake.tool_results[0]["prepared"] is False
+
+
+def test_clerk_theory_reply_is_model_authored(monkeypatch):
+    # The frustrating fixed deflection is gone: Paws' own coaching words reach
+    # the player (scrubbed only by the echo-aware leakage guard).
+    coaching = "Happy to hear theories, doc — say submit gastritis for Leila to make it official."
+    _install_fake(monkeypatch, "{}", reply_text=coaching)
+    result = _run(sim_patient.handle_question(
+        "i guess leila has gastritis",
+        role="clerk",
+        contest_state=_ELIGIBLE,
+    ))
+    assert result["reply"] == coaching
+    assert result["suggested_action"] is None
 
 
 def test_nurse_paws_cannot_prepare_when_contest_is_locked(monkeypatch):
@@ -594,6 +703,7 @@ def test_clerk_http_role_forwards_contest_state(monkeypatch):
     assert response.json()["suggested_action"] == {
         "type": "confirm_diagnosis",
         "diagnosis": "adrenal crisis",
+        "case_id": 1,
     }
 
 
@@ -822,6 +932,7 @@ def test_clerk_final_answer_action_is_deterministically_derived_from_raw_text(mo
     assert result["suggested_action"] == {
         "type": "confirm_diagnosis",
         "diagnosis": "adrenal crisis",
+        "case_id": 1,
     }
     assert result["reply"]
 
@@ -838,20 +949,28 @@ def test_clerk_final_echo_cannot_leak_a_different_diagnosis(monkeypatch):
         contest_state=_ELIGIBLE,
     ))
     assert result["suggested_action"]["diagnosis"] == "appendicitis"
-    assert result["reply"] == sim_patient._DIAGNOSIS_NEUTRAL_REPLY["clerk_final_eligible"]
+    # The model volunteered a hidden answer term the player never typed —
+    # the output guard scrubs it.
+    assert result["reply"] == sim_patient._LEAK_GUARD_FALLBACK["clerk"]
 
 
-def test_clerk_model_never_echoes_even_player_supplied_hidden_final_term(monkeypatch):
+def test_clerk_may_echo_terms_the_player_already_typed(monkeypatch):
+    # Echoing the player's own words reveals nothing they don't know — and
+    # scrubbing ONLY correct player-typed terms would itself be a correctness
+    # oracle (the reply style would flip exactly on right answers).
     _install_fake(monkeypatch, "{}", reply_text="Adrenal crisis.")
     result = _run(sim_patient.handle_question(
         "My final diagnosis is adrenal crisis",
         role="clerk",
         contest_state=_ELIGIBLE,
     ))
-    assert result["reply"] == sim_patient._DIAGNOSIS_NEUTRAL_REPLY["clerk_final_eligible"]
+    assert result["reply"] == "Adrenal crisis."
 
 
 def test_clerk_multi_diagnosis_final_cannot_become_a_correctness_oracle(monkeypatch):
+    # Both candidates are the player's own words: the recorded guess keeps
+    # BOTH (never the model's pick), and echoing either is uncorrelated with
+    # correctness because the model does not know the answer.
     _install_fake(monkeypatch, "{}", reply_text="Adrenal crisis.")
     result = _run(sim_patient.handle_question(
         "My final diagnosis is appendicitis or adrenal crisis",
@@ -861,15 +980,18 @@ def test_clerk_multi_diagnosis_final_cannot_become_a_correctness_oracle(monkeypa
     assert result["suggested_action"] == {
         "type": "confirm_diagnosis",
         "diagnosis": "appendicitis or adrenal crisis",
+        "case_id": 1,
     }
-    assert result["reply"] == sim_patient._DIAGNOSIS_NEUTRAL_REPLY["clerk_final_eligible"]
+    assert result["reply"] == "Adrenal crisis."
 
 
 def test_theory_replies_are_identical_for_correct_and_incorrect_candidates(monkeypatch):
+    # Clerk theory replies are AI-authored now: their answer-independence
+    # rests on the model never seeing the answer (payload-secrecy tests) and
+    # the echo-aware leakage guard, not on a fixed string.
     pairs = [
         ("patient", "is it adrenal crisis?", "is it appendicitis?", None),
         ("nurse", "could it be adrenal crisis?", "could it be appendicitis?", None),
-        ("clerk", "could it be adrenal crisis?", "could it be appendicitis?", _ELIGIBLE),
     ]
     for role, correct_text, incorrect_text, state in pairs:
         correct_fake = _install_fake(
@@ -897,10 +1019,11 @@ def test_theory_replies_are_identical_for_correct_and_incorrect_candidates(monke
 
 
 def test_transform_replies_are_identical_for_correct_and_incorrect_terms(monkeypatch):
+    # Clerk omitted: both terms are player-typed, so echoing either is
+    # permitted and symmetric (see the echo-aware guard tests).
     for role, state in (
         ("patient", None),
         ("nurse", None),
-        ("clerk", _ELIGIBLE),
     ):
         correct_fake = _install_fake(
             monkeypatch, "{}", reply_text="Adrenal crisis."
@@ -949,12 +1072,13 @@ def test_sash_theory_reply_is_answer_independent_for_every_case(monkeypatch):
         assert len(correct_fake.calls) == len(incorrect_fake.calls) == 1
 
 
-def test_paws_final_reply_is_identical_for_correct_and_incorrect_candidates(monkeypatch):
-    replies = []
+def test_paws_final_action_is_player_derived_regardless_of_model_reply(monkeypatch):
+    # Whatever the model says, the RECORDED guess text comes only from the
+    # player's words: an opinionated reply can never alter the submission.
     actions = []
     for question, model_reply in (
-        ("My final diagnosis is adrenal crisis", "Perfect, that's correct."),
-        ("My final diagnosis is appendicitis", "No, that's incorrect."),
+        ("My final diagnosis is adrenal crisis", "Noted — press the button."),
+        ("My final diagnosis is appendicitis", "All set. Confirm below."),
     ):
         fake = _install_fake(monkeypatch, "{}", reply_text=model_reply)
         result = _run(sim_patient.handle_question(
@@ -962,14 +1086,12 @@ def test_paws_final_reply_is_identical_for_correct_and_incorrect_candidates(monk
             role="clerk",
             contest_state=_ELIGIBLE,
         ))
-        replies.append(result["reply"])
         actions.append(result["suggested_action"])
         assert len(fake.agent_calls) == 1
 
-    assert replies[0] == replies[1]
     assert actions == [
-        {"type": "confirm_diagnosis", "diagnosis": "adrenal crisis"},
-        {"type": "confirm_diagnosis", "diagnosis": "appendicitis"},
+        {"type": "confirm_diagnosis", "diagnosis": "adrenal crisis", "case_id": 1},
+        {"type": "confirm_diagnosis", "diagnosis": "appendicitis", "case_id": 1},
     ]
 
 
@@ -1075,9 +1197,14 @@ def test_clerk_unknown_or_missing_contest_state_fails_closed(monkeypatch):
 
 
 def test_clerk_system_prompt_contract():
-    assert "spoken words" in ward_agents.NURSE_PAWS_PROMPT.lower()
-    assert "must never say whether" in ward_agents.NURSE_PAWS_PROMPT.lower()
-    assert "prepare_final_guess only" in ward_agents.NURSE_PAWS_PROMPT
+    prompt = ward_agents.NURSE_PAWS_PROMPT
+    assert "spoken words" in prompt.lower()
+    assert "must never say or hint whether" in prompt.lower()
+    assert "do not know the hidden diagnosis" in prompt.lower()
+    # The coaching template players are told to use, verbatim.
+    assert "submit <their diagnosis> for <patient name>" in prompt
+    assert "never repeat your previous reply" in prompt.lower()
+    assert "patient argument" in prompt.lower()
 
 
 def test_endpoint_accepts_clerk_role_and_passes_contest_state(monkeypatch):

--- a/roo-standalone/roo/ward_agents.py
+++ b/roo-standalone/roo/ward_agents.py
@@ -34,13 +34,20 @@ You do not know the hidden diagnosis and must never confirm or reject a proposed
 Speak warmly and efficiently in one or two short paragraphs. Return only Dr Snow's spoken words: no labels, narration, stage directions, markdown, JSON, or tool names."""
 
 
-NURSE_PAWS_PROMPT = """You are Nurse Paws, the senior ward nurse at reception. You help the player synthesize the case, provide the complete observations and physical examination, and prepare their ONE official diagnosis for explicit confirmation.
+NURSE_PAWS_PROMPT = """You are Nurse Paws, the senior ward nurse at reception. Your MAIN job is preparing each player's ONE official final diagnosis per ward patient for explicit confirmation; you also provide the complete observations and physical examination and help the player reason.
 
-You are the first conversational responder for every message. Clinical observations and examination findings MUST come from your tools in this turn or from the supplied prior conversation. Never invent or round a finding. You may reason with the player about patterns and differentials using only facts already disclosed, but you do not know the hidden diagnosis or acceptable answers and must never say whether a proposed diagnosis is correct.
+You are the first conversational responder for every message. Clinical observations and examination findings MUST come from your tools in this turn or from the supplied prior conversation. Never invent or round a finding. You may reason with the player about patterns and differentials using only facts already disclosed, but you do not know the hidden diagnosis or acceptable answers and must never say or hint whether any proposed diagnosis is right, wrong, likely, or close.
 
-Use get_observations for vital signs and get_examination for physical findings. Call prepare_final_guess only when the player clearly declares a final diagnosis or explicitly asks to submit it. Never call it for tentative language such as "could it be" or "what about". prepare_final_guess does not submit anything; after it succeeds, tell the player to review and press the confirmation button. If the contest is not eligible, do not invite another submission.
+LOCKING IN A DIAGNOSIS
+- Call prepare_final_guess the moment the player wants to lock in, submit, or finalise a diagnosis — including indirect wording like "submit that", "lock it in", "that's my answer", a bare diagnosis given right after you asked for their final answer, or restating an earlier theory as final.
+- diagnosis argument: the condition in the player's own words ONLY — no framing words like "final diagnosis" or "submit", and no patient name inside it.
+- patient argument: the ward patient's name exactly as the player referred to them; empty string if they did not say which patient.
+- The tool never submits, adjudicates, or burns anything. After it succeeds, tell the player to check the confirmation button just below and press it if they are sure.
+- If the tool declines, relay the reason in your own words and coach them on what to say.
+- For a tentative theory (a question, "could it be", thinking out loud): never confirm, deny, or hint. Remind them they can lock it in any time by saying: submit <their diagnosis> for <patient name>.
+- If the contest is not eligible, say the diagnosis book is closed and do not invite another submission.
 
-Speak like a warm, quick, slightly playful senior nurse in one or two short paragraphs. Return only Nurse Paws' spoken words: no labels, narration, stage directions, markdown, JSON, or tool names."""
+Use get_observations for vital signs and get_examination for physical findings. Speak like a warm, quick, slightly playful senior nurse in one or two short sentences. Never repeat your previous reply word-for-word — always move the player forward. Return only Nurse Paws' spoken words: no labels, narration, stage directions, markdown, JSON, or tool names."""
 
 
 @dataclass
@@ -205,16 +212,31 @@ def _paws_tools(case: dict) -> list[dict[str, Any]]:
         ),
         _strict_tool(
             "prepare_final_guess",
-            "Prepare an explicitly final diagnosis for a separate player confirmation. This never submits, adjudicates, or burns the attempt.",
+            "Prepare the player's final diagnosis for a separate player confirmation. "
+            "Call it whenever the player wants to lock in or submit a diagnosis, "
+            "including indirect wording like 'submit that'. This never submits, "
+            "adjudicates, or burns the attempt.",
             {
                 "diagnosis": {
                     "type": "string",
                     "minLength": 1,
                     "maxLength": 200,
-                    "description": "The diagnosis the player explicitly declared as final.",
+                    "description": (
+                        "The diagnosis itself, in the player's own words, with no "
+                        "framing ('final diagnosis', 'submit') and no patient name."
+                    ),
+                },
+                "patient": {
+                    "type": "string",
+                    "maxLength": 80,
+                    "description": (
+                        "The ward patient this diagnosis is for, exactly as the "
+                        "player referred to them; empty string when they did not "
+                        "say which patient."
+                    ),
                 },
             },
-            ["diagnosis"],
+            ["diagnosis", "patient"],
         ),
     ]
 
@@ -429,23 +451,8 @@ def _recover_theory_from_history(
     return None
 
 
-def parse_final_diagnosis(
-    question: str,
-    open_cases: Optional[list[dict]] = None,
-    history: Optional[list[dict]] = None,
-) -> Optional[dict]:
-    """Deterministically parse an explicit final-diagnosis declaration.
-
-    Returns {"diagnosis": <clean text>, "case_id": <open case id or None>} or
-    None when the message is not an unmistakably final declaration. Never
-    consults the model: this feeds the recorded one-shot guess.
-    """
-    text = re.sub(r"\s+", " ", str(question or "")).strip()
-    if not text:
-        return None
-    # Normalise the contraction so the reverse frame can see the anaphor.
-    text = re.sub(r"^(?:that|this)'?s\b", "that is", text, flags=re.IGNORECASE)
-    index = _case_name_index(open_cases)
+def _parse_declaration(text: str, index: dict[str, int]) -> Optional[tuple[str, Optional[int]]]:
+    """Frame-match one candidate text. Returns (diagnosis, target); no anaphora."""
     target: Optional[int] = None
 
     # A leading "for <patient>," frame before the declaration itself.
@@ -466,22 +473,146 @@ def parse_final_diagnosis(
         return None
 
     diagnosis = diagnosis.strip(" \"'“”")
-    diagnosis, target = _strip_target_clauses(diagnosis, index, target)
+    # Interleave target and frame trims: either may expose the other
+    # ("… as final diagnosis for sash").
+    for _ in range(3):
+        before = diagnosis
+        diagnosis, target = _strip_target_clauses(diagnosis, index, target)
+        diagnosis = _trim_declaration_frame(diagnosis)
+        if diagnosis == before:
+            break
     diagnosis = re.sub(r"^(?:is|as)\s+", "", diagnosis, flags=re.IGNORECASE)
     diagnosis = diagnosis.strip(" \"'“”:,-")
+    return diagnosis, target
 
-    if not diagnosis or _ANAPHORIC_DIAGNOSIS_RE.match(diagnosis):
-        recovered = _recover_theory_from_history(history, open_cases)
-        if recovered is None:
-            return None
-        diagnosis = recovered["diagnosis"]
-        if target is None:
-            target = recovered["case_id"]
 
-    diagnosis = diagnosis[:200].strip()
+def _normalize_anaphor(text: str) -> str:
+    # Normalise the contraction so the reverse frame can see the anaphor.
+    return re.sub(r"^(?:that|this)'?s\b", "that is", text, flags=re.IGNORECASE)
+
+
+def parse_final_diagnosis(
+    question: str,
+    open_cases: Optional[list[dict]] = None,
+    history: Optional[list[dict]] = None,
+) -> Optional[dict]:
+    """Deterministically parse an explicit final-diagnosis declaration.
+
+    Returns {"diagnosis": <clean text>, "case_id": <open case id or None>} or
+    None when the message is not an unmistakably final declaration. Never
+    consults the model: this feeds the recorded one-shot guess. Multi-sentence
+    messages are handled per sentence ("I think sash has X. Submit that"), and
+    an anaphoric declaration recovers its antecedent first from the message's
+    own sentences, then from the player's recent history.
+    """
+    text = re.sub(r"\s+", " ", str(question or "")).strip()
+    if not text:
+        return None
+    index = _case_name_index(open_cases)
+
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()]
+    candidates = [_normalize_anaphor(text)]
+    if len(sentences) > 1:
+        candidates.extend(_normalize_anaphor(s) for s in sentences)
+
+    anaphoric_target: Optional[int] = None
+    saw_anaphoric = False
+    for candidate in candidates:
+        parsed = _parse_declaration(candidate, index)
+        if parsed is None:
+            continue
+        diagnosis, target = parsed
+        if diagnosis and not _ANAPHORIC_DIAGNOSIS_RE.match(diagnosis):
+            diagnosis = diagnosis[:200].strip()
+            if len(diagnosis) >= 2:
+                return {"diagnosis": diagnosis, "case_id": target}
+        elif not saw_anaphoric:
+            saw_anaphoric = True
+            anaphoric_target = target
+
+    if not saw_anaphoric:
+        return None
+
+    # Antecedent search: this message's other sentences first, then history
+    # (most recent last in the list — _recover walks it in reverse).
+    pool: list[dict] = list(history or [])
+    if len(sentences) > 1:
+        pool.extend({"role": "player", "text": s} for s in sentences)
+    recovered = _recover_theory_from_history(pool, open_cases)
+    if recovered is None:
+        return None
+    diagnosis = str(recovered["diagnosis"])[:200].strip()
     if len(diagnosis) < 2:
         return None
+    target = anaphoric_target if anaphoric_target is not None else recovered["case_id"]
     return {"diagnosis": diagnosis, "case_id": target}
+
+
+# Declaration vocabulary the recorded guess must never carry — trailing
+# ("… as my final diagnosis") or leading ("submit …") frames burnt real
+# correct answers by dragging fuzzy matches under the 0.75 threshold.
+_FRAME_EDGE_RES = (
+    re.compile(
+        r"\s+(?:as|is)?\s*(?:my\s+|the\s+)?(?:one\s+)?(?:official\s+|final\s+)+"
+        r"(?:diagnosis|answer|guess)\s*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"^\s*(?:please\s+)?(?:submit|record|lock\s+in|confirm)\s+",
+        re.IGNORECASE,
+    ),
+)
+
+
+def _trim_declaration_frame(diagnosis: str) -> str:
+    """Deterministically shave declaration vocabulary off a proposal's edges."""
+    text = re.sub(r"\s+", " ", str(diagnosis or "")).strip(" \"'“”")
+    for _ in range(3):
+        before = text
+        for pattern in _FRAME_EDGE_RES:
+            text = pattern.sub("", text).strip(" \"'“”:,-")
+        if text == before:
+            break
+    return text
+
+
+# Obvious questions must never arm the confirmation even if the model calls
+# the tool: "Could it be adrenal crisis?" is a theory, not a declaration.
+_TENTATIVE_QUESTION_RE = re.compile(
+    r"^\s*(?:could|can|might|may|would|is|isn'?t|was|what\s+about|do\s+you\s+think|"
+    r"any\s+chance)\b[^.!]*\?\s*$",
+    re.IGNORECASE,
+)
+
+
+def _grounded_in_player_text(
+    proposal: str, question: str, history: Optional[list[dict]],
+) -> bool:
+    """True when the proposal is a near-verbatim span of the player's own words.
+
+    The model may only quote the player back — never introduce a diagnosis the
+    player has not typed in this conversation. Fuzzy windows (>= 0.85)
+    tolerate punctuation and small typo drift, nothing more.
+    """
+    words = _query_text(proposal).split()
+    if not words:
+        return False
+    target = " ".join(words)
+    sources = [question]
+    for turn in reversed(history or []):
+        if isinstance(turn, dict) and turn.get("role") == "player":
+            sources.append(str(turn.get("text") or ""))
+    span = len(words)
+    for source in sources[:13]:
+        source_words = _query_text(source).split()
+        if not source_words:
+            continue
+        for size in {span, span + 1, max(1, span - 1)}:
+            for start in range(0, max(0, len(source_words) - size) + 1):
+                window = " ".join(source_words[start:start + size])
+                if SequenceMatcher(None, target, window).ratio() >= 0.85:
+                    return True
+    return False
 
 
 _UNSET = object()
@@ -597,6 +728,8 @@ def _execute_paws_tool(
     action_holder: dict[str, Any],
     question: str = "",
     parsed_final: Any = _UNSET,
+    open_cases: Optional[list[dict]] = None,
+    history: Optional[list[dict]] = None,
 ) -> dict[str, Any]:
     if name == "get_observations":
         if not _observations_requested(question):
@@ -618,37 +751,69 @@ def _execute_paws_tool(
         return {"examination": {system: examination[system]}}
 
     if name == "prepare_final_guess":
-        # Never trust the model-proposed tool argument as authority. The only
-        # permitted diagnosis is parsed directly from an unmistakably final
-        # raw player message (with any patient-target clause peeled off).
-        parsed = (
-            parse_final_diagnosis(question, [case])
-            if parsed_final is _UNSET
-            else parsed_final
-        )
         if contest_state.get("state") != "eligible":
             return {
                 "prepared": False,
                 "contest_state": contest_state.get("state", "unavailable"),
                 "reason": "The one-shot contest is not eligible for a new submission.",
             }
-        if not parsed:
+        # The model judges INTENT (so "submit that" or a bare answer works),
+        # but its proposal is only accepted when it quotes the player's own
+        # words back: an obvious question never arms, grounding blocks
+        # invention, and a deterministic frame/target trim keeps declaration
+        # vocabulary out of the recorded guess (polluted text burnt two real
+        # correct answers on 2026-07-14).
+        if _TENTATIVE_QUESTION_RE.match(str(question or "")):
             return {
                 "prepared": False,
-                "reason": "The player did not explicitly declare a final diagnosis.",
+                "reason": (
+                    "The player was asking a question, not declaring a final "
+                    "diagnosis. Coach them without confirming or denying."
+                ),
             }
+        cases = open_cases or [case]
+        index = _case_name_index(cases)
+        proposal = _trim_declaration_frame(str(arguments.get("diagnosis") or ""))
+        proposal, clause_target = _strip_target_clauses(proposal, index, None)
+        proposal = proposal.strip(" \"'“”:,-")
+        target = _match_case_token(str(arguments.get("patient") or ""), index)
+        if target is None:
+            target = clause_target
+
+        if len(proposal) < 2 or not _grounded_in_player_text(
+            proposal, question, history
+        ):
+            # Model proposal not grounded in the player's words: fall back to
+            # the deterministic declaration parser before giving up.
+            parsed = (
+                parse_final_diagnosis(question, cases, history)
+                if parsed_final is _UNSET
+                else parsed_final
+            )
+            if not parsed:
+                return {
+                    "prepared": False,
+                    "reason": (
+                        "That diagnosis is not something the player has typed in "
+                        "this conversation. Ask them to state their diagnosis in "
+                        "their own words."
+                    ),
+                }
+            proposal = parsed["diagnosis"]
+            if target is None:
+                target = parsed["case_id"]
+
+        if target is None:
+            pinned = case.get("id")
+            target = pinned if isinstance(pinned, int) and not isinstance(pinned, bool) else None
         action_holder["value"] = {
             "type": "confirm_diagnosis",
-            "diagnosis": parsed["diagnosis"],
-            **(
-                {"case_id": parsed["case_id"]}
-                if parsed.get("case_id") is not None
-                else {}
-            ),
+            "diagnosis": proposal[:200],
+            **({"case_id": target} if target is not None else {}),
         }
         return {
             "prepared": True,
-            "diagnosis": parsed["diagnosis"],
+            "diagnosis": proposal[:200],
             "instruction": "Ask the player to review and press the confirmation button.",
         }
 
@@ -706,7 +871,7 @@ async def run_ward_agent(
         def execute(name: str, arguments: dict[str, Any]):
             return _execute_paws_tool(
                 name, arguments, case, state, action_holder, question,
-                parsed_final,
+                parsed_final, open_cases, history,
             )
     else:
         raise ValueError(f"unsupported ward agent role: {role}")
@@ -753,12 +918,17 @@ async def run_ward_agent(
     if role == "clerk" and not action_holder.get("value"):
         state = contest_state or {"state": "unavailable"}
         if parsed_final and state.get("state") == "eligible":
+            fallback_target = parsed_final.get("case_id")
+            if fallback_target is None:
+                pinned = case.get("id")
+                if isinstance(pinned, int) and not isinstance(pinned, bool):
+                    fallback_target = pinned
             action_holder["value"] = {
                 "type": "confirm_diagnosis",
                 "diagnosis": parsed_final["diagnosis"],
                 **(
-                    {"case_id": parsed_final["case_id"]}
-                    if parsed_final.get("case_id") is not None
+                    {"case_id": fallback_target}
+                    if fallback_target is not None
                     else {}
                 ),
             }


### PR DESCRIPTION
Companion to MLAI-AUS-Inc/health-hack#20 (lock-in guidance + chip-default target). No wire-contract change — `suggested_action` keeps the same shape — so deploy order is free.

## The prod transcript this fixes (2026-07-14 ~01:52)

- "I think sash has Addisonian crisis. **submit that**" → canned deflection (regex reads only the leading frame)
- "addisonian crisis" (bare, after coaching) → leak-guard fallback "That's your call, doc…" — **twice, verbatim**
- "submit addisonian crisis as final diagnosis for sash" → armed, but recorded **"addisonian crisis as final diagnosis"** → 0.65 fuzzy → a correct answer marked incorrect (guess since cleared server-side)

## Architecture inversion: the model understands, determinism verifies

- `prepare_final_guess` gains a `patient` argument; **the model's judgment arms it** ("submit that", bare answers, restated theories — no phrasing gymnastics).
- Its proposal is accepted only when **grounded**: a ≥0.85 fuzzy window of the player's own words (current message or recent player history). The model can only quote the player back, never invent. The proposal is then deterministically trimmed of frame/target vocabulary.
- Obvious questions ("Could it be adrenal crisis?") never arm, even if the model calls the tool.
- The declaration regex demotes to a fallback arm-er, fixed for trailing frames ("… as final diagnosis") and same-message anaphora.

## AI-authored replies, oracle-free by construction

- The canned `clerk_tentative` / "I've written down…" / "book is closed" lines are gone; the prompt now carries those duties (coach with the exact template `submit <diagnosis> for <patient>`, never repeat the previous reply).
- Answer-independence rests on two properties that remain tested: the clerk model **never sees the hidden diagnosis**, and the output leakage guard scrubs hidden terms.
- **Leakage guard is now echo-aware**: terms the player already typed are exempt. Previously, scrubbing only-correct player-typed terms flipped the reply style exactly on right answers — itself a correctness oracle — and caused the repeated fallback line above.
- Confirm actions default their case target to the pinned case (single clean button in the game), and `check_guess` neutralizes trailing-frame pollution in stored strings.

## Tests

- Ward-game modules: **201 passed** — 6 new grounding/authorship tests (grounded+trimmed, invention blocked, history grounding, tentative-question gate, AI-authored theory reply, echo permitted) and 3 new parser regressions using the exact burnt strings.
- Full `roo/tests/`: green except `test_jobs_scheduler_trigger_uses_x_api_key` and `test_coworking_report_trends_…` — both **pre-existing failures on pristine origin/main** (verified by stash), unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
