### PR TITLE
Open contest case 3 (Jordo) in the default gateway allowlist

### DIFF
--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -95,11 +95,11 @@ class Settings(BaseSettings):
     # clients can never pick a case and farm tickets from cases not in play.
     SIM_ACTIVE_CASE_ID: int = 1
     # Contest cases the authenticated gateway may target (comma-separated
-    # cases.yaml ids). Two wards run concurrently, so the gateway forwards the
-    # player's chosen case; anything outside this set is refused so hidden or
-    # retired cases can never leak dialogue or verdicts. Mirrors MLAI
-    # Backend's HEALTH_HACK_OPEN_CASE_IDS default.
-    SIM_OPEN_CASE_IDS: str = "1,2"
+    # cases.yaml ids). Three wards run concurrently (Sash, Leila, Jordo), so
+    # the gateway forwards the player's chosen case; anything outside this set
+    # is refused so hidden or retired cases can never leak dialogue or
+    # verdicts. Mirrors MLAI Backend's HEALTH_HACK_OPEN_CASE_IDS default.
+    SIM_OPEN_CASE_IDS: str = "1,2,3"
 
     @property
     def sim_open_case_ids(self) -> frozenset[int]:

--- a/roo-standalone/roo/tests/test_diagnosis_check.py
+++ b/roo-standalone/roo/tests/test_diagnosis_check.py
@@ -181,11 +181,13 @@ def test_gateway_picks_an_open_case(monkeypatch):
 
 
 def test_hidden_case_is_refused_and_unrecorded(monkeypatch):
-    # Cases that exist in cases.yaml but are not open must 404 with nothing
-    # recorded — indistinguishable from ids that do not exist at all, so the
-    # endpoint never confirms which future cases are authored.
+    # Cases outside the *pinned* open set must 404 with nothing recorded —
+    # indistinguishable from ids that do not exist at all, so the endpoint
+    # never confirms which future cases are authored. Case 3 is open by
+    # DEFAULT now, so pinning "1,2" here also proves the allowlist beats both
+    # the default and yaml existence.
     calls = _install_recorder(monkeypatch, response={})
-    client = _client(monkeypatch, active_case=1)
+    client = _client(monkeypatch, active_case=1, open_cases="1,2")
 
     for hidden in (3, 7):
         resp = client.post("/api/diagnosis-check", json={
@@ -194,6 +196,33 @@ def test_hidden_case_is_refused_and_unrecorded(monkeypatch):
         assert resp.status_code == 404
         assert resp.json() == {"detail": "unknown case_id"}
     assert calls == []
+
+
+def test_case_3_adjudicates_under_the_default_open_set(monkeypatch):
+    # The shipped default opens the third ward. The guess below is case 1's
+    # CORRECT answer, so an "incorrect" verdict proves the matcher ran against
+    # case 3, and the record carries case 3's id/title.
+    assert config.Settings.model_fields["SIM_OPEN_CASE_IDS"].default == "1,2,3"
+
+    _install_llm_bomb(monkeypatch)
+    calls = _install_recorder(monkeypatch, response={
+        "already_guessed": False, "is_correct": False,
+        "outcome": "incorrect", "prize_kind": "none",
+        "is_first_solver": False, "winner_taken": False,
+    })
+    client = _client(monkeypatch, active_case=1, open_cases="1,2,3")
+
+    body = client.post("/api/diagnosis-check", json={
+        "guess": "adrenal crisis", "client_id": VALID_CLIENT, "case_id": 3,
+    }).json()
+
+    assert calls == [{
+        "case_id": 3, "case_title": "Keto Cut Catastrophe", "client_id": VALID_CLIENT,
+        "guess_text": "adrenal crisis", "is_correct": False,
+    }]
+    assert body["case_id"] == 3
+    assert body["result"] == "incorrect"
+    assert body["diagnosis"] is None
 
 
 def test_case_id_type_is_strict(monkeypatch):

--- a/roo-standalone/roo/tests/test_sim_patient.py
+++ b/roo-standalone/roo/tests/test_sim_patient.py
@@ -1257,9 +1257,10 @@ def test_endpoint_accepts_clerk_role_and_passes_contest_state(monkeypatch):
 
 
 def test_endpoint_honors_open_case_id(monkeypatch):
-    """Two wards run concurrently: the gateway's case_id is honored within
-    SIM_OPEN_CASE_IDS, absent keeps the active pin, and hidden or malformed
-    cases never reach the narrator."""
+    """The gateway's case_id is honored within SIM_OPEN_CASE_IDS, absent
+    keeps the active pin, and hidden or malformed cases never reach the
+    narrator. Pins "1,2" so case 3 doubles as the closed exemplar even though
+    the shipped default now opens it."""
     from fastapi.testclient import TestClient
     from roo import config
     from roo.main import app
@@ -1302,6 +1303,12 @@ def test_endpoint_honors_open_case_id(monkeypatch):
     assert client.post("/api/sim-patient", json={**base, "case_id": 3}).status_code == 404
     assert client.post("/api/sim-patient", json={**base, "case_id": "2"}).status_code == 422
     assert seen == {}  # refused requests never reached handle_question
+
+    # Under the shipped three-ward default, case 3 reaches the narrator.
+    monkeypatch.setattr(real, "SIM_OPEN_CASE_IDS", "1,2,3", raising=False)
+    resp = client.post("/api/sim-patient", json={**base, "case_id": 3})
+    assert resp.status_code == 200
+    assert seen["case_id"] == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part A of the third-patient rollout (roo → game → backend, game before backend this time — the deployed game's `projectContestStatus` requires the case set it renders, so the backend opens case 3 only after the game ships its three-book UI).

## Change
- `SIM_OPEN_CASE_IDS` default `"1,2"` → `"1,2,3"` (config.py). That's the single roo-side playability gate (`_validated_case_id`) — chat, adjudication, Paws tools, and case-name targeting all follow it.
- **No persona/prompt/endpoint work**: case 3 ("Keto Cut Catastrophe", Jordan "Jordo" Price) is already fully authored in `cases.yaml` — vibe, historian dial, disclosure rules, vitals/exam/investigations, acceptable answers, hints — and the per-case prompt system reads all of it.

## Why it's safe to deploy now
MLAI Backend's `HEALTH_HACK_OPEN_CASE_IDS` (still `1,2`) refuses case 3 before anything reaches roo, so this is inert for players until the paired backend rollout step.

## Tests
- Hidden-case boundary tests now pin `open_cases="1,2"` explicitly and keep case 3 as the closed exemplar — proving the allowlist beats both the shipped default and yaml existence.
- New: default pinned to `"1,2,3"`; case-3 guess adjudicated against case 3's matcher (case 1's correct answer judged incorrect) and recorded with case 3's id/title; narrator passthrough for case 3 under the default set.
- `test_diagnosis_check.py` + `test_sim_patient.py` + `test_ai_security.py`: **174 passed**. Full suite: 524 passed; the 4 failures (`test_points_requests` ×3, `test_jobs_scheduler` ×1) reproduce identically on clean main in my venv — pre-existing, untouched areas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)