### PR TITLE
Scope data catalog to requester

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -1690,11 +1690,14 @@ class MLAIBackendClient:
         self._raise_for_status_or_backend_unavailable(response)
         return response.json()
 
-    async def get_data_catalog(self) -> dict:
-        """Get Roo's curated read-only data resource catalog."""
+    async def get_data_catalog(self, requester_slack_id: str) -> dict:
+        """Get the requester's curated read-only data resource catalog."""
         response = await self._request(
             "GET",
             f"{self._data_base}/catalog/",
+            params={
+                "requester_slack_id": self._clean_slack_id(requester_slack_id),
+            },
             timeout=15.0,
             transport_retries=1,
             retry_backoff_seconds=0.25,

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -8555,7 +8555,7 @@ Chunk {index} source: {label}
 
         try:
             if self._data_query_catalog_requested(text, params):
-                catalog = await client.get_data_catalog()
+                catalog = await client.get_data_catalog(user_id)
                 return {
                     "message": self._format_data_catalog(catalog),
                     "data": {"action": "data_catalog", "catalog": catalog},

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -208,6 +208,7 @@ async def test_get_data_catalog_uses_canonical_endpoint(monkeypatch):
     async def fake_request(method, endpoint, **kwargs):
         captured["method"] = method
         captured["endpoint"] = endpoint
+        captured["params"] = kwargs["params"]
         request = httpx.Request(method, f"https://backend.test{endpoint}")
         return httpx.Response(200, request=request, json={"resources": [{"key": "vibe_raising_companies"}]})
 
@@ -218,11 +219,12 @@ async def test_get_data_catalog_uses_canonical_endpoint(monkeypatch):
     )
     monkeypatch.setattr(client, "_request", fake_request)
 
-    result = await client.get_data_catalog()
+    result = await client.get_data_catalog("<@U123>")
 
     assert result == {"resources": [{"key": "vibe_raising_companies"}]}
     assert captured["method"] == "GET"
     assert captured["endpoint"] == "/api/v1/data/catalog/"
+    assert captured["params"] == {"requester_slack_id": "U123"}
 
 
 @pytest.mark.asyncio

--- a/roo-standalone/roo/tests/test_mlai_data_query.py
+++ b/roo-standalone/roo/tests/test_mlai_data_query.py
@@ -35,15 +35,15 @@ class FakeDataBackendClient:
         "offset": 0,
         "has_more": False,
     }
-    catalog_calls = 0
+    catalog_requesters = []
     queries = []
     last_init = None
 
     def __init__(self, *args, **kwargs):
         self.__class__.last_init = {"args": args, "kwargs": kwargs}
 
-    async def get_data_catalog(self):
-        self.__class__.catalog_calls += 1
+    async def get_data_catalog(self, requester_slack_id):
+        self.__class__.catalog_requesters.append(requester_slack_id)
         return self.catalog
 
     async def query_data(self, payload):
@@ -69,7 +69,7 @@ def _reset_fake_client():
         "offset": 0,
         "has_more": False,
     }
-    FakeDataBackendClient.catalog_calls = 0
+    FakeDataBackendClient.catalog_requesters = []
     FakeDataBackendClient.queries = []
     FakeDataBackendClient.last_init = None
 
@@ -88,7 +88,7 @@ async def test_data_query_catalog_calls_backend_catalog(monkeypatch):
         user_id="U123",
     )
 
-    assert FakeDataBackendClient.catalog_calls == 1
+    assert FakeDataBackendClient.catalog_requesters == ["U123"]
     assert FakeDataBackendClient.queries == []
     assert "Available data resources" in result["message"]
     assert "`vibe_raising_companies`" in result["message"]
@@ -133,7 +133,7 @@ async def test_data_query_specific_count_beats_bad_catalog_param(monkeypatch):
         user_id="U123",
     )
 
-    assert FakeDataBackendClient.catalog_calls == 0
+    assert FakeDataBackendClient.catalog_requesters == []
     assert FakeDataBackendClient.queries == [
         {
             "requester_slack_id": "U123",

--- a/roo-standalone/skills/mlai_data_query/SKILL.md
+++ b/roo-standalone/skills/mlai_data_query/SKILL.md
@@ -39,10 +39,12 @@ Use this skill when a Slack user asks Roo to read curated backend data across th
 
 Roo must not write data and must not send SQL. It calls the backend's read-only data access API:
 
-- `GET /api/v1/data/catalog/`
+- `GET /api/v1/data/catalog/?requester_slack_id=<actual Slack user ID>`
 - `POST /api/v1/data/query/`
 
 The backend registry is the security contract. Each resource has explicit allow-listed fields, supported operations, filters, ordering, pagination limits, and role-scoped policies. There is no "admin bypass all" mode.
+The catalog uses the same requester identity and policies, so it only includes
+resources, operations, and fields the requesting Slack user can query.
 
 ## Parameters
 


### PR DESCRIPTION
## What changed

- pass the actual Slack requester ID when Roo fetches the data catalog
- keep catalog identity tied to the Slack event rather than prompt text
- update client, executor, tests, and skill documentation for the requester-scoped backend contract

## Why

The catalog previously described every registered resource even when the requesting user could not query it. This made the catalog misleading and exposed internal resource and field names.

## Impact

After the companion backend change is deployed, Slack users see only resources, operations, and allow-listed fields available to their effective role and row scope.

## Validation

- 36 focused Roo routing, catalog, client, and agent tests passed
- `git diff --check` passed

## Deployment

Merge/deploy this Roo change before the companion backend change so rolling deployments remain compatible.