### PR TITLE
Fix Studio Linear sizing validation

### DIFF
--- a/roo-standalone/roo/linear_context.py
+++ b/roo-standalone/roo/linear_context.py
@@ -20,7 +20,10 @@ from .slack_client import (
 CONTEXTUAL_LINEAR_REFERENCE_RE = re.compile(
     r"\b(?:add|create|make|put|send|sync|turn|log|file|raise)\s+"
     r"(?:the\s+)?(?:this|that|above|previous|last|conversation|discussion|thread|message)\b"
-    r"|\b(?:request|item|task|message)\s+above\b",
+    r"|\b(?:request|item|task|message)\s+above\b"
+    r"|\b(?:using|from|based\s+on)\s+(?:this|these|the)\s+"
+    r"(?:transcript|meeting\s+notes?|notes?|summary|conversation|discussion|"
+    r"thread|message|file|document)\b",
     flags=re.IGNORECASE,
 )
 

--- a/roo-standalone/roo/linear_effort_sizing.py
+++ b/roo-standalone/roo/linear_effort_sizing.py
@@ -46,6 +46,31 @@ EffortRange = Literal[
     ">5h",
 ]
 
+_DURATION_ANCHOR_RE = re.compile(
+    r"\b(?:\d+(?:\.\d+)?\s*(?:m|min|mins|minute|minutes|h|hr|hrs|hour|hours)|"
+    r"fifteen minutes?|one hour|two hours?|three hours?|four hours?|five hours?)\b",
+    flags=re.IGNORECASE,
+)
+_EFFORT_RANGE_TIME_ANCHORS = {
+    "<=15m": "up to 15 minutes",
+    ">15m-1h": "up to 1 hour",
+    ">1h-2h": "up to 2 hours",
+    ">2h-3h": "up to 3 hours",
+    ">3h-5h": "up to 5 hours",
+    ">5h": "over 5 hours",
+}
+
+
+def _one_sentence_rationale(value: str, *, prefix: str = "") -> str:
+    text = re.sub(r"\s+", " ", str(value or "")).strip()
+    text = re.sub(r"[.!?]+(?=\s|$)", ";", text).strip(" ;.!?")
+    if prefix and text:
+        text = f"{prefix}{text[:1].lower()}{text[1:]}"
+    elif prefix:
+        text = prefix.rstrip()
+    text = text[:279].rstrip(" ;,.!?")
+    return f"{text}."
+
 
 class StudioEffortAssessment(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -63,17 +88,19 @@ class StudioEffortAssessment(BaseModel):
 
     @model_validator(mode="after")
     def validate_rubric_consistency(self):
-        if "\n" in self.rationale or len(
-            re.findall(r"[.!?](?:[\"')\]]+)?(?=\s|$)", self.rationale)
-        ) > 1:
-            raise ValueError("rationale must be one sentence")
-        if self.sizing_basis in {"duration", "both"} and not re.search(
-            r"\b(?:\d+(?:\.\d+)?\s*(?:m|min|mins|minute|minutes|h|hr|hrs|hour|hours)|"
-            r"fifteen minutes?|one hour|two hours?|three hours?|four hours?|five hours?)\b",
-            self.rationale,
-            flags=re.IGNORECASE,
+        self.rationale = _one_sentence_rationale(self.rationale)
+        if (
+            self.sizing_basis in {"duration", "both"}
+            and not _DURATION_ANCHOR_RE.search(self.rationale)
         ):
-            raise ValueError("duration-based rationale must include a time anchor")
+            self.rationale = _one_sentence_rationale(
+                self.rationale,
+                prefix=(
+                    "Estimated at "
+                    f"{_EFFORT_RANGE_TIME_ANCHORS[self.expected_effort_range]} "
+                    "because "
+                ),
+            )
         if not self.context_sufficient and not self.missing_context:
             raise ValueError("insufficient context must name what is missing")
         exact_ranges = {
@@ -171,16 +198,15 @@ Rules:
             raise LinearInferenceValidationError(
                 "Studio sizing response did not contain exactly one result per candidate."
             )
-        unknown_refs = {
-            reference
-            for assessment in assessments.values()
-            for reference in assessment.evidence_refs
-            if reference not in evidence_refs
-        }
-        if unknown_refs:
-            raise LinearInferenceValidationError(
-                "Studio sizing response cited evidence that was not supplied."
-            )
+        for assessment in assessments.values():
+            seen_refs: set[str] = set()
+            sanitized_refs: list[str] = []
+            for reference in assessment.evidence_refs:
+                if reference not in evidence_refs or reference in seen_refs:
+                    continue
+                sanitized_refs.append(reference)
+                seen_refs.add(reference)
+            assessment.evidence_refs = sanitized_refs
 
     context_collections = (
         "projectUpdates",

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -4109,6 +4109,30 @@ Return the structured action_items list."""
         action = self._normalize_match_text(params.get("action"))
         if action in {"projectupdate", "updateproject", "projectstatus"}:
             return True
+        request_text = re.sub(
+            r"\s+",
+            " ",
+            str(text or "").lower().replace("’", "'"),
+        ).strip()
+        negative_patterns = (
+            (
+                r"\b(?:do\s+not|don't|dont|never)\s+"
+                r"(?:write|create|add|post|make|include|generate|send)\s+"
+                r"(?:(?:a|the|any)\s+)?project\s+updates?\b"
+            ),
+            (
+                r"\b(?:no|not|without)\s+"
+                r"(?:(?:a|the|any)\s+)?project\s+updates?\b"
+            ),
+            (
+                r"\b(?:skip|omit|avoid)\s+"
+                r"(?:(?:writing|creating|adding|posting|making|including|"
+                r"generating|sending)\s+)?"
+                r"(?:(?:a|the|any)\s+)?project\s+updates?\b"
+            ),
+        )
+        if any(re.search(pattern, request_text) for pattern in negative_patterns):
+            return False
         normalized_text = self._normalize_match_text(text)
         if "projectupdate" not in normalized_text:
             return False

--- a/roo-standalone/roo/tests/test_linear_context.py
+++ b/roo-standalone/roo/tests/test_linear_context.py
@@ -13,6 +13,12 @@ def test_contextual_linear_reference_is_narrow():
     assert linear_context.is_contextual_linear_reference(
         "make the request above a Linear issue"
     )
+    assert linear_context.is_contextual_linear_reference(
+        (
+            "For the Linear project [Studio] Aaron AI, using this transcript "
+            "and meeting notes, add the to-do items."
+        )
+    )
     assert not linear_context.is_contextual_linear_reference(
         "create a Linear task to change the name of this project"
     )

--- a/roo-standalone/roo/tests/test_linear_effort_sizing.py
+++ b/roo-standalone/roo/tests/test_linear_effort_sizing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -126,6 +127,24 @@ def test_effort_schema_rejects_inconsistent_range_and_split():
     assert xl.split_recommended is True
 
 
+def test_effort_schema_normalizes_duration_rationale_to_one_sentence_with_time_anchor():
+    assessment = _assessment(
+        "c1",
+        rationale=(
+            "The implementation is well scoped. "
+            "The existing endpoint can be reused."
+        ),
+    )
+
+    assert assessment.rationale.startswith("Estimated at up to 1 hour because ")
+    assert assessment.rationale.endswith(".")
+    assert "\n" not in assessment.rationale
+    assert len(
+        re.findall(r"[.!?](?:[\"')\]]+)?(?=\s|$)", assessment.rationale)
+    ) == 1
+    assert len(assessment.rationale) <= 280
+
+
 @pytest.mark.asyncio
 async def test_sizing_uses_dedicated_openai_responses_configuration(monkeypatch):
     calls = []
@@ -163,6 +182,59 @@ async def test_sizing_uses_dedicated_openai_responses_configuration(monkeypatch)
     assert kwargs["reasoning_effort"] == "xhigh"
     assert kwargs["store"] is False
     assert "untrusted data" in calls[0][0][-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_sizing_discards_unsupplied_evidence_refs_without_retry(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        async def responses_parse(self, messages, response_format, **kwargs):
+            calls.append((messages, response_format, kwargs))
+            return StudioEffortAssessmentBatch(
+                assessments=[
+                    _assessment(
+                        "c1",
+                        rationale=(
+                            "The endpoint and secure sharing steps are already "
+                            "well understood."
+                        ),
+                        evidence_refs=[
+                            "c1",
+                            "invented-reference",
+                            "project-1",
+                            "invented-reference",
+                        ],
+                    )
+                ]
+            )
+
+    monkeypatch.setattr(
+        inference_module,
+        "get_llm_client",
+        lambda provider: FakeClient() if provider == "openai" else None,
+    )
+
+    result = await assess_studio_effort_batch(
+        candidates=[
+            {
+                "candidate_key": "c1",
+                "title": "Create the Aaron AI API key",
+                "remaining_work": "Create and securely share the key.",
+            }
+        ],
+        project_context={
+            "project": {"id": "project-1", "name": "[Studio] Aaron AI"}
+        },
+        context_max_chars=40_000,
+        safety_identifier="roo-linear-test",
+    )
+
+    assert result["c1"].evidence_refs == ["c1", "project-1"]
+    assert result["c1"].rationale.startswith(
+        "Estimated at up to 1 hour because "
+    )
+    assert len(calls) == 1
 
 
 @pytest.mark.asyncio

--- a/roo-standalone/roo/tests/test_linear_meeting_actions.py
+++ b/roo-standalone/roo/tests/test_linear_meeting_actions.py
@@ -67,6 +67,42 @@ def test_linear_meeting_transcript_uses_thread_history_and_message():
     assert "turn this meeting summary into Linear tasks" in transcript
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        (
+            "For the Linear project [Studio] Aaron AI, extract the to-do items "
+            "from these meeting notes. Don't write a project update."
+        ),
+        "Create the Linear tasks, but do not create a project update.",
+        "Add the to-dos to Linear without a project update.",
+        "Extract the meeting actions in Linear; skip the project update.",
+        "Create Linear issues from the transcript, not a project update.",
+    ],
+)
+def test_linear_meeting_project_update_request_honors_explicit_negation(text):
+    executor = SkillExecutor()
+
+    assert executor._linear_meeting_project_update_requested(text, {}) is False
+
+
+def test_linear_meeting_project_update_request_keeps_positive_and_explicit_actions():
+    executor = SkillExecutor()
+
+    assert executor._linear_meeting_project_update_requested(
+        "Please write a project update in Linear from these meeting notes.",
+        {},
+    )
+    assert executor._linear_meeting_project_update_requested(
+        "Don't forget to create a project update in Linear.",
+        {},
+    )
+    assert executor._linear_meeting_project_update_requested(
+        "Extract the meeting actions only.",
+        {"action": "project_update"},
+    )
+
+
 def test_linear_meeting_owner_matches_slack_mention_email(monkeypatch):
     executor = SkillExecutor()
 

--- a/roo-standalone/skills/linear_meeting_actions/SKILL.md
+++ b/roo-standalone/skills/linear_meeting_actions/SKILL.md
@@ -50,7 +50,7 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
 - For top-level commands such as "add this as a task", read a bounded slice of the preceding channel conversation on demand.
 - Create a Linear issue directly from an explicit Slack command such as "create a to do item in Linear project X and assign to Y".
 - Create an explicit, high-confidence contextual assignment in one step; keep discussion-derived follow-ups review-only.
-- Create a Linear project update when the request explicitly asks for a project update and Roo can confidently match the project.
+- Create a Linear project update only when the request affirmatively asks for one and Roo can confidently match the project; honor explicit instructions to skip, omit, or not write an update.
 - Use the latest Linear project update and recent project issues as context for concise PDF/transcript-derived project updates.
 - Download and parse `.pdf`, `.docx`, `.txt`, `.md`, `.csv`, `.png`, `.jpg`, `.jpeg`, `.webp`, and non-animated `.gif` files from the current Slack thread.
 - Inspect Linear teams, users, active projects, project members, labels, and recent open issues.
@@ -84,7 +84,7 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
    - Recent open issues for duplicate detection
 3. For explicit direct issue commands, parse the command itself as the issue source, including project and assignee hints.
 4. Otherwise, extract concrete action items into structured candidates with title, description, owner hint, project terms, due expression/date, explicit-commitment flag, evidence message timestamp, source label, and confidence.
-5. If a project update was requested, summarize all parsed source chunks, compare against the latest project update context, and create a concise Linear project update for the matched project.
+5. If a project update was affirmatively requested and not explicitly negated, summarize all parsed source chunks, compare against the latest project update context, and create a concise Linear project update for the matched project.
 6. If no concrete action item is found but the user asked to add the thread context to Linear, draft one contextual issue and require Slack approval before creation.
 7. Match owners by explicit requester/self-reference and Slack mention/email first, then unique Linear name/email-prefix match, then display/name similarity.
 8. Match projects by explicit project hint, exact name/slug, linked Slack channel, project description/content/update/recent issues, and true project membership as a tie-breaker.
@@ -96,10 +96,11 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
 14. Treat each extracted source chunk as one inference source; track total batch chunks separately so a long PDF does not artificially increase every chunk's reasoning effort.
 15. Retry a structured parsing or workflow-contract failure at most once. For a missing Studio structured response, lower reasoning effort and increase the output allowance so the model can emit the full schema; for other validation failures, use the next reasoning level.
 16. If meeting-action inference times out, retry only the failed chunk once at smaller paragraph/page-aligned scope with bounded concurrency. Finish extraction and deduplication before any issue write; if recovery or the total extraction deadline fails, create nothing and say so explicitly.
-17. If a Studio sizing batch still fails, retry its candidates individually and preserve successful assessments. Add the exact effort label and one-sentence rationale to the issue description and Slack preview. Never create an eligible Studio issue without exactly one valid effort label.
-18. Send an idempotency fingerprint and preserve a Slack permalink in the Linear issue.
-19. Present uncertain candidates in Slack with Approve and Reject buttons.
-20. Report created project updates, created issues, skipped duplicates, and unresolved items clearly.
+17. Discard duplicate or unrecognized optional evidence references without rejecting an otherwise valid Studio assessment. Normalize its rationale to one sentence and, when duration-based, add the rubric's canonical time anchor if the model omitted one.
+18. If a Studio sizing batch still fails its required candidate or rubric fields, retry its candidates individually and preserve successful assessments. Add the exact effort label and normalized one-sentence rationale to the issue description and Slack preview. Never create an eligible Studio issue without exactly one valid effort label.
+19. Send an idempotency fingerprint and preserve a Slack permalink in the Linear issue.
+20. Present uncertain candidates in Slack with Approve and Reject buttons.
+21. Report created project updates, created issues, skipped duplicates, and unresolved items clearly.
 
 ## Creation Rules
 
@@ -107,7 +108,7 @@ This skill turns pasted Slack meeting transcripts, summaries, supported Slack fi
 - Do not auto-create an issue without a high-confidence assignee and project.
 - A contextual command can auto-create only when its source contains an explicit assignment/commitment and the assignee, project, team, and due date are unambiguous.
 - Do not auto-create contextual discussion-thread issues; always request Slack approval first.
-- Project updates are created immediately when explicitly requested and the project match is confident.
+- Project updates are created immediately only when affirmatively requested, not when the request says not to write one, and the project match is confident.
 - Apply the compatible `meeting-action` label if it already exists.
 - In Studio sizing `review` or `required` mode, apply exactly one of `Extra Small (XS)`, `Small (S)`, `Medium (M)`, `Large (L)`, or `Extra Large (XL)`. Fail closed if sizing context, structured output, or the compatible label is unavailable.
 - Studio sizing `shadow` mode captures estimates without mutating issue labels or descriptions; `review` sends every Studio candidate for approval; `required` may auto-create only a high-confidence, context-sufficient assessment.


### PR DESCRIPTION
## What changed

- honor explicit instructions not to create a Linear project update
- recognize transcript and meeting-note wording as a request for surrounding Slack context
- normalize Studio effort rationales and add a canonical duration anchor when omitted
- discard invented or duplicate optional evidence references instead of rejecting a valid assessment
- update the Linear meeting-actions skill contract and add regression coverage

## Why

Production sizing rejected all eight extracted Aaron AI tasks before any Linear issue write because optional evidence references and a missing time phrase were treated as fatal validation errors. The same request also created a project update despite explicitly saying not to.

## Impact

Transcript-to-Linear requests for `[Studio]` projects can proceed with their required effort labels when the core sizing result is valid, while explicit project-update negation is respected.

## Validation

- full deployment test gate: 387 passed
- Python compile check for `roo` and `bridge`
- repository skill catalog validation
