### PR TITLE
Deliver Roo top-up buttons in durable Slack DMs

### DIFF
--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -8913,9 +8913,12 @@ Chunk {index} source: {label}
                 blocks=blocks,
             )
             return {
-                "message": "",
+                "message": (
+                    f"🔒 I’ve sent <@{user_id}> private Stripe Checkout buttons. "
+                    "Only they can see them."
+                ),
                 "data": response_data,
-                "suppress_post": True,
+                "suppress_post": False,
             }
         return {
             "message": message,

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -67,8 +67,8 @@ from ..points_request_approval import (
 from ..slack_client import (
     get_channel_id,
     get_channel_name,
-    post_ephemeral,
     post_message,
+    send_dm,
     upload_file,
 )
 from ..config import get_settings
@@ -8896,26 +8896,32 @@ Chunk {index} source: {label}
         ]
         response_data = {
             "action": "topup_points",
-            "delivery": (
-                "direct_message"
-                if channel_id and channel_id.startswith("D")
-                else "ephemeral"
-            ),
+            "delivery": "direct_message",
             "pack_ids": [option["pack_id"] for option in options],
             "partial": had_partial_errors,
         }
         if channel_id and not channel_id.startswith("D"):
-            post_ephemeral(
-                channel=channel_id,
-                user=user_id,
-                text=message,
-                thread_ts=thread_ts,
+            dm_response = send_dm(
+                user_id,
+                message,
                 blocks=blocks,
             )
+            if not dm_response or not dm_response.get("ok"):
+                return {
+                    "message": (
+                        f"⚠️ I couldn’t open a private Slack DM for <@{user_id}>. "
+                        "Please DM me `topup` and I’ll create fresh checkout buttons there."
+                    ),
+                    "data": {
+                        **response_data,
+                        "delivery_failed": True,
+                    },
+                    "suppress_post": False,
+                }
             return {
                 "message": (
-                    f"🔒 I’ve sent <@{user_id}> private Stripe Checkout buttons. "
-                    "Only they can see them."
+                    f"🔒 I’ve sent <@{user_id}> a direct message with private "
+                    "Stripe Checkout buttons. Check your DMs."
                 ),
                 "data": response_data,
                 "suppress_post": False,

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -759,7 +759,7 @@ async def test_topup_points_missing_pack_lists_fixed_packs(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_topup_points_missing_pack_posts_three_private_stripe_buttons(
+async def test_topup_points_missing_pack_sends_three_stripe_buttons_by_dm(
     monkeypatch,
 ):
     executor = SkillExecutor()
@@ -777,8 +777,11 @@ async def test_topup_points_missing_pack_posts_three_private_stripe_buttons(
     )
     monkeypatch.setattr(
         executor_module,
-        "post_ephemeral",
-        lambda **kwargs: delivered.update(kwargs) or {"ok": True},
+        "send_dm",
+        lambda user_id, text, **kwargs: (
+            delivered.update({"user_id": user_id, "text": text, **kwargs})
+            or {"ok": True, "channel": "D123", "ts": "333.444"}
+        ),
     )
 
     result = await executor._handle_points_action(
@@ -795,11 +798,11 @@ async def test_topup_points_missing_pack_posts_three_private_stripe_buttons(
 
     assert result["suppress_post"] is False
     assert result["message"] == (
-        "🔒 I’ve sent <@U123> private Stripe Checkout buttons. "
-        "Only they can see them."
+        "🔒 I’ve sent <@U123> a direct message with private "
+        "Stripe Checkout buttons. Check your DMs."
     )
     assert "checkout.stripe.com" not in result["message"]
-    assert result["data"]["delivery"] == "ephemeral"
+    assert result["data"]["delivery"] == "direct_message"
     assert result["data"]["pack_ids"] == ["topup_5", "topup_10", "topup_25"]
     assert client.created == {
         "slack_user_id": "U123",
@@ -811,9 +814,9 @@ async def test_topup_points_missing_pack_posts_three_private_stripe_buttons(
             "slack_thread_ts": "111.222",
         },
     }
-    assert delivered["channel"] == "C123"
-    assert delivered["user"] == "U123"
-    assert delivered["thread_ts"] == "111.222"
+    assert delivered["user_id"] == "U123"
+    assert "private Stripe Checkout buttons" in delivered["text"]
+    assert "thread_ts" not in delivered
     buttons = delivered["blocks"][1]["elements"]
     assert [button["text"]["text"] for button in buttons] == [
         "10 points · A$19.99",
@@ -826,6 +829,44 @@ async def test_topup_points_missing_pack_posts_three_private_stripe_buttons(
     )
     assert buttons[1]["style"] == "primary"
     assert "checkout.stripe.com" not in delivered["text"]
+
+
+@pytest.mark.asyncio
+async def test_topup_points_dm_failure_posts_safe_public_recovery(monkeypatch):
+    executor = SkillExecutor()
+    client = FakeTopupButtonsClient()
+
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            ROO_POINTS_TOPUP_ENABLED=True,
+            ROO_POINTS_TOPUP_BUTTONS_ENABLED=True,
+            roo_points_stripe_checkout_hosts={"checkout.stripe.com"},
+        ),
+    )
+    monkeypatch.setattr(executor_module, "send_dm", lambda *args, **kwargs: None)
+
+    result = await executor._handle_points_action(
+        client=client,
+        action="topup_points",
+        params={},
+        text="topup",
+        user_id="U123",
+        channel_id="C123",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+        request_id="EvTopupDmFailure",
+    )
+
+    assert result["suppress_post"] is False
+    assert result["data"]["delivery"] == "direct_message"
+    assert result["data"]["delivery_failed"] is True
+    assert result["message"] == (
+        "⚠️ I couldn’t open a private Slack DM for <@U123>. "
+        "Please DM me `topup` and I’ll create fresh checkout buttons there."
+    )
+    assert "checkout.stripe.com" not in result["message"]
 
 
 @pytest.mark.asyncio
@@ -844,8 +885,10 @@ async def test_topup_points_explicit_pack_returns_one_button_in_dm(monkeypatch):
     )
     monkeypatch.setattr(
         executor_module,
-        "post_ephemeral",
-        lambda **kwargs: pytest.fail("DM checkout must not use chat.postEphemeral"),
+        "send_dm",
+        lambda *args, **kwargs: pytest.fail(
+            "An existing DM checkout must post to its current channel"
+        ),
     )
 
     result = await executor._handle_points_action(
@@ -899,8 +942,8 @@ async def test_topup_points_rejects_untrusted_checkout_url(monkeypatch):
     )
     monkeypatch.setattr(
         executor_module,
-        "post_ephemeral",
-        lambda **kwargs: pytest.fail("Untrusted links must never be posted"),
+        "send_dm",
+        lambda *args, **kwargs: pytest.fail("Untrusted links must never be posted"),
     )
 
     result = await executor._handle_points_action(

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -793,8 +793,12 @@ async def test_topup_points_missing_pack_posts_three_private_stripe_buttons(
         request_id="EvTopup123",
     )
 
-    assert result["suppress_post"] is True
-    assert result["message"] == ""
+    assert result["suppress_post"] is False
+    assert result["message"] == (
+        "🔒 I’ve sent <@U123> private Stripe Checkout buttons. "
+        "Only they can see them."
+    )
+    assert "checkout.stripe.com" not in result["message"]
     assert result["data"]["delivery"] == "ephemeral"
     assert result["data"]["pack_ids"] == ["topup_5", "topup_10", "topup_25"]
     assert client.created == {

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -339,6 +339,9 @@ When the user asks to top up without choosing a pack, show all three Stripe
 Checkout buttons. If the user names a valid pack, show only that pack's button.
 Checkout buttons must be private to the requester in shared channels. Stripe
 collects the Roo Points terms acknowledgement before payment.
+After delivering private buttons in a shared channel, post a short public
+confirmation in the thread so everyone can see that Roo responded. The public
+confirmation must not contain a checkout URL or any purchase details.
 
 ## Response Style
 

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -337,11 +337,13 @@ Top-up Roo Points are optional and do not count toward lifetime earned contribut
 
 When the user asks to top up without choosing a pack, show all three Stripe
 Checkout buttons. If the user names a valid pack, show only that pack's button.
-Checkout buttons must be private to the requester in shared channels. Stripe
-collects the Roo Points terms acknowledgement before payment.
-After delivering private buttons in a shared channel, post a short public
-confirmation in the thread so everyone can see that Roo responded. The public
-confirmation must not contain a checkout URL or any purchase details.
+From a shared channel, send checkout buttons in a persistent direct message to
+the requester; do not use a transient ephemeral channel message. Stripe collects
+the Roo Points terms acknowledgement before payment. After DM delivery, post a
+short public confirmation in the original thread so everyone can see that Roo
+responded. The public confirmation must not contain a checkout URL or purchase
+details. If opening the DM fails, tell the requester publicly to DM Roo `topup`
+so fresh buttons can be created safely in that conversation.
 
 ## Response Style
 


### PR DESCRIPTION
## What changed

- replace transient `chat.postEphemeral` top-up delivery with a persistent Roo direct message
- keep Stripe Checkout URLs out of shared-channel history
- post a short public thread confirmation after successful DM delivery
- post a safe recovery instruction if Slack cannot open the DM
- document the delivery guarantees and add regression coverage

## Root cause

Slack accepted the ephemeral API request, but ephemeral delivery is not guaranteed, messages do not persist across sessions or devices, and threaded ephemerals require an active thread. The original top-up command therefore produced a successful API acknowledgement without a durable message Trevor could retrieve.

## User impact

Members requesting `@Roo topup` in a shared channel now receive persistent Stripe buttons in their Roo DM and a visible confirmation in the original thread. Checkout URLs remain private.

## Validation

- `10 passed, 95 deselected` across Roo's focused top-up tests
- Python compilation
- `git diff --check`

The broader points test file currently has three unrelated failures already present on `main` (two coworking expectations and one stale GPT-5.4 assertion).