### PR TITLE
Recover Slack-to-Linear extraction timeouts

### DIFF
--- a/roo-standalone/roo/linear_inference.py
+++ b/roo-standalone/roo/linear_inference.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import time
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from typing import Generic, Literal, TypeVar
 
+from openai import APITimeoutError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from .llm import ToolCallParseError, get_llm_client
@@ -146,6 +148,9 @@ class LinearReasoningSignals:
     stage: LinearInferenceStage
     source_chars: int = 0
     source_count: int = 1
+    batch_chunk_index: int = 1
+    batch_chunk_count: int = 1
+    recovery_depth: int = 0
     candidate_count: int = 1
     explicit_project: bool = True
     explicit_owner: bool = True
@@ -178,6 +183,29 @@ class LinearInferenceResult(Generic[StructuredT]):
 
 class LinearInferenceValidationError(ValueError):
     """Structured output parsed but did not satisfy the workflow contract."""
+
+
+class LinearInferenceTimeoutError(TimeoutError):
+    """A bounded Linear inference call timed out before producing a result."""
+
+    def __init__(
+        self,
+        *,
+        decision: LinearReasoningDecision,
+        signals: LinearReasoningSignals,
+        attempt: int,
+        duration_ms: int,
+    ) -> None:
+        self.decision = decision
+        self.signals = signals
+        self.attempt = attempt
+        self.duration_ms = duration_ms
+        super().__init__(
+            "Linear inference timed out "
+            f"(stage={signals.stage}, effort={decision.effort}, "
+            f"attempt={attempt}, chunk={signals.batch_chunk_index}/"
+            f"{signals.batch_chunk_count}, duration_ms={duration_ms})"
+        )
 
 
 def choose_linear_reasoning(signals: LinearReasoningSignals) -> LinearReasoningDecision:
@@ -264,6 +292,42 @@ def linear_safety_identifier(requester_id: str | None) -> str:
     return f"roo-linear-{digest[:24]}"
 
 
