### PR TITLE
Forward exact Roo release SHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,6 +114,7 @@ jobs:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1.0.3
         env:
+          RELEASE_SHA: ${{ github.sha }}
           SIM_PATIENT_API_KEY: ${{ secrets.SIM_PATIENT_API_KEY }}
           SIM_PATIENT_SAFETY_SALT: ${{ secrets.SIM_PATIENT_SAFETY_SALT }}
           ROO_API_KEY: ${{ secrets.ROO_API_KEY }}


### PR DESCRIPTION
## Summary

- bind `RELEASE_SHA` to `github.sha` in the SSH deployment step
- preserve the existing 40-character validation, main-ancestry check, detached checkout, and exact-HEAD assertion

## Incident context

The deployment of `2ab254ec73b61e445802568ad8e29df0f6cfc8ea` passed all official security checks, then failed before any host mutation because `RELEASE_SHA` was listed in the SSH action's forwarded variables but absent from the step environment.

## Verification

- workflow YAML parses successfully
- `git diff --check`
- forwarding declaration and 40-character release validation reviewed together
- one-file, one-line diff