### PR TITLE
Add private Stripe buttons for Roo top-ups

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,6 +149,9 @@ jobs:
             upsert_env "VICTOR_AI_ROO_SIGNING_SECRET" "$VICTOR_AI_ROO_SIGNING_SECRET"
             upsert_env "VICTOR_AI_SKILL_ENABLED" "true"
             upsert_env "VICTOR_AI_SLACK_CHANNEL_NAME" "exp-victor-ai"
+            upsert_env "ROO_POINTS_TOPUP_ENABLED" "true"
+            upsert_env "ROO_POINTS_TOPUP_BUTTONS_ENABLED" "true"
+            upsert_env "ROO_POINTS_STRIPE_CHECKOUT_HOSTS" "checkout.stripe.com"
             
             # Restart the app
             docker compose up -d --build --remove-orphans

--- a/roo-standalone/.env.example
+++ b/roo-standalone/.env.example
@@ -67,6 +67,9 @@ LINEAR_CONTEXT_MAX_CHARS=16000
 LINEAR_CONTEXTUAL_AUTO_CREATE_ENABLED=true
 COWORKING_INTENTS_DB_PATH=data/coworking_booking_intents.db
 COWORKING_RETRY_POLL_SECONDS=30
+ROO_POINTS_TOPUP_ENABLED=false
+ROO_POINTS_TOPUP_BUTTONS_ENABLED=false
+ROO_POINTS_STRIPE_CHECKOUT_HOSTS=checkout.stripe.com
 
 # Daily jobs scheduler
 # Recommended production setup: keep this disabled in Roo and let

--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -2417,6 +2417,33 @@ class MLAIBackendClient:
         self._raise_for_status_or_backend_unavailable(response)
         return response.json()
 
