### PR TITLE
Add HealthHack Slack announcements

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -2606,13 +2606,20 @@ class MLAIBackendClient:
             print(f"⚠️ MedHack get case history error: {e}")
             return []
 
-    async def medhack_create_announcement(self, title: str, body: str, slack_user_id: str) -> Optional[dict]:
+    async def medhack_create_announcement(
+        self,
+        title: str,
+        body: str,
+        requester_slack_id: str,
+        author_slack_id: Optional[str] = None,
+    ) -> Optional[dict]:
         """Create an announcement on the MedHack: Frontiers website.
 
         Args:
             title: Announcement title
             body: Announcement body text
-            slack_user_id: Slack ID of the user creating the announcement
+            requester_slack_id: Slack ID of the human requesting the announcement
+            author_slack_id: Optional Slack ID to display as the author
 
         Returns:
             Response dict on success (201), None on error
@@ -2624,7 +2631,8 @@ class MLAIBackendClient:
                 json={
                     "title": title,
                     "body": body,
-                    "slack_user_id": slack_user_id,
+                    "requester_slack_id": requester_slack_id,
+                    "author_slack_id": author_slack_id,
                 },
                 timeout=10.0,
                 circuit_breaker=True,
@@ -2634,6 +2642,43 @@ class MLAIBackendClient:
             return {"status_code": response.status_code, "detail": response.text}
         except Exception as e:
             print(f"⚠️ MedHack create announcement error: {e}")
+            return None
+
+    async def healthhack_create_announcement(
+        self,
+        *,
+        title: str,
+        body: str,
+        requester_slack_id: str,
+        author_slack_id: Optional[str],
+        source_channel_id: str,
+        source_message_ts: str,
+    ) -> Optional[dict]:
+        """Create one idempotent HealthHack app announcement via mlai-backend."""
+        try:
+            response = await self._request(
+                "POST",
+                "/api/v1/hackathons/hospital/announcements/",
+                json={
+                    "title": title,
+                    "body": body,
+                    "requester_slack_id": requester_slack_id,
+                    "author_slack_id": author_slack_id,
+                    "source_channel_id": source_channel_id,
+                    "source_message_ts": source_message_ts,
+                },
+                timeout=10.0,
+                circuit_breaker=True,
+            )
+            if response.status_code in (200, 201):
+                return response.json()
+            try:
+                detail = response.json().get("detail", response.text)
+            except ValueError:
+                detail = response.text
+            return {"status_code": response.status_code, "detail": detail}
+        except Exception as e:
+            print(f"⚠️ HealthHack create announcement error: {e}")
             return None
 
     async def generic_hackathon_create_announcement(

--- a/roo-standalone/roo/routing_eval/cases/paraphrases.yaml
+++ b/roo-standalone/roo/routing_eval/cases/paraphrases.yaml
@@ -299,6 +299,23 @@
   expect: {skill: medhack}
   tags: [paraphrase, channel]
 
+# --- healthhack announcements (exclusive to #healthhack) ---
+- id: para-healthhack-announce-doors
+  text: "announce that doors open at 10:30"
+  channel: healthhack
+  expect: {skill: healthhack, action: announce}
+  tags: [paraphrase, channel]
+- id: para-healthhack-publish-lunch
+  text: "publish an app announcement titled Lunch with body Pizza is upstairs"
+  channel: healthhack
+  expect: {skill: healthhack, action: announce}
+  tags: [paraphrase, channel]
+- id: para-healthhack-post-judging
+  text: "post this to the HealthHack app: judging starts at 5pm"
+  channel: healthhack
+  expect: {skill: healthhack, action: announce}
+  tags: [paraphrase, channel]
+
 # --- watt-the-hack (exclusive to #watt-the-hack) ---
 - id: para-watt-judging
   text: "announce that judging starts at 5pm"
@@ -378,6 +395,11 @@
   tags: [paraphrase, trap, action-trap]
 - id: trap-medhack-meeting
   text: "schedule a meeting with the medhack organisers"
+  channel: general
+  expect: {skill: none}
+  tags: [paraphrase, trap, negative, channel, misroute-guard]
+- id: trap-healthhack-announcement-wrong-channel
+  text: "post a HealthHack app announcement that lunch is ready"
   channel: general
   expect: {skill: none}
   tags: [paraphrase, trap, negative, channel, misroute-guard]

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -175,6 +175,16 @@ class SkillExecutor:
                 result = await self._execute_tone_of_voice(skill, text, params, user_id)
             elif skill.name == "medhack":
                 result = await self._execute_medhack(skill, text, params, user_id, channel_id, thread_ts, thread_history)
+            elif skill.name == "healthhack":
+                result = await self._execute_healthhack(
+                    skill,
+                    text,
+                    params,
+                    user_id,
+                    channel_id,
+                    thread_ts,
+                    kwargs.get("current_message_ts"),
+                )
             elif skill.name == "watt-the-hack":
                 result = await self._execute_watt_the_hack(skill, text, params, user_id, channel_id, thread_ts, thread_history)
             elif skill.name == "luma-events":
@@ -997,6 +1007,134 @@ JSON:"""
         # Success — the framework posts this confirmation back in-thread.
         return f"Announcement *\"{ann_title}\"* has been posted to the Watt The Hack website."
 