+def _log_linear_inference_event(
+    level: int,
+    event: str,
+    *,
+    decision: LinearReasoningDecision,
+    signals: LinearReasoningSignals,
+    attempt: int,
+    duration_ms: int | None = None,
+    error_type: str | None = None,
+) -> None:
+    payload = {
+        "event": event,
+        "stage": signals.stage,
+        "model": LINEAR_SKILL_MODEL,
+        "reasoning_effort": decision.effort,
+        "timeout_seconds": decision.timeout_seconds,
+        "complexity_score": decision.complexity_score,
+        "reasoning_reasons": list(decision.reasons),
+        "attempt": attempt,
+        "source_chars": signals.source_chars,
+        "source_count": signals.source_count,
+        "batch_chunk_index": signals.batch_chunk_index,
+        "batch_chunk_count": signals.batch_chunk_count,
+        "recovery_depth": signals.recovery_depth,
+    }
+    if duration_ms is not None:
+        payload["duration_ms"] = duration_ms
+    if error_type:
+        payload["error_type"] = error_type
+    logger.log(
+        level,
+        "LINEAR_INFERENCE %s",
+        json.dumps(payload, ensure_ascii=True, separators=(",", ":"), sort_keys=True),
+    )
+
+
 async def run_linear_structured_inference(
     *,
     messages: list[dict[str, str]],
@@ -277,7 +341,9 @@ async def run_linear_structured_inference(
     client = get_llm_client("openai")
     parse_method = getattr(client, "responses_parse", None)
     if parse_method is None:
-        raise RuntimeError("The OpenAI client does not support structured Responses output.")
+        raise RuntimeError(
+            "The OpenAI client does not support structured Responses output."
+        )
 
     decision = choose_linear_reasoning(signals)
     retryable_errors = (
@@ -287,8 +353,17 @@ async def run_linear_structured_inference(
     )
     last_error: Exception | None = None
     for attempt in range(2):
-        attempt_decision = decision if attempt == 0 else escalate_linear_reasoning(decision)
+        attempt_decision = (
+            decision if attempt == 0 else escalate_linear_reasoning(decision)
+        )
         started_at = time.monotonic()
+        _log_linear_inference_event(
+            logging.INFO,
+            "started",
+            decision=attempt_decision,
+            signals=signals,
+            attempt=attempt + 1,
+        )
         try:
             parsed = await parse_method(
                 messages,
@@ -305,36 +380,48 @@ async def run_linear_structured_inference(
                 parsed = response_format.model_validate(parsed)
             if validator is not None:
                 validator(parsed)
-            logger.info(
-                "linear_inference_completed",
-                extra={
-                    "linear_stage": signals.stage,
-                    "linear_model": LINEAR_SKILL_MODEL,
-                    "linear_reasoning_effort": attempt_decision.effort,
-                    "linear_complexity_score": attempt_decision.complexity_score,
-                    "linear_reasoning_reasons": list(attempt_decision.reasons),
-                    "linear_attempts": attempt + 1,
-                    "linear_duration_ms": round(
-                        (time.monotonic() - started_at) * 1000
-                    ),
-                },
+            duration_ms = round((time.monotonic() - started_at) * 1000)
+            _log_linear_inference_event(
+                logging.INFO,
+                "completed",
+                decision=attempt_decision,
+                signals=signals,
+                attempt=attempt + 1,
+                duration_ms=duration_ms,
             )
             return LinearInferenceResult(
                 value=parsed,
                 decision=attempt_decision,
                 attempts=attempt + 1,
             )
+        except APITimeoutError as exc:
+            duration_ms = round((time.monotonic() - started_at) * 1000)
+            _log_linear_inference_event(
+                logging.WARNING,
+                "timed_out",
+                decision=attempt_decision,
+                signals=signals,
+                attempt=attempt + 1,
+                duration_ms=duration_ms,
+                error_type=type(exc).__name__,
+            )
+            raise LinearInferenceTimeoutError(
+                decision=attempt_decision,
+                signals=signals,
+                attempt=attempt + 1,
+                duration_ms=duration_ms,
+            ) from exc
         except retryable_errors as exc:
             last_error = exc
-            logger.warning(
-                "linear_inference_validation_retry",
-                extra={
-                    "linear_stage": signals.stage,
-                    "linear_model": LINEAR_SKILL_MODEL,
-                    "linear_reasoning_effort": attempt_decision.effort,
-                    "linear_attempt": attempt + 1,
-                    "linear_error_type": type(exc).__name__,
-                },
+            duration_ms = round((time.monotonic() - started_at) * 1000)
+            _log_linear_inference_event(
+                logging.WARNING,
+                "validation_retry" if attempt == 0 else "validation_failed",
+                decision=attempt_decision,
+                signals=signals,
+                attempt=attempt + 1,
+                duration_ms=duration_ms,
+                error_type=type(exc).__name__,
             )
             if attempt == 1:
                 raise

--- a/roo-standalone/roo/linear_meeting_sources.py
+++ b/roo-standalone/roo/linear_meeting_sources.py
@@ -439,8 +439,18 @@ def _is_animated_gif(file_bytes: bytes) -> bool:
     return file_bytes.count(b"\x21\xf9\x04") > 1
 
 
-def source_text_chunks(source: ParsedSource, max_chars: int = 10000) -> list[str]:
+def source_text_chunks(
+    source: ParsedSource,
+    max_chars: int = 10000,
+    *,
+    hard_split_overlap_chars: int = 0,
+) -> list[str]:
     """Split source text into chunks without dropping source attribution."""
+    if max_chars <= 0:
+        raise ValueError("max_chars must be positive")
+    if hard_split_overlap_chars < 0 or hard_split_overlap_chars >= max_chars:
+        raise ValueError("hard_split_overlap_chars must be between 0 and max_chars")
+
     text = source.text.strip()
     if len(text) <= max_chars:
         return [f"Source: {source.label}\n{text}"] if text else []
@@ -452,14 +462,21 @@ def source_text_chunks(source: ParsedSource, max_chars: int = 10000) -> list[str
         paragraph = paragraph.strip()
         if not paragraph:
             continue
+        if len(paragraph) > max_chars:
+            if current:
+                chunks.append(f"Source: {source.label}\n{current}")
+                current = ""
+            step = max_chars - hard_split_overlap_chars
+            for start in range(0, len(paragraph), step):
+                chunk_text = paragraph[start:start + max_chars]
+                chunks.append(f"Source: {source.label}\n{chunk_text}")
+                if start + max_chars >= len(paragraph):
+                    break
+            continue
         next_value = f"{current}\n\n{paragraph}".strip() if current else paragraph
         if len(next_value) > max_chars and current:
             chunks.append(f"Source: {source.label}\n{current}")
             current = paragraph
-        elif len(next_value) > max_chars:
-            for start in range(0, len(paragraph), max_chars):
-                chunks.append(f"Source: {source.label}\n{paragraph[start:start + max_chars]}")
-            current = ""
         else:
             current = next_value
     if current:

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -51,6 +51,7 @@ from ..linear_inference import (
     LINEAR_SKILL_MODEL,
     LinearContextualIssueResult,
     LinearDirectIssueBatch,
+    LinearInferenceTimeoutError,
     LinearMeetingActionBatch,
     LinearProjectSourceSummary,
     LinearProjectUpdateResult,
@@ -94,6 +95,17 @@ VICTOR_AI_ACCESS_UNAVAILABLE_MESSAGE = (
     "Victor application data is not available in this conversation."
 )
 LINEAR_MEETING_PENDING_ACTIONS: dict[str, dict[str, Any]] = {}
+LINEAR_MEETING_EXTRACTION_CONCURRENCY = 2
+LINEAR_MEETING_EXTRACTION_TOTAL_TIMEOUT_SECONDS = 240.0
+LINEAR_MEETING_TIMEOUT_RECOVERY_MAX_CHARS = 5_000
+LINEAR_MEETING_TIMEOUT_RECOVERY_OVERLAP_CHARS = 300
+LINEAR_MEETING_TIMEOUT_RECOVERY_DEPTH = 1
+
+
+class LinearMeetingExtractionDeadlineError(RuntimeError):
+    """The complete meeting-action extraction exceeded its wall-clock budget."""
+
+
 # Pack ids are opaque and kept stable; the id number no longer matches the
 # points it grants (points were doubled for the same price). Must stay in sync
 # with mlai-backend roo/services.py ROO_TOPUP_PACKS.
@@ -2783,32 +2795,60 @@ Keep the response concise but informative."""
                 "message": f"I couldn't read Linear context yet: {detail}"
             }
 
-        if use_direct_issue_path:
-            candidates = await self._extract_linear_direct_issue_candidates(
-                text=text,
-                params=params,
-                users=users,
-                projects=projects,
-            )
-        else:
-            candidates = await self._extract_linear_meeting_candidates_from_sources(
-                sources=source_result.sources,
-                params=params,
-                users=users,
-                projects=projects,
-            )
         project_update_requested = self._linear_meeting_project_update_requested(text, params)
         contextual_review_mode = False
-        if not candidates and thread_reference_request and not project_update_requested:
-            contextual_candidate = await self._extract_linear_thread_context_candidate(
-                sources=source_result.sources,
-                params=params,
-                users=users,
-                projects=projects,
+        try:
+            if use_direct_issue_path:
+                candidates = await self._extract_linear_direct_issue_candidates(
+                    text=text,
+                    params=params,
+                    users=users,
+                    projects=projects,
+                )
+            else:
+                candidates = await self._extract_linear_meeting_candidates_from_sources(
+                    sources=source_result.sources,
+                    params=params,
+                    users=users,
+                    projects=projects,
+                )
+            if not candidates and thread_reference_request and not project_update_requested:
+                contextual_candidate = await self._extract_linear_thread_context_candidate(
+                    sources=source_result.sources,
+                    params=params,
+                    users=users,
+                    projects=projects,
+                )
+                if contextual_candidate:
+                    candidates = [contextual_candidate]
+                    contextual_review_mode = True
+        except (LinearInferenceTimeoutError, LinearMeetingExtractionDeadlineError) as exc:
+            print(
+                "LINEAR_MEETING_EXTRACTION "
+                + json.dumps(
+                    {
+                        "event": "aborted_before_writes",
+                        "error_type": type(exc).__name__,
+                        "project_hint": params.get("project_hint"),
+                        "files_parsed": source_result.files_parsed,
+                    },
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
             )
-            if contextual_candidate:
-                candidates = [contextual_candidate]
-                contextual_review_mode = True
+            return {
+                "message": (
+                    "I timed out while extracting action items from those notes, so I stopped "
+                    "before creating any Linear tasks. Nothing was changed. Please try again."
+                ),
+                "data": {
+                    "created_count": 0,
+                    "review_count": 0,
+                    "skipped_count": 0,
+                    "timed_out": True,
+                },
+            }
         if not candidates and not project_update_requested:
             return {
                 "message": (
@@ -3691,25 +3731,144 @@ Return the structured issue list. Preserve the parsed project and assignee hints
         users: list[dict[str, Any]],
         projects: list[dict[str, Any]],
     ) -> list[dict[str, Any]]:
-        candidates: list[dict[str, Any]] = []
         source_chunks = [
             (source, chunk)
             for source in sources
             for chunk in source_text_chunks(source)
         ]
-        for source, chunk in source_chunks:
-            extracted = await self._extract_linear_meeting_candidates(
-                transcript=chunk,
-                params=params,
-                users=users,
-                projects=projects,
-                source_label=source.label,
-                source_count=max(1, len(source_chunks)),
+        if not source_chunks:
+            return []
+
+        semaphore = asyncio.Semaphore(LINEAR_MEETING_EXTRACTION_CONCURRENCY)
+        batch_chunk_count = len(source_chunks)
+
+        async def extract_chunk(
+            source: ParsedSource,
+            chunk: str,
+            *,
+            batch_chunk_index: int,
+            recovery_depth: int = 0,
+        ) -> list[dict[str, Any]]:
+            try:
+                async with semaphore:
+                    return await self._extract_linear_meeting_candidates(
+                        transcript=chunk,
+                        params=params,
+                        users=users,
+                        projects=projects,
+                        source_label=source.label,
+                        # This model request contains one source chunk. The total
+                        # batch size is logged separately and must not inflate
+                        # reasoning effort for every individual request.
+                        source_count=1,
+                        batch_chunk_index=batch_chunk_index,
+                        batch_chunk_count=batch_chunk_count,
+                        recovery_depth=recovery_depth,
+                    )
+            except LinearInferenceTimeoutError as exc:
+                if recovery_depth >= LINEAR_MEETING_TIMEOUT_RECOVERY_DEPTH:
+                    raise
+                recovery_chunks = self._linear_meeting_timeout_recovery_chunks(
+                    source=source,
+                    chunk=chunk,
+                )
+                print(
+                    "LINEAR_MEETING_EXTRACTION "
+                    + json.dumps(
+                        {
+                            "event": "chunk_timeout_recovery",
+                            "batch_chunk_index": batch_chunk_index,
+                            "batch_chunk_count": batch_chunk_count,
+                            "recovery_depth": recovery_depth + 1,
+                            "retry_chunk_count": len(recovery_chunks),
+                            "source_chars": len(chunk),
+                            "reasoning_effort": exc.decision.effort,
+                            "timeout_seconds": exc.decision.timeout_seconds,
+                        },
+                        ensure_ascii=True,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    )
+                )
+                recovered = await asyncio.gather(
+                    *(
+                        extract_chunk(
+                            source,
+                            recovery_chunk,
+                            batch_chunk_index=batch_chunk_index,
+                            recovery_depth=recovery_depth + 1,
+                        )
+                        for recovery_chunk in recovery_chunks
+                    ),
+                    return_exceptions=True,
+                )
+                recovered_candidates: list[dict[str, Any]] = []
+                for result in recovered:
+                    if isinstance(result, BaseException):
+                        raise result
+                    recovered_candidates.extend(result)
+                return self._dedupe_linear_meeting_candidates(recovered_candidates)
+
+        async def extract_all_chunks() -> list[list[dict[str, Any]]]:
+            extracted = await asyncio.gather(
+                *(
+                    extract_chunk(
+                        source,
+                        chunk,
+                        batch_chunk_index=index,
+                    )
+                    for index, (source, chunk) in enumerate(source_chunks, start=1)
+                ),
+                return_exceptions=True,
             )
+            for result in extracted:
+                if isinstance(result, BaseException):
+                    raise result
+            return extracted
+
+        try:
+            extracted_batches = await asyncio.wait_for(
+                extract_all_chunks(),
+                timeout=LINEAR_MEETING_EXTRACTION_TOTAL_TIMEOUT_SECONDS,
+            )
+        except LinearInferenceTimeoutError:
+            raise
+        except asyncio.TimeoutError as exc:
+            raise LinearMeetingExtractionDeadlineError(
+                "Meeting-action extraction exceeded its "
+                f"{LINEAR_MEETING_EXTRACTION_TOTAL_TIMEOUT_SECONDS:g} second runtime budget."
+            ) from exc
+
+        candidates: list[dict[str, Any]] = []
+        for (source, _), extracted in zip(source_chunks, extracted_batches):
             for item in extracted:
                 item.setdefault("source_label", source.label)
                 candidates.append(item)
         return self._dedupe_linear_meeting_candidates(candidates)
+
+    @staticmethod
+    def _linear_meeting_timeout_recovery_chunks(
+        *,
+        source: ParsedSource,
+        chunk: str,
+    ) -> list[str]:
+        source_header = f"Source: {source.label}\n"
+        source_text = (
+            chunk[len(source_header):]
+            if chunk.startswith(source_header)
+            else chunk
+        )
+        recovery_source = ParsedSource(
+            label=source.label,
+            text=source_text,
+            kind=source.kind,
+            metadata=source.metadata,
+        )
+        return source_text_chunks(
+            recovery_source,
+            max_chars=LINEAR_MEETING_TIMEOUT_RECOVERY_MAX_CHARS,
+            hard_split_overlap_chars=LINEAR_MEETING_TIMEOUT_RECOVERY_OVERLAP_CHARS,
+        ) or [chunk]
 
     async def _extract_linear_meeting_candidates(
         self,
@@ -3720,6 +3879,9 @@ Return the structured issue list. Preserve the parsed project and assignee hints
         projects: list[dict[str, Any]],
         source_label: Optional[str] = None,
         source_count: int = 1,
+        batch_chunk_index: int = 1,
+        batch_chunk_count: int = 1,
+        recovery_depth: int = 0,
     ) -> list[dict[str, Any]]:
         from ..utils import get_current_date
 
@@ -3773,6 +3935,9 @@ Return the structured action_items list."""
                     stage="meeting_actions",
                     source_chars=len(transcript),
                     source_count=max(1, source_count),
+                    batch_chunk_index=max(1, batch_chunk_index),
+                    batch_chunk_count=max(1, batch_chunk_count),
+                    recovery_depth=max(0, recovery_depth),
                     explicit_project=bool(params.get("project_hint")),
                     explicit_owner=bool(
                         params.get("owner_hint")

--- a/roo-standalone/roo/tests/test_linear_inference.py
+++ b/roo-standalone/roo/tests/test_linear_inference.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
+from openai import APITimeoutError
 from pydantic import BaseModel, ConfigDict, Field
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
@@ -11,6 +14,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 import roo.linear_inference as inference_module
 from roo.linear_inference import (
     LINEAR_SKILL_MODEL,
+    LinearInferenceTimeoutError,
     LinearReasoningSignals,
     choose_linear_reasoning,
     run_linear_structured_inference,
@@ -149,3 +153,55 @@ async def test_linear_gateway_retries_once_and_only_retry_reaches_max(monkeypatc
     assert result.attempts == 2
     assert [call["reasoning_effort"] for call in calls] == ["xhigh", "max"]
     assert result.decision.retry is True
+
+
+@pytest.mark.asyncio
+async def test_linear_gateway_surfaces_timeout_without_validation_escalation(
+    monkeypatch,
+    caplog,
+):
+    calls = []
+
+    class FakeClient:
+        async def responses_parse(self, messages, response_format, **kwargs):
+            calls.append(kwargs)
+            raise APITimeoutError(
+                request=httpx.Request("POST", "https://api.openai.test/v1/responses")
+            )
+
+    monkeypatch.setattr(
+        inference_module,
+        "get_llm_client",
+        lambda provider: FakeClient(),
+    )
+
+    signals = LinearReasoningSignals(
+        stage="meeting_actions",
+        source_chars=9_000,
+        source_count=1,
+        batch_chunk_index=2,
+        batch_chunk_count=5,
+        explicit_project=True,
+        explicit_owner=True,
+    )
+    with (
+        caplog.at_level(logging.INFO),
+        pytest.raises(LinearInferenceTimeoutError) as error,
+    ):
+        await run_linear_structured_inference(
+            messages=[{"role": "user", "content": "Extract the action items."}],
+            response_format=ExampleResult,
+            signals=signals,
+        )
+
+    assert len(calls) == 1
+    assert calls[0]["model"] == LINEAR_SKILL_MODEL == "gpt-5.6-sol"
+    assert calls[0]["reasoning_effort"] == "medium"
+    assert calls[0]["max_retries"] == 0
+    assert error.value.signals == signals
+    assert error.value.attempt == 1
+    assert '"event":"started"' in caplog.text
+    assert '"event":"timed_out"' in caplog.text
+    assert '"batch_chunk_index":2' in caplog.text
+    assert '"batch_chunk_count":5' in caplog.text
+    assert '"error_type":"APITimeoutError"' in caplog.text

--- a/roo-standalone/roo/tests/test_linear_meeting_actions.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_actions.py
@@ -15,11 +15,39 @@ import roo.skills.executor as executor_module
 from roo.linear_inference import (
     LinearCandidate,
     LinearDirectIssueBatch,
+    LinearInferenceTimeoutError,
     LinearProjectSourceSummary,
     LinearProjectUpdateResult,
+    LinearReasoningSignals,
+    choose_linear_reasoning,
 )
 from roo.linear_meeting_sources import ParsedSource, SourceParseResult
 from roo.skills.executor import SkillExecutor
+
+
+def _meeting_timeout_error(
+    *,
+    source_chars: int,
+    batch_chunk_index: int = 1,
+    batch_chunk_count: int = 1,
+    recovery_depth: int = 0,
+) -> LinearInferenceTimeoutError:
+    signals = LinearReasoningSignals(
+        stage="meeting_actions",
+        source_chars=source_chars,
+        source_count=1,
+        batch_chunk_index=batch_chunk_index,
+        batch_chunk_count=batch_chunk_count,
+        recovery_depth=recovery_depth,
+        explicit_project=True,
+        explicit_owner=True,
+    )
+    return LinearInferenceTimeoutError(
+        decision=choose_linear_reasoning(signals),
+        signals=signals,
+        attempt=1,
+        duration_ms=45_000,
+    )
 
 
 def test_linear_meeting_transcript_uses_thread_history_and_message():
@@ -721,9 +749,19 @@ async def test_linear_meeting_candidate_extraction_chunks_sources(monkeypatch):
         projects,
         source_label=None,
         source_count=1,
+        batch_chunk_index=1,
+        batch_chunk_count=1,
+        recovery_depth=0,
     ):
-        calls.append(transcript)
-        assert source_count >= 1
+        calls.append(
+            {
+                "transcript": transcript,
+                "source_count": source_count,
+                "batch_chunk_index": batch_chunk_index,
+                "batch_chunk_count": batch_chunk_count,
+                "recovery_depth": recovery_depth,
+            }
+        )
         return [
             {
                 "title": "Update onboarding docs",
@@ -744,10 +782,217 @@ async def test_linear_meeting_candidate_extraction_chunks_sources(monkeypatch):
     )
 
     assert len(calls) > 1
-    assert all(call.startswith("Source: notes.pdf") for call in calls)
-    assert all(len(call) <= 10100 for call in calls)
+    assert all(call["transcript"].startswith("Source: notes.pdf") for call in calls)
+    assert all(len(call["transcript"]) <= 10100 for call in calls)
+    assert all(call["source_count"] == 1 for call in calls)
+    assert {call["batch_chunk_count"] for call in calls} == {len(calls)}
+    assert {call["batch_chunk_index"] for call in calls} == set(
+        range(1, len(calls) + 1)
+    )
     assert len(candidates) == 1
     assert candidates[0]["source_label"] == "notes.pdf"
+
+
+@pytest.mark.asyncio
+async def test_linear_meeting_timeout_retries_only_failed_chunk_at_smaller_scope(
+    monkeypatch,
+):
+    executor = SkillExecutor()
+    calls = []
+    body = ("Sam will update the onboarding checklist after the meeting. " * 150).strip()
+    assert 5_000 < len(body) < 10_000
+
+    async def fake_extract(
+        *,
+        transcript,
+        params,
+        users,
+        projects,
+        source_label=None,
+        source_count=1,
+        batch_chunk_index=1,
+        batch_chunk_count=1,
+        recovery_depth=0,
+    ):
+        calls.append(
+            {
+                "chars": len(transcript),
+                "source_count": source_count,
+                "batch_chunk_index": batch_chunk_index,
+                "batch_chunk_count": batch_chunk_count,
+                "recovery_depth": recovery_depth,
+            }
+        )
+        if recovery_depth == 0:
+            raise _meeting_timeout_error(
+                source_chars=len(transcript),
+                batch_chunk_index=batch_chunk_index,
+                batch_chunk_count=batch_chunk_count,
+            )
+        return [
+            {
+                "title": "Update the onboarding checklist",
+                "owner_hint": "Sam",
+                "source_label": source_label,
+                "confidence": 0.9,
+            }
+        ]
+
+    monkeypatch.setattr(executor, "_extract_linear_meeting_candidates", fake_extract)
+
+    candidates = await executor._extract_linear_meeting_candidates_from_sources(
+        sources=[ParsedSource(label="notes.pdf", text=body, kind="pdf")],
+        params={"project_hint": "[Studio] Aaron AI", "default_assignee_hint": "Sam"},
+        users=[],
+        projects=[],
+    )
+
+    initial_calls = [call for call in calls if call["recovery_depth"] == 0]
+    recovery_calls = [call for call in calls if call["recovery_depth"] == 1]
+    assert len(initial_calls) == 1
+    assert len(recovery_calls) == 2
+    assert all(call["chars"] < initial_calls[0]["chars"] for call in recovery_calls)
+    assert all(call["source_count"] == 1 for call in calls)
+    assert {call["batch_chunk_index"] for call in calls} == {1}
+    assert {call["batch_chunk_count"] for call in calls} == {1}
+    assert len(candidates) == 1
+    assert candidates[0]["title"] == "Update the onboarding checklist"
+
+
+@pytest.mark.asyncio
+async def test_linear_meeting_chunk_extraction_uses_bounded_concurrency(monkeypatch):
+    executor = SkillExecutor()
+    active = 0
+    peak_active = 0
+    total_calls = 0
+
+    async def fake_extract(
+        *,
+        transcript,
+        params,
+        users,
+        projects,
+        source_label=None,
+        source_count=1,
+        batch_chunk_index=1,
+        batch_chunk_count=1,
+        recovery_depth=0,
+    ):
+        nonlocal active, peak_active, total_calls
+        total_calls += 1
+        active += 1
+        peak_active = max(peak_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return [
+            {
+                "title": f"Complete action {batch_chunk_index}",
+                "owner_hint": "Sam",
+                "source_label": source_label,
+                "confidence": 0.9,
+            }
+        ]
+
+    monkeypatch.setattr(executor, "_extract_linear_meeting_candidates", fake_extract)
+    paragraphs = [
+        f"Sam will complete action {index}. " + ("context " * 550)
+        for index in range(1, 6)
+    ]
+
+    candidates = await executor._extract_linear_meeting_candidates_from_sources(
+        sources=[
+            ParsedSource(
+                label="notes.pdf",
+                text="\n\n".join(paragraphs),
+                kind="pdf",
+            )
+        ],
+        params={},
+        users=[],
+        projects=[],
+    )
+
+    assert peak_active == 2
+    assert total_calls >= 3
+    assert candidates
+
+
+@pytest.mark.asyncio
+async def test_linear_meeting_repeated_timeout_aborts_before_any_linear_write(
+    monkeypatch,
+):
+    executor = SkillExecutor()
+    write_calls = []
+
+    async def fake_source_result(**kwargs):
+        return SourceParseResult(
+            sources=[
+                ParsedSource(
+                    label="notes.pdf",
+                    text="Sam will update the Aaron AI onboarding checklist.",
+                    kind="pdf",
+                )
+            ],
+            files_seen=1,
+            files_parsed=1,
+        )
+
+    async def timed_out_extraction(**kwargs):
+        raise _meeting_timeout_error(source_chars=8_000)
+
+    class FakeClient:
+        async def list_teams(self):
+            return []
+
+        async def list_users(self):
+            return []
+
+        async def list_active_projects(self):
+            return [{"id": "project-1", "name": "[Studio] Aaron AI"}]
+
+        async def list_issue_labels(self):
+            return []
+
+        async def list_recent_open_issues(self):
+            return []
+
+        async def create_issue(self, **kwargs):
+            write_calls.append(kwargs)
+            raise AssertionError("create_issue must not be called after extraction timeout")
+
+    class FakeSkill:
+        def get_client_class(self, name):
+            assert name == "LinearMeetingActionsClient"
+            return FakeClient
+
+    monkeypatch.setattr(executor_module, "get_settings", lambda: SimpleNamespace())
+    monkeypatch.setattr(executor, "_build_linear_meeting_source_result", fake_source_result)
+    monkeypatch.setattr(
+        executor,
+        "_extract_linear_meeting_candidates_from_sources",
+        timed_out_extraction,
+    )
+
+    result = await executor._execute_linear_meeting_actions(
+        skill=FakeSkill(),
+        text=(
+            "For Linear project [Studio] Aaron AI, extract the action items from "
+            "this transcript and assign them."
+        ),
+        params={"project_hint": "[Studio] Aaron AI"},
+        user_id="U1",
+        channel_id="C1",
+        thread_ts="1.1",
+        thread_history=[],
+        event_files=[{"id": "F1", "name": "notes.pdf"}],
+    )
+
+    assert result["data"]["timed_out"] is True
+    assert result["data"]["created_count"] == 0
+    assert result["data"]["review_count"] == 0
+    assert "before creating any Linear tasks" in result["message"]
+    assert "Nothing was changed" in result["message"]
+    assert write_calls == []
 
 
 @pytest.mark.asyncio

--- a/roo-standalone/roo/tests/test_linear_meeting_sources.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_sources.py
@@ -11,6 +11,25 @@ from roo import linear_meeting_sources as sources
 from roo import slack_client
 
 
+def test_source_text_chunks_overlap_only_when_hard_splitting_long_paragraph():
+    source = sources.ParsedSource(
+        label="notes.pdf",
+        text="A" * 12_000,
+        kind="pdf",
+    )
+
+    chunks = sources.source_text_chunks(
+        source,
+        max_chars=5_000,
+        hard_split_overlap_chars=300,
+    )
+    bodies = [chunk.split("\n", 1)[1] for chunk in chunks]
+
+    assert [len(body) for body in bodies] == [5_000, 5_000, 2_600]
+    assert bodies[0][-300:] == bodies[1][:300]
+    assert bodies[1][-300:] == bodies[2][:300]
+
+
 def test_get_thread_messages_preserves_file_metadata(monkeypatch):
     class FakeSlackClient:
         def conversations_replies(self, **kwargs):

--- a/roo-standalone/skills/linear_meeting_actions/SKILL.md
+++ b/roo-standalone/skills/linear_meeting_actions/SKILL.md
@@ -59,6 +59,7 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
 - Avoid likely duplicate open issues and make retries idempotent from Slack source evidence.
 - Use the exact `gpt-5.6-sol` model through the OpenAI Responses API for every Linear inference stage.
 - Select model reasoning effort from source length, source count, ambiguity, partial work, dependencies, artifacts, and conflicting context; never derive model effort from the XS/S/M/L/XL task label.
+- Recover a timed-out meeting-note chunk once at smaller scope while keeping the overall extraction bounded and creating no partial Linear issues.
 - For projects whose current Linear name starts exactly with `[Studio]`, estimate the remaining effort with the dedicated Studio rubric and apply exactly one compatible XS/S/M/L/XL label.
 - Ask for Slack approval when an action item is useful but not confident enough to create automatically.
 
@@ -92,11 +93,13 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
 11. For each resolved project whose current title starts exactly with `[Studio]`, read its bounded project updates, active work, terminal references, related issues, label registry, and labelled precedents. Estimate all candidates for the same project in one structured `gpt-5.6-sol` Responses API call.
 12. Estimate remaining work rather than original scope: XS is up to 15 minutes, S is up to 1 hour, M is up to 2 hours, L is up to 3 hours, and XL is up to 5 hours or has substantial uncertainty. Work over 5 hours is XL and should be split.
 13. Start direct cleanup at `low`, ordinary extraction and source summaries at `medium`, and contextual inference, project synthesis, and Studio sizing at `high`. Increase to `xhigh` when deterministic complexity signals warrant it.
-14. Retry a structured parsing or workflow-contract failure at most once with the next reasoning level. Use `max` only when that single escalation follows an `xhigh` attempt.
-15. Add the exact effort label and one-sentence rationale to the issue description and Slack preview. Never create an eligible Studio issue without exactly one valid effort label.
-16. Send an idempotency fingerprint and preserve a Slack permalink in the Linear issue.
-17. Present uncertain candidates in Slack with Approve and Reject buttons.
-18. Report created project updates, created issues, skipped duplicates, and unresolved items clearly.
+14. Treat each extracted source chunk as one inference source; track total batch chunks separately so a long PDF does not artificially increase every chunk's reasoning effort.
+15. Retry a structured parsing or workflow-contract failure at most once with the next reasoning level. Use `max` only when that single escalation follows an `xhigh` attempt.
+16. If meeting-action inference times out, retry only the failed chunk once at smaller paragraph/page-aligned scope with bounded concurrency. Finish extraction and deduplication before any issue write; if recovery or the total extraction deadline fails, create nothing and say so explicitly.
+17. Add the exact effort label and one-sentence rationale to the issue description and Slack preview. Never create an eligible Studio issue without exactly one valid effort label.
+18. Send an idempotency fingerprint and preserve a Slack permalink in the Linear issue.
+19. Present uncertain candidates in Slack with Approve and Reject buttons.
+20. Report created project updates, created issues, skipped duplicates, and unresolved items clearly.
 
 ## Creation Rules
 


### PR DESCRIPTION
## What changed

- wrap OpenAI `APITimeoutError` in a typed Linear inference timeout with structured stage, model, effort, attempt, chunk, and duration telemetry
- retry only a timed-out meeting-note chunk once at smaller paragraph/page-aligned scope, with overlap for hard splits
- process at most two extraction chunks concurrently and enforce a four-minute batch deadline
- keep extraction atomic: no Linear issue writes occur unless every chunk finishes and candidates are deduplicated
- correct adaptive reasoning so total PDF chunk count is logged separately instead of inflating every individual model request
- return a specific Slack response confirming that nothing was created when recovery fails
- document the timeout contract in the `linear-meeting-actions` skill

## Why

Production successfully loaded `[Studio] Aaron AI` Linear context, then a `gpt-5.6-sol` structured extraction request timed out. The gateway did not classify or recover `APITimeoutError`, so one slow PDF chunk aborted the whole run and Roo returned a generic skill failure before any sizing or issue-creation calls.

## Impact

Long Slack meeting-note PDFs keep using the exact `gpt-5.6-sol` model and adaptive reasoning, but a transient slow chunk can recover without restarting successful work. Repeated failures fail closed before any Linear mutations and tell the user that nothing changed.

## Validation

- `82 passed`: Linear inference, meeting sources/actions, Studio effort sizing, and LLM agent tests on Python 3.11
- repository-wide comparison: branch `668 passed, 22 failed`; untouched `origin/main` `663 passed, 22 failed` — identical unrelated failure set plus five new passing tests
- Python 3.11 compilation passed
- `git diff --check` passed