+    async def create_points_checkout_options(
+        self,
+        slack_user_id: str,
+        *,
+        checkout_request_id: str,
+        pack_ids: Optional[list[str]] = None,
+        purchase_from: Optional[dict] = None,
+    ) -> dict:
+        """Create idempotent Stripe-hosted checkout options for Roo in Slack."""
+        payload = {
+            "slack_user_id": self._clean_slack_id(slack_user_id),
+            "checkout_request_id": str(checkout_request_id or "").strip(),
+            "purchase_from": {"source": "slack", **(purchase_from or {})},
+        }
+        if pack_ids is not None:
+            payload["pack_ids"] = list(pack_ids)
+
+        response = await self._request(
+            "POST",
+            f"{self._points_base}/purchases/checkout-options/",
+            json=payload,
+            timeout=30.0,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
     async def attach_points_request_slack_summary(
         self,
         request_id: int,

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -96,6 +96,8 @@ class Settings(BaseSettings):
     COWORKING_INTENTS_DB_PATH: str = "data/coworking_booking_intents.db"
     COWORKING_RETRY_POLL_SECONDS: float = 30.0
     ROO_POINTS_TOPUP_ENABLED: bool = False
+    ROO_POINTS_TOPUP_BUTTONS_ENABLED: bool = False
+    ROO_POINTS_STRIPE_CHECKOUT_HOSTS: str = "checkout.stripe.com"
     BOOST_LINK_LOVE_ENABLED: bool = True
     BOOST_LINK_LOVE_CHANNEL_NAME: str = "boost-my-startup"
     BOOST_LINK_LOVE_DB_PATH: str = "data/link_love_awards.db"
@@ -161,6 +163,15 @@ class Settings(BaseSettings):
         return self._split_configured_values(self.ROO_IMPLICIT_ACTION_ALLOWLIST)
 
     @property
+    def roo_points_stripe_checkout_hosts(self) -> frozenset[str]:
+        return frozenset(
+            value.lower()
+            for value in self._split_configured_values(
+                self.ROO_POINTS_STRIPE_CHECKOUT_HOSTS
+            )
+        )
+
+    @property
     def victor_ai_slack_channel_name(self) -> str:
         return str(self.VICTOR_AI_SLACK_CHANNEL_NAME or "").strip().lstrip("#").lower()
 
@@ -200,6 +211,13 @@ class Settings(BaseSettings):
         if self.ROO_CONTEXTUAL_RESPONSES_ENABLED and not self.contextual_channel_ids:
             raise ValueError(
                 "Contextual Roo responses require ROO_CONTEXTUAL_CHANNEL_IDS"
+            )
+        if (
+            self.ROO_POINTS_TOPUP_BUTTONS_ENABLED
+            and not self.roo_points_stripe_checkout_hosts
+        ):
+            raise ValueError(
+                "ROO_POINTS_STRIPE_CHECKOUT_HOSTS is required when top-up buttons are enabled"
             )
         if self.VICTOR_AI_SKILL_ENABLED:
             if not str(self.MLAI_BACKEND_URL or "").strip():

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -12,6 +12,7 @@ import json
 import re
 import asyncio
 import calendar
+from urllib.parse import urlsplit
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
 from typing import Any, Optional, List
@@ -52,7 +53,13 @@ from ..points_request_approval import (
     build_points_request_record,
     remember_points_request_summary,
 )
-from ..slack_client import get_channel_id, get_channel_name, post_message, upload_file
+from ..slack_client import (
+    get_channel_id,
+    get_channel_name,
+    post_ephemeral,
+    post_message,
+    upload_file,
+)
 from ..config import get_settings
 from ..clients.mlai_backend import MLAIBackendClient, MLAIBackendUnavailableError
 from ..coworking_booking_intents import (
@@ -165,7 +172,18 @@ class SkillExecutor:
             elif skill.name == "connect-users":
                 result = await self._execute_connect_users(skill, text, params, user_id)
             elif skill.name == "mlai-points":
-                result = await self._execute_mlai_points(skill, text, params, user_id, channel_id, thread_ts)
+                result = await self._execute_mlai_points(
+                    skill,
+                    text,
+                    params,
+                    user_id,
+                    channel_id,
+                    thread_ts,
+                    request_id=(
+                        kwargs.get("event_id")
+                        or kwargs.get("current_message_ts")
+                    ),
+                )
             elif skill.name == "mlai-data-query":
                 result = await self._execute_mlai_data_query(skill, text, params, user_id)
             elif skill.name == "github-integration":
@@ -8139,7 +8157,8 @@ Chunk {index} source: {label}
         params: dict,
         user_id: str,
         channel_id: Optional[str],
-        thread_ts: Optional[str]
+        thread_ts: Optional[str],
+        request_id: Optional[str] = None,
     ) -> Any:
         """Execute the MLAI Points skill."""
         import httpx
@@ -8175,15 +8194,20 @@ Chunk {index} source: {label}
                 )
 
             # Execute the appropriate action
+            handle_kwargs = {
+                "client": client,
+                "action": action,
+                "params": params,
+                "text": text,
+                "user_id": user_id,
+                "channel_id": channel_id,
+                "thread_ts": thread_ts,
+                "skill": skill,
+            }
+            if request_id:
+                handle_kwargs["request_id"] = request_id
             return await self._handle_points_action(
-                client=client,
-                action=action,
-                params=params,
-                text=text,
-                user_id=user_id,
-                channel_id=channel_id,
-                thread_ts=thread_ts,
-                skill=skill
+                **handle_kwargs
             )
             
         except MLAIBackendUnavailableError:
@@ -8294,6 +8318,161 @@ Chunk {index} source: {label}
             "Top-up Roo Points are optional and do not count toward lifetime earned contribution."
         )
         return "\n".join(lines)