+    async def _execute_healthhack(
+        self,
+        skill: Skill,
+        text: str,
+        params: dict,
+        user_id: str,
+        channel_id: Optional[str] = None,
+        thread_ts: Optional[str] = None,
+        current_message_ts: Optional[str] = None,
+    ) -> str:
+        """Publish an announcement from #healthhack to the participant app."""
+        import json
+        import re
+
+        if skill.exclusive_channels:
+            from ..slack_client import get_channel_name
+
+            channel_name = get_channel_name(channel_id) if channel_id else None
+            if channel_name not in skill.exclusive_channels:
+                return "The HealthHack announcement skill is only available in #*healthhack*."
+
+        ann_title = str(params.get("title") or "").strip() or None
+        ann_body = str(params.get("body") or "").strip() or None
+
+        if not ann_title or not ann_body:
+            extract_prompt = f"""Extract the announcement title and body from this message.
+The user wants to publish an announcement to the HealthHack participant app.
+
+User message: "{text}"
+
+Return ONLY valid JSON with two keys: "title" and "body".
+If you cannot determine a clear title or body, set the missing field to null.
+
+Example: {{"title": "Lunch is served", "body": "Pizza is in the atrium at 1pm."}}
+
+JSON:"""
+            openai_client = get_llm_client("openai")
+            extract_response = await openai_client.chat(
+                [
+                    {
+                        "role": "system",
+                        "content": "You extract structured data from text. Return valid JSON only.",
+                    },
+                    {"role": "user", "content": extract_prompt},
+                ],
+                model="gpt-4o-mini",
+                max_tokens=1024,
+            )
+
+            try:
+                content = extract_response.content.strip()
+                if content.startswith("```"):
+                    content = re.sub(r'^```\w*\n?', '', content)
+                    content = re.sub(r'\n?```$', '', content)
+                extracted = json.loads(content)
+            except (json.JSONDecodeError, TypeError, AttributeError):
+                extracted = {}
+
+            ann_title = ann_title or extracted.get("title")
+            ann_body = ann_body or extracted.get("body")
+
+        if not ann_title or not ann_body:
+            return (
+                f"<@{user_id}> I need both a *title* and *body* for the announcement. "
+                "Try: _\"Post an announcement titled 'Lunch is served' with body "
+                "'Pizza is in the atrium at 1pm.'\"_"
+            )
+
+        if not channel_id or not current_message_ts:
+            return (
+                f"<@{user_id}> I couldn't identify the source Slack message, so I didn't "
+                "publish the announcement. Please try again in #healthhack."
+            )
+
+        return await self._publish_healthhack_announcement(
+            user_id=user_id,
+            ann_title=str(ann_title).strip(),
+            ann_body=str(ann_body).strip(),
+            channel_id=channel_id,
+            source_message_ts=current_message_ts,
+        )
+
+    async def _publish_healthhack_announcement(
+        self,
+        *,
+        user_id: str,
+        ann_title: str,
+        ann_body: str,
+        channel_id: str,
+        source_message_ts: str,
+    ) -> str:
+        """Persist one backend-authorised HealthHack announcement."""
+        from ..clients.mlai_backend import MLAIBackendClient
+        from ..slack_client import get_bot_user_id
+
+        backend = MLAIBackendClient()
+        result = await backend.healthhack_create_announcement(
+            title=ann_title,
+            body=ann_body,
+            requester_slack_id=user_id,
+            author_slack_id=get_bot_user_id(),
+            source_channel_id=channel_id,
+            source_message_ts=source_message_ts,
+        )
+
+        if result is None:
+            return f"<@{user_id}> Something went wrong creating the announcement. Please try again later."
+
+        status_code = result.get("status_code")
+        if status_code == 400:
+            return f"<@{user_id}> The announcement couldn't be created — {result.get('detail', 'something is missing')}."
+        if status_code == 409:
+            return (
+                f"<@{user_id}> That Slack message is already linked to a different "
+                "HealthHack announcement, so I didn't overwrite it."
+            )
+        if status_code in (401, 403):
+            return (
+                f"<@{user_id}> Sorry, only authorised HealthHack organisers can "
+                "publish announcements to the participant app."
+            )
+        if status_code is not None:
+            return f"<@{user_id}> Unexpected error (HTTP {status_code}): {result.get('detail', 'unknown')}"
+
+        if result.get("created") is False:
+            return f"Announcement *\"{ann_title}\"* was already posted to the HealthHack app."
+        return f"Announcement *\"{ann_title}\"* has been posted to the HealthHack app."
+
     async def _execute_medhack(
         self,
         skill: Skill,
@@ -1198,7 +1336,12 @@ JSON:"""
             from ..slack_client import get_bot_user_id
             backend = MLAIBackendClient()
             bot_id = get_bot_user_id()
-            result = await backend.medhack_create_announcement(ann_title, ann_body, bot_id or user_id)
+            result = await backend.medhack_create_announcement(
+                ann_title,
+                ann_body,
+                requester_slack_id=user_id,
+                author_slack_id=bot_id or user_id,
+            )
 
             if result is None:
                 return f"<@{user_id}> Something went wrong creating the announcement. Please try again later."

--- a/roo-standalone/roo/tests/test_healthhack_announcements.py
+++ b/roo-standalone/roo/tests/test_healthhack_announcements.py
@@ -1,0 +1,173 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.modules.setdefault("frontmatter", SimpleNamespace(load=lambda *args, **kwargs: None))
+
+from roo.clients.mlai_backend import MLAIBackendClient
+from roo.skills.executor import SkillExecutor
+from roo.skills.loader import Skill
+
+
+@pytest.fixture(autouse=True)
+def backend_settings(monkeypatch):
+    monkeypatch.setattr(
+        "roo.clients.mlai_backend.get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            ROO_API_KEY="test-roo-key",
+            MLAI_API_KEY=None,
+            INTERNAL_API_KEY="test-internal-key",
+        ),
+    )
+
+
+def healthhack_skill():
+    return Skill(
+        name="healthhack",
+        description="HealthHack announcements",
+        content="",
+        path=Path("."),
+        exclusive_channels=["healthhack"],
+        actions=[
+            {
+                "name": "announce",
+                "description": "Publish an announcement.",
+                "params": {
+                    "title": {"type": "string"},
+                    "body": {"type": "string"},
+                },
+            }
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_healthhack_executor_publishes_structured_announcement(monkeypatch):
+    captured = {}
+
+    async def fake_create(self, **kwargs):
+        captured.update(kwargs)
+        return {"id": "announcement-1", "created": True}
+
+    monkeypatch.setattr(MLAIBackendClient, "healthhack_create_announcement", fake_create)
+    monkeypatch.setattr("roo.slack_client.get_channel_name", lambda channel_id: "healthhack")
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "U0ROO00000")
+
+    result = await SkillExecutor()._execute_healthhack(
+        healthhack_skill(),
+        "post the announcement",
+        {"action": "announce", "title": "Doors open", "body": "Come upstairs."},
+        "U0SUPER123",
+        "C0BHZ9NS21L",
+        "1784286514.495879",
+        "1784286520.123456",
+    )
+
+    assert result == 'Announcement *"Doors open"* has been posted to the HealthHack app.'
+    assert captured == {
+        "title": "Doors open",
+        "body": "Come upstairs.",
+        "requester_slack_id": "U0SUPER123",
+        "author_slack_id": "U0ROO00000",
+        "source_channel_id": "C0BHZ9NS21L",
+        "source_message_ts": "1784286520.123456",
+    }
+
+
+@pytest.mark.asyncio
+async def test_healthhack_executor_reports_idempotent_replay(monkeypatch):
+    async def fake_create(self, **kwargs):
+        return {"id": "announcement-1", "created": False}
+
+    monkeypatch.setattr(MLAIBackendClient, "healthhack_create_announcement", fake_create)
+    monkeypatch.setattr("roo.slack_client.get_channel_name", lambda channel_id: "healthhack")
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "U0ROO00000")
+
+    result = await SkillExecutor()._execute_healthhack(
+        healthhack_skill(),
+        "post the announcement",
+        {"action": "announce", "title": "Doors open", "body": "Come upstairs."},
+        "U0SUPER123",
+        "C0BHZ9NS21L",
+        None,
+        "1784286520.123456",
+    )
+
+    assert result == 'Announcement *"Doors open"* was already posted to the HealthHack app.'
+
+
+@pytest.mark.asyncio
+async def test_healthhack_executor_relays_backend_authorisation(monkeypatch):
+    async def fake_create(self, **kwargs):
+        return {"status_code": 403, "detail": "forbidden"}
+
+    monkeypatch.setattr(MLAIBackendClient, "healthhack_create_announcement", fake_create)
+    monkeypatch.setattr("roo.slack_client.get_channel_name", lambda channel_id: "healthhack")
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "U0ROO00000")
+
+    result = await SkillExecutor()._execute_healthhack(
+        healthhack_skill(),
+        "post the announcement",
+        {"action": "announce", "title": "Doors open", "body": "Come upstairs."},
+        "U0PART1234",
+        "C0BHZ9NS21L",
+        None,
+        "1784286520.123456",
+    )
+
+    assert "only authorised HealthHack organisers" in result
+
+
+@pytest.mark.asyncio
+async def test_healthhack_executor_rejects_wrong_channel(monkeypatch):
+    monkeypatch.setattr("roo.slack_client.get_channel_name", lambda channel_id: "general")
+
+    result = await SkillExecutor()._execute_healthhack(
+        healthhack_skill(),
+        "post the announcement",
+        {"action": "announce", "title": "Doors open", "body": "Come upstairs."},
+        "U0SUPER123",
+        "CGENERAL123",
+        None,
+        "1784286520.123456",
+    )
+
+    assert result == "The HealthHack announcement skill is only available in #*healthhack*."
+
+
+@pytest.mark.asyncio
+async def test_healthhack_executor_fails_closed_when_channel_cannot_be_resolved(monkeypatch):
+    monkeypatch.setattr("roo.slack_client.get_channel_name", lambda channel_id: None)
+
+    result = await SkillExecutor()._execute_healthhack(
+        healthhack_skill(),
+        "post the announcement",
+        {"action": "announce", "title": "Doors open", "body": "Come upstairs."},
+        "U0SUPER123",
+        "CUNKNOWN123",
+        None,
+        "1784286520.123456",
+    )
+
+    assert result == "The HealthHack announcement skill is only available in #*healthhack*."
+
+
+@pytest.mark.asyncio
+async def test_healthhack_executor_requires_source_message_provenance(monkeypatch):
+    monkeypatch.setattr("roo.slack_client.get_channel_name", lambda channel_id: "healthhack")
+
+    result = await SkillExecutor()._execute_healthhack(
+        healthhack_skill(),
+        "post the announcement",
+        {"action": "announce", "title": "Doors open", "body": "Come upstairs."},
+        "U0SUPER123",
+        "C0BHZ9NS21L",
+        None,
+        None,
+    )
+
+    assert "couldn't identify the source Slack message" in result

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -257,6 +257,52 @@ async def test_query_data_uses_canonical_endpoint_and_payload(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_healthhack_announcement_uses_canonical_endpoint_and_provenance(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured["method"] = method
+        captured["endpoint"] = endpoint
+        captured["json"] = kwargs["json"]
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(
+            201,
+            request=request,
+            json={"id": "announcement-1", "created": True},
+        )
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.healthhack_create_announcement(
+        title="Doors open",
+        body="Registration opens at 10:30am.",
+        requester_slack_id="U0SUPER123",
+        author_slack_id="U0ROO00000",
+        source_channel_id="C0BHZ9NS21L",
+        source_message_ts="1784286514.495879",
+    )
+
+    assert result == {"id": "announcement-1", "created": True}
+    assert captured == {
+        "method": "POST",
+        "endpoint": "/api/v1/hackathons/hospital/announcements/",
+        "json": {
+            "title": "Doors open",
+            "body": "Registration opens at 10:30am.",
+            "requester_slack_id": "U0SUPER123",
+            "author_slack_id": "U0ROO00000",
+            "source_channel_id": "C0BHZ9NS21L",
+            "source_message_ts": "1784286514.495879",
+        },
+    }
+
+
+@pytest.mark.asyncio
 async def test_create_points_purchase_sends_slack_origin(monkeypatch):
     captured = {}
 

--- a/roo-standalone/roo/tests/test_router_v2.py
+++ b/roo-standalone/roo/tests/test_router_v2.py
@@ -36,23 +36,44 @@ POINTS = _skill(
     ],
 )
 MEDHACK = _skill("medhack", exclusive=["medhack-frontiers"])
+HEALTHHACK = _skill(
+    "healthhack",
+    exclusive=["healthhack"],
+    actions=[
+        {
+            "name": "announce",
+            "description": "Publish an announcement.",
+            "params": {
+                "title": {"type": "string"},
+                "body": {"type": "string"},
+            },
+        }
+    ],
+)
 
 
 def test_build_tools_filters_exclusive_channels_and_always_offers_chat():
-    tools, by_name = router.build_tools([POINTS, MEDHACK], channel_name="general")
+    tools, by_name = router.build_tools([POINTS, MEDHACK, HEALTHHACK], channel_name="general")
     names = [tool["function"]["name"] for tool in tools]
     assert "mlai-points" in names
     assert "medhack" not in names
+    assert "healthhack" not in names
     assert router.RESPOND_IN_CHAT in names
     assert router.ASK_CLARIFICATION in names
     assert "medhack" not in by_name
 
-    tools, by_name = router.build_tools([POINTS, MEDHACK], channel_name="medhack-frontiers")
+    tools, by_name = router.build_tools([POINTS, MEDHACK, HEALTHHACK], channel_name="medhack-frontiers")
     assert "medhack" in [tool["function"]["name"] for tool in tools]
+    assert "healthhack" not in [tool["function"]["name"] for tool in tools]
+
+    tools, by_name = router.build_tools([POINTS, MEDHACK, HEALTHHACK], channel_name="healthhack")
+    assert "healthhack" in [tool["function"]["name"] for tool in tools]
+    assert "medhack" not in [tool["function"]["name"] for tool in tools]
 
     # unknown channel mirrors the executor rule: allowed through
-    tools, _ = router.build_tools([POINTS, MEDHACK], channel_name=None)
+    tools, _ = router.build_tools([POINTS, MEDHACK, HEALTHHACK], channel_name=None)
     assert "medhack" in [tool["function"]["name"] for tool in tools]
+    assert "healthhack" in [tool["function"]["name"] for tool in tools]
 
 
 def test_skill_tool_embeds_routing_block_and_action_enum():

--- a/roo-standalone/skills/healthhack/SKILL.md
+++ b/roo-standalone/skills/healthhack/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: healthhack
+description: Let authorised HealthHack organisers publish announcements from the #healthhack Slack channel to the HealthHack participant app.
+priority_channels:
+  - healthhack
+exclusive_channels:
+  - healthhack
+routing:
+  use_when: >
+    In #healthhack only: an organiser asks Roo to make, create, post, or publish
+    an announcement to the HealthHack participant app.
+  avoid_when: >
+    Any other channel. Rewriting announcement copy without publishing it
+    (tone-of-voice), general HealthHack questions, or requests to message event
+    attendees outside the HealthHack app.
+  examples:
+    - {text: "announce that doors open at 10:30", action: announce}
+    - {text: "post an announcement titled Lunch with body Pizza is in the atrium", action: announce}
+    - {text: "publish this to the HealthHack app: judging starts at 5pm", action: announce}
+  negative_examples:
+    - {text: "rewrite this announcement in our tone of voice", instead: tone-of-voice}
+    - {text: "what time does HealthHack start?", instead: respond_in_chat}
+    - {text: "email this to everyone going", instead: respond_in_chat}
+actions:
+  - name: announce
+    description: Publish an announcement to the HealthHack participant app (authorised organisers only).
+    params:
+      title: {type: string}
+      body: {type: string}
+---
+
+# HealthHack announcements
+
+Use this skill only in `#healthhack` when an organiser asks Roo to publish an
+announcement to the HealthHack participant app.
+
+- Extract a clear **title** and **body** from the request.
+- If either is missing, ask the organiser to provide it.
+- The backend verifies the requesting human's permissions. Roo must not rely on
+  a local list of admin Slack IDs.
+- Attribute the visible announcement author to Roo while retaining the human
+  requester and source Slack message for auditability.
+- On success, confirm once in the originating Slack thread.
+- This skill publishes only to the HealthHack app. It does not send email, SMS,
+  push notifications, Luma blasts, or other attendee communications.
+
+Example:
+
+`@Roo post an announcement titled "Lunch is served" with body "Pizza is in the atrium at 1pm."`


### PR DESCRIPTION
## Summary

- add a dedicated Roo skill restricted to #healthhack
- publish app announcements through the canonical backend endpoint
- retain Slack provenance and handle retries safely
- add routing, client, and executor coverage

## Validation

- 32 targeted Roo tests passed
- Python compilation and diff checks passed

Luma attendee blasts are intentionally excluded.