+
+    def _trusted_topup_checkout_options(
+        self,
+        raw_options: Any,
+        *,
+        settings: Any,
+    ) -> list[dict[str, Any]]:
+        """Return sanitized Stripe Checkout options safe to embed in Slack."""
+        allowed_hosts = set(
+            getattr(settings, "roo_points_stripe_checkout_hosts", set()) or set()
+        )
+        trusted = []
+        for raw_option in raw_options if isinstance(raw_options, list) else []:
+            if not isinstance(raw_option, dict):
+                continue
+            checkout_url = str(raw_option.get("checkout_session_url") or "").strip()
+            parsed = urlsplit(checkout_url)
+            try:
+                checkout_port = parsed.port
+            except ValueError:
+                checkout_port = -1
+            if (
+                parsed.scheme != "https"
+                or not parsed.hostname
+                or parsed.hostname.lower() not in allowed_hosts
+                or parsed.username
+                or parsed.password
+                or checkout_port not in {None, 443}
+            ):
+                print(
+                    "ROO_TOPUP_UNTRUSTED_CHECKOUT_URL "
+                    f"pack_id={raw_option.get('pack_id')}"
+                )
+                continue
+            try:
+                points = int(raw_option.get("points_amount"))
+                amount_cents = int(raw_option.get("amount_cents"))
+            except (TypeError, ValueError):
+                continue
+            if points <= 0 or amount_cents <= 0:
+                continue
+            currency = str(raw_option.get("currency") or "aud").strip().lower()
+            pack_id = str(raw_option.get("pack_id") or "").strip()
+            if not pack_id:
+                continue
+            trusted.append(
+                {
+                    "pack_id": pack_id,
+                    "points": points,
+                    "amount_cents": amount_cents,
+                    "currency": currency,
+                    "checkout_url": checkout_url,
+                    "expires_at": str(raw_option.get("expires_at") or "").strip(),
+                }
+            )
+        return trusted
+
+    @staticmethod
+    def _topup_price_label(amount_cents: int, currency: str) -> str:
+        amount = amount_cents / 100
+        if currency.lower() == "aud":
+            return f"A${amount:.2f}"
+        return f"{currency.upper()} {amount:.2f}"
+
+    def _topup_checkout_button_response(
+        self,
+        *,
+        options: list[dict[str, Any]],
+        user_id: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+        had_partial_errors: bool,
+    ) -> dict:
+        singular = len(options) == 1
+        message = (
+            "Your Top-up Roo Points checkout is ready. Use the private Stripe "
+            "Checkout button below."
+            if singular
+            else "Choose a Top-up Roo Points pack using one of the private Stripe Checkout buttons."
+        )
+        if had_partial_errors:
+            message += " Some checkout options are temporarily unavailable."
+        message += (
+            "\n\nTop-up Roo Points are optional MLAI community reward points. "
+            "They are not money, have no cash value, cannot be converted to cash, "
+            "and do not count toward lifetime earned contribution."
+        )
+
+        buttons = []
+        for option in options:
+            price = self._topup_price_label(
+                option["amount_cents"],
+                option["currency"],
+            )
+            button = {
+                "type": "button",
+                "text": {
+                    "type": "plain_text",
+                    "text": f"{option['points']} points · {price}",
+                    "emoji": True,
+                },
+                "url": option["checkout_url"],
+                "action_id": f"roo_topup_checkout_{option['pack_id']}",
+            }
+            if option["pack_id"] == "topup_10":
+                button["style"] = "primary"
+            buttons.append(button)
+
+        blocks = [
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": message},
+            },
+            {"type": "actions", "elements": buttons},
+            {
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": (
+                            "Stripe will ask you to accept the Roo Points terms "
+                            "before payment. Checkout links expire within 24 hours."
+                        ),
+                    }
+                ],
+            },
+        ]
+        response_data = {
+            "action": "topup_points",
+            "delivery": (
+                "direct_message"
+                if channel_id and channel_id.startswith("D")
+                else "ephemeral"
+            ),
+            "pack_ids": [option["pack_id"] for option in options],
+            "partial": had_partial_errors,
+        }
+        if channel_id and not channel_id.startswith("D"):
+            post_ephemeral(
+                channel=channel_id,
+                user=user_id,
+                text=message,
+                thread_ts=thread_ts,
+                blocks=blocks,
+            )
+            return {
+                "message": "",
+                "data": response_data,
+                "suppress_post": True,
+            }
+        return {
+            "message": message,
+            "blocks": blocks,
+            "data": response_data,
+        }
 
     def _normalize_points_routing_text(self, text: str) -> str:
         """Normalize common Slack typo variants before deterministic routing."""
@@ -9862,7 +10041,8 @@ Chunk {index} source: {label}
         user_id: str,
         channel_id: Optional[str],
         thread_ts: Optional[str],
-        skill
+        skill,
+        request_id: Optional[str] = None,
     ) -> Any:
         """Handle individual points actions."""
         
@@ -9876,6 +10056,45 @@ Chunk {index} source: {label}
                 return "Top-up checkout is not enabled yet. Ask the MLAI team to finish enabling Stripe top-ups first."
 
             pack_id, unsupported_amount = self._resolve_topup_pack_id(text, params)
+            if getattr(settings, "ROO_POINTS_TOPUP_BUTTONS_ENABLED", False):
+                purchase_from = {"source": "slack"}
+                if channel_id:
+                    purchase_from["slack_channel_id"] = channel_id
+                if thread_ts:
+                    purchase_from["slack_thread_ts"] = thread_ts
+                checkout_request_id = str(
+                    request_id or f"roo-topup-{uuid4().hex}"
+                ).strip()
+                requested_pack_ids = [pack_id] if pack_id else None
+                try:
+                    checkout_payload = await client.create_points_checkout_options(
+                        slack_user_id=user_id,
+                        checkout_request_id=checkout_request_id,
+                        pack_ids=requested_pack_ids,
+                        purchase_from=purchase_from,
+                    )
+                except httpx.HTTPStatusError as exc:
+                    error_detail = self._extract_http_error_detail(exc)
+                    detail = f" {error_detail}" if error_detail else ""
+                    return f"I couldn't create the Stripe top-up buttons yet.{detail}"
+
+                options = self._trusted_topup_checkout_options(
+                    checkout_payload.get("options"),
+                    settings=settings,
+                )
+                if not options:
+                    return (
+                        "I couldn't create trusted Stripe Checkout links for those "
+                        "top-up packs. Please try again shortly."
+                    )
+                return self._topup_checkout_button_response(
+                    options=options,
+                    user_id=user_id,
+                    channel_id=channel_id,
+                    thread_ts=thread_ts,
+                    had_partial_errors=bool(checkout_payload.get("errors")),
+                )
+
             if not pack_id:
                 if unsupported_amount is None:
                     return self._topup_pack_list_message()

--- a/roo-standalone/roo/slack_client.py
+++ b/roo-standalone/roo/slack_client.py
@@ -90,6 +90,37 @@ def post_message(
         raise
 
 
+def post_ephemeral(
+    channel: str,
+    user: str,
+    text: str,
+    thread_ts: Optional[str] = None,
+    **kwargs,
+) -> Dict[str, Any]:
+    """Post a private message visible only to one member in a Slack channel."""
+    client = get_slack_client()
+
+    try:
+        response = client.chat_postEphemeral(
+            channel=channel,
+            user=user,
+            text=text,
+            thread_ts=thread_ts,
+            **kwargs,
+        )
+        if response.get("ok"):
+            print(f"✅ Private message posted in {channel} for {user}")
+        else:
+            print(
+                "❌ Failed to post private message: "
+                f"error={response.get('error', 'unknown')}"
+            )
+        return response
+    except Exception as exc:
+        print(f"❌ Slack private post error: error_type={exc.__class__.__name__}")
+        raise
+
+
 def upload_file(
     channel: str,
     content: str,

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -92,6 +92,70 @@ class FakeTopupPurchaseClient:
         return self.response
 
 
+class FakeTopupButtonsClient:
+    def __init__(self, response=None):
+        self.created = None
+        self.response = response or {
+            "checkout_request_id": "EvTopup123",
+            "options": [
+                {
+                    "pack_id": "topup_5",
+                    "points_amount": 10,
+                    "amount_cents": 1999,
+                    "currency": "aud",
+                    "expires_at": "2026-07-28T10:00:00Z",
+                    "checkout_session_url": (
+                        "https://checkout.stripe.com/c/pay/cs_test_topup_5#checkout"
+                    ),
+                },
+                {
+                    "pack_id": "topup_10",
+                    "points_amount": 20,
+                    "amount_cents": 3699,
+                    "currency": "aud",
+                    "expires_at": "2026-07-28T10:00:00Z",
+                    "checkout_session_url": (
+                        "https://checkout.stripe.com/c/pay/cs_test_topup_10"
+                    ),
+                },
+                {
+                    "pack_id": "topup_25",
+                    "points_amount": 50,
+                    "amount_cents": 6399,
+                    "currency": "aud",
+                    "expires_at": "2026-07-28T10:00:00Z",
+                    "checkout_session_url": (
+                        "https://checkout.stripe.com/c/pay/cs_test_topup_25"
+                    ),
+                },
+            ],
+            "errors": [],
+        }
+
+    async def create_points_checkout_options(
+        self,
+        slack_user_id,
+        *,
+        checkout_request_id,
+        pack_ids=None,
+        purchase_from=None,
+    ):
+        self.created = {
+            "slack_user_id": slack_user_id,
+            "checkout_request_id": checkout_request_id,
+            "pack_ids": pack_ids,
+            "purchase_from": purchase_from,
+        }
+        if pack_ids is None:
+            return self.response
+        selected = [
+            option
+            for option in self.response["options"]
+            if option["pack_id"] in pack_ids
+        ]
+        return {**self.response, "options": selected}
+
+
 class FakeBalanceClient:
     def __init__(self, response):
         self.response = response
@@ -692,6 +756,163 @@ async def test_topup_points_missing_pack_lists_fixed_packs(monkeypatch):
     assert "20 Top-up Roo Points - A$36.99" in result
     assert "50 Top-up Roo Points - A$63.99" in result
     assert "price per point" not in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_topup_points_missing_pack_posts_three_private_stripe_buttons(
+    monkeypatch,
+):
+    executor = SkillExecutor()
+    client = FakeTopupButtonsClient()
+    delivered = {}
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            ROO_POINTS_TOPUP_ENABLED=True,
+            ROO_POINTS_TOPUP_BUTTONS_ENABLED=True,
+            roo_points_stripe_checkout_hosts={"checkout.stripe.com"},
+        ),
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "post_ephemeral",
+        lambda **kwargs: delivered.update(kwargs) or {"ok": True},
+    )
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="topup_points",
+        params={},
+        text="top up Roo Points",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+        request_id="EvTopup123",
+    )
+
+    assert result["suppress_post"] is True
+    assert result["message"] == ""
+    assert result["data"]["delivery"] == "ephemeral"
+    assert result["data"]["pack_ids"] == ["topup_5", "topup_10", "topup_25"]
+    assert client.created == {
+        "slack_user_id": "U123",
+        "checkout_request_id": "EvTopup123",
+        "pack_ids": None,
+        "purchase_from": {
+            "source": "slack",
+            "slack_channel_id": "C123",
+            "slack_thread_ts": "111.222",
+        },
+    }
+    assert delivered["channel"] == "C123"
+    assert delivered["user"] == "U123"
+    assert delivered["thread_ts"] == "111.222"
+    buttons = delivered["blocks"][1]["elements"]
+    assert [button["text"]["text"] for button in buttons] == [
+        "10 points · A$19.99",
+        "20 points · A$36.99",
+        "50 points · A$63.99",
+    ]
+    assert all(
+        button["url"].startswith("https://checkout.stripe.com/")
+        for button in buttons
+    )
+    assert buttons[1]["style"] == "primary"
+    assert "checkout.stripe.com" not in delivered["text"]
+
+
+@pytest.mark.asyncio
+async def test_topup_points_explicit_pack_returns_one_button_in_dm(monkeypatch):
+    executor = SkillExecutor()
+    client = FakeTopupButtonsClient()
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            ROO_POINTS_TOPUP_ENABLED=True,
+            ROO_POINTS_TOPUP_BUTTONS_ENABLED=True,
+            roo_points_stripe_checkout_hosts={"checkout.stripe.com"},
+        ),
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "post_ephemeral",
+        lambda **kwargs: pytest.fail("DM checkout must not use chat.postEphemeral"),
+    )
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="topup_points",
+        params={"points": 20},
+        text="topup 20 points",
+        user_id="U123",
+        channel_id="D123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+        request_id="EvTopup20",
+    )
+
+    assert result["data"]["delivery"] == "direct_message"
+    assert result["data"]["pack_ids"] == ["topup_10"]
+    assert client.created["pack_ids"] == ["topup_10"]
+    buttons = result["blocks"][1]["elements"]
+    assert len(buttons) == 1
+    assert buttons[0]["text"]["text"] == "20 points · A$36.99"
+    assert "checkout.stripe.com" not in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_topup_points_rejects_untrusted_checkout_url(monkeypatch):
+    executor = SkillExecutor()
+    client = FakeTopupButtonsClient(
+        response={
+            "checkout_request_id": "EvEvil",
+            "options": [
+                {
+                    "pack_id": "topup_5",
+                    "points_amount": 10,
+                    "amount_cents": 1999,
+                    "currency": "aud",
+                    "checkout_session_url": "https://evil.example/checkout",
+                }
+            ],
+            "errors": [],
+        }
+    )
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            ROO_POINTS_TOPUP_ENABLED=True,
+            ROO_POINTS_TOPUP_BUTTONS_ENABLED=True,
+            roo_points_stripe_checkout_hosts={"checkout.stripe.com"},
+        ),
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "post_ephemeral",
+        lambda **kwargs: pytest.fail("Untrusted links must never be posted"),
+    )
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="topup_points",
+        params={},
+        text="topup",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+        request_id="EvEvil",
+    )
+
+    assert "trusted Stripe Checkout links" in result
+    assert "evil.example" not in result
 
 
 @pytest.mark.asyncio
@@ -2053,6 +2274,64 @@ async def test_backend_client_create_points_purchase_uses_canonical_endpoint(mon
     assert recorder.calls[0]["headers"]["X-API-Key"] == "api-key"
     assert recorder.calls[0]["headers"]["X-Request-ID"].startswith("roo-")
     assert recorder.calls[0]["timeout"] == 10.0
+
+
+@pytest.mark.asyncio
+async def test_backend_client_create_checkout_options_uses_canonical_endpoint(
+    monkeypatch,
+):
+    response_payload = {
+        "checkout_request_id": "EvTopup123",
+        "options": [
+            {
+                "pack_id": "topup_10",
+                "points_amount": 20,
+                "amount_cents": 3699,
+                "currency": "aud",
+                "checkout_session_url": (
+                    "https://checkout.stripe.com/c/pay/cs_test_topup_10"
+                ),
+            }
+        ],
+        "errors": [],
+    }
+    recorder = RecordingAsyncClient(json_data=response_payload)
+    monkeypatch.setattr(backend_module.httpx, "AsyncClient", lambda: recorder)
+
+    client = backend_module.MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="api-key",
+        internal_api_key="internal-key",
+    )
+
+    result = await client.create_points_checkout_options(
+        slack_user_id="<@U123>",
+        checkout_request_id="EvTopup123",
+        pack_ids=["topup_10"],
+        purchase_from={
+            "slack_channel_id": "C123",
+            "slack_thread_ts": "111.222",
+        },
+    )
+
+    assert result == response_payload
+    assert len(recorder.calls) == 1
+    assert recorder.calls[0]["method"] == "POST"
+    assert (
+        recorder.calls[0]["url"]
+        == "https://backend.test/api/v1/points/purchases/checkout-options/"
+    )
+    assert recorder.calls[0]["json"] == {
+        "slack_user_id": "U123",
+        "checkout_request_id": "EvTopup123",
+        "pack_ids": ["topup_10"],
+        "purchase_from": {
+            "source": "slack",
+            "slack_channel_id": "C123",
+            "slack_thread_ts": "111.222",
+        },
+    }
+    assert recorder.calls[0]["timeout"] == 30.0
 
 
 @pytest.mark.asyncio

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -319,7 +319,7 @@ Call the appropriate MLAIBackendClient method with extracted parameters.
 ### Step 4: Format Response
 Generate friendly response with relevant information:
 - Balance: Show points count and encourage engagement
-- Top-up: Show only fixed pack prices or the MLAI checkout link; never show a price-per-point value
+- Top-up: Show fixed pack prices as private Stripe Checkout buttons; never show a price-per-point value
 - Tasks: Format as a short list with task code, points, and portfolio
 - Bookings: Confirm date and show remaining balance
 - Errors: Explain what went wrong and suggest alternatives
@@ -327,13 +327,18 @@ Generate friendly response with relevant information:
 ## Top-up Roo Points
 
 Allowed fixed packs:
-- `topup_5`: 5 Top-up Roo Points - A$19.99
-- `topup_10`: 10 Top-up Roo Points - A$36.99
-- `topup_25`: 25 Top-up Roo Points - A$63.99
+- `topup_5`: 10 Top-up Roo Points - A$19.99
+- `topup_10`: 20 Top-up Roo Points - A$36.99
+- `topup_25`: 50 Top-up Roo Points - A$63.99
 
 Top-up Roo Points are MLAI's internal community reward points. They are not money, have no cash value, cannot be converted to cash, and cannot be sold or transferred. The price of Top-up Roo Points does not represent a monetary value for Roo Points.
 
 Top-up Roo Points are optional and do not count toward lifetime earned contribution.
+
+When the user asks to top up without choosing a pack, show all three Stripe
+Checkout buttons. If the user names a valid pack, show only that pack's button.
+Checkout buttons must be private to the requester in shared channels. Stripe
+collects the Roo Points terms acknowledgement before payment.
 
 ## Response Style
 


### PR DESCRIPTION
## What changed

- call the new backend checkout-options endpoint for Roo Points top-ups
- render three direct Stripe Checkout URL buttons for `@Roo topup`, or one button for an explicitly requested pack
- deliver buttons ephemerally in shared channels and normally in DMs
- allow only HTTPS Checkout URLs from configured Stripe hosts
- add production deployment flags for top-ups, buttons, and the Stripe hostname allowlist
- update Roo's points skill documentation and regression tests

## Why

The existing flow showed pack prices as text and required a second typed command. This release lets the requester choose a pack directly while keeping generated checkout links private.

## Validation

- rebased onto Roo `main` after PR #199
- `218` workflow security/AI/bridge tests pass in the supported container runtime
- `10` focused top-up tests pass
- Python compilation and `git diff --check`

## Rollout state

- backend PR MLAI-AUS-Inc/mlai-backend#640 is deployed
- migration `roo.0028` is applied
- Stripe public Terms and Privacy URLs are configured and verified
- this PR enables the production feature flags during deployment