### PR TITLE
Moderate paid boost channel posts

### DIFF
--- a/roo-standalone/.env.example
+++ b/roo-standalone/.env.example
@@ -3,6 +3,11 @@
 # Slack
 SLACK_BOT_TOKEN=xoxb-your-slack-bot-token
 SLACK_SIGNING_SECRET=your-slack-signing-secret
+# Dedicated Workspace Admin user credential used only to remove rejected
+# #boost-my-startup roots. Never place this token in Admin Roo.
+SLACK_MODERATOR_USER_TOKEN=
+SLACK_MODERATOR_USER_ID=
+SLACK_MODERATOR_TEAM_ID=
 SLACK_REQUEST_MAX_AGE_SECONDS=300
 SLACK_RECEIPT_TTL_SECONDS=600
 SLACK_RECEIPTS_DB_PATH=data/slack_request_receipts.db
@@ -87,6 +92,25 @@ COWORKING_RETRY_POLL_SECONDS=30
 ROO_POINTS_TOPUP_ENABLED=false
 ROO_POINTS_TOPUP_BUTTONS_ENABLED=false
 ROO_POINTS_STRIPE_CHECKOUT_HOSTS=checkout.stripe.com
+
+# #boost-my-startup rewards and paid root-post admission.
+BOOST_LINK_LOVE_ENABLED=true
+BOOST_LINK_LOVE_CHANNEL_NAME=boost-my-startup
+BOOST_LINK_LOVE_CHANNEL_ID=
+BOOST_LINK_LOVE_DB_PATH=data/link_love_awards.db
+BOOST_LINK_LOVE_NOTIFICATION_DELAY_SECONDS=60
+BOOST_LINK_LOVE_RETRY_POLL_SECONDS=15
+BOOST_LINK_LOVE_MAX_RETRY_ATTEMPTS=5
+BOOST_LINK_LOVE_MAX_ROOT_AGE_DAYS=7
+
+# Enable both only after the backend admission endpoint is deployed. Set the
+# cutoff to the activation Slack timestamp so existing roots remain eligible.
+BOOST_POST_MODERATION_ENABLED=false
+BOOST_POST_AUTO_DELETE_ENABLED=false
+BOOST_POST_ENFORCEMENT_CUTOFF_TS=
+BOOST_POST_DECISION_TIMEOUT_SECONDS=30
+BOOST_POST_RETRY_POLL_SECONDS=15
+BOOST_POST_MAX_RETRY_ATTEMPTS=5
 
 # Daily jobs scheduler
 # Recommended production setup: keep this disabled in Roo and let

--- a/roo-standalone/roo/boost_moderation.py
+++ b/roo-standalone/roo/boost_moderation.py
@@ -1,0 +1,884 @@
+"""Durable admission and moderation for direct boost-channel root posts.
+
+Slack publishes member messages before Roo sees them. This module records that
+published root, asks mlai-backend to atomically price/debit it, and only then
+marks the campaign approved. Rejected roots can be removed by the separate,
+allowlisted Workspace Admin client in :mod:`roo.slack_moderation`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import threading
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import httpx
+
+from .clients.mlai_backend import MLAIBackendClient, MLAIBackendUnavailableError
+from .config import get_settings
+from .link_love import extract_social_post_url
+
+DEFAULT_PROCESSING_LEASE_SECONDS = 90.0
+TERMINAL_REJECTION_STATUSES = {
+    "rejected_insufficient_points",
+    "rejected_member_unlinked",
+    "rejected_invalid",
+    "deleted",
+    "delete_failed",
+    "removed_by_author",
+    "blocked",
+}
+RETRYABLE_STATUSES = {"pending", "retry"}
+
+
+def _now() -> float:
+    return time.time()
+
+
+def boost_post_submission_key(
+    workspace_id: str,
+    channel_id: str,
+    root_message_ts: str,
+) -> str:
+    return f"boost-post:{workspace_id}:{channel_id}:{root_message_ts}"
+
+
+def _retry_delay(attempt_count: int) -> float:
+    return min(15 * 60, 15 * (2 ** max(0, int(attempt_count or 1) - 1)))
+
+
+class BoostPostAdmissionStore:
+    """SQLite outbox/ledger for Slack-side boost admission state."""
+
+    def __init__(self, db_path: str | Path):
+        self.db_path = Path(db_path)
+        self._lock = threading.RLock()
+        self._initialized = False
+
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(self.db_path), timeout=30, isolation_level=None)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA busy_timeout=30000")
+        return conn
+
+    def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+        with self._lock:
+            if self._initialized:
+                return
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS boost_post_admissions (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        submission_key TEXT NOT NULL UNIQUE,
+                        workspace_id TEXT NOT NULL,
+                        channel_id TEXT NOT NULL,
+                        root_message_ts TEXT NOT NULL,
+                        poster_slack_id TEXT NOT NULL,
+                        root_text TEXT,
+                        social_post_url TEXT,
+                        status TEXT NOT NULL,
+                        attempt_count INTEGER NOT NULL DEFAULT 0,
+                        next_attempt_at REAL NOT NULL,
+                        locked_until REAL,
+                        locked_by TEXT,
+                        backend_admission_id TEXT,
+                        base_cost_points INTEGER,
+                        charged_points INTEGER,
+                        discount_applied INTEGER,
+                        new_balance INTEGER,
+                        backend_result_json TEXT,
+                        rejection_reason TEXT,
+                        last_error TEXT,
+                        pending_notified_at REAL,
+                        decision_notified_at REAL,
+                        dm_notified_at REAL,
+                        deleted_at REAL,
+                        created_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        UNIQUE(channel_id, root_message_ts)
+                    )
+                    """
+                )
+                columns = {
+                    str(row[1])
+                    for row in conn.execute("PRAGMA table_info(boost_post_admissions)").fetchall()
+                }
+                if "pending_notified_at" not in columns:
+                    conn.execute(
+                        "ALTER TABLE boost_post_admissions ADD COLUMN pending_notified_at REAL"
+                    )
+                conn.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS idx_boost_post_admissions_due
+                    ON boost_post_admissions (status, next_attempt_at)
+                    """
+                )
+            self._initialized = True
+
+    @staticmethod
+    def _row(row: sqlite3.Row | None) -> dict[str, Any] | None:
+        return dict(row) if row is not None else None
+
+    def get(self, channel_id: str, root_message_ts: str) -> dict[str, Any] | None:
+        self._ensure_schema()
+        with self._connect() as conn:
+            return self._row(
+                conn.execute(
+                    """SELECT * FROM boost_post_admissions
+                       WHERE channel_id = ? AND root_message_ts = ?""",
+                    (channel_id, root_message_ts),
+                ).fetchone()
+            )
+
+    def record_root(
+        self,
+        *,
+        workspace_id: str,
+        channel_id: str,
+        root_message_ts: str,
+        poster_slack_id: str,
+        root_text: str,
+        social_post_url: str,
+    ) -> dict[str, Any]:
+        self._ensure_schema()
+        now = _now()
+        key = boost_post_submission_key(workspace_id, channel_id, root_message_ts)
+        with self._lock, self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO boost_post_admissions (
+                    submission_key, workspace_id, channel_id, root_message_ts,
+                    poster_slack_id, root_text, social_post_url, status,
+                    next_attempt_at, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?)
+                """,
+                (
+                    key,
+                    workspace_id,
+                    channel_id,
+                    root_message_ts,
+                    poster_slack_id,
+                    root_text,
+                    social_post_url,
+                    now,
+                    now,
+                    now,
+                ),
+            )
+            row = conn.execute(
+                """SELECT * FROM boost_post_admissions
+                   WHERE channel_id = ? AND root_message_ts = ?""",
+                (channel_id, root_message_ts),
+            ).fetchone()
+            conn.execute("COMMIT")
+        result = self._row(row)
+        if result is None:
+            raise RuntimeError("Failed to record boost post admission")
+        return result
+
+    def update_root_text(
+        self,
+        *,
+        channel_id: str,
+        root_message_ts: str,
+        root_text: str,
+        social_post_url: str,
+    ) -> dict[str, Any] | None:
+        self._ensure_schema()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE boost_post_admissions
+                SET root_text = ?, social_post_url = ?, updated_at = ?
+                WHERE channel_id = ? AND root_message_ts = ?
+                """,
+                (root_text, social_post_url, _now(), channel_id, root_message_ts),
+            )
+        return self.get(channel_id, root_message_ts)
+
+    def claim_one(
+        self,
+        admission_id: int,
+        *,
+        owner: str,
+        lease_seconds: float = DEFAULT_PROCESSING_LEASE_SECONDS,
+    ) -> dict[str, Any] | None:
+        self._ensure_schema()
+        now = _now()
+        with self._lock, self._connect() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            row = conn.execute(
+                """
+                SELECT * FROM boost_post_admissions
+                WHERE id = ?
+                  AND (
+                    (status IN ('pending', 'retry') AND next_attempt_at <= ?)
+                    OR (status = 'processing' AND COALESCE(locked_until, 0) <= ?)
+                  )
+                """,
+                (int(admission_id), now, now),
+            ).fetchone()
+            if row is None:
+                conn.execute("COMMIT")
+                return None
+            conn.execute(
+                """
+                UPDATE boost_post_admissions
+                SET status = 'processing', attempt_count = attempt_count + 1,
+                    locked_by = ?, locked_until = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (owner, now + max(10.0, float(lease_seconds)), now, int(admission_id)),
+            )
+            claimed = conn.execute(
+                "SELECT * FROM boost_post_admissions WHERE id = ?",
+                (int(admission_id),),
+            ).fetchone()
+            conn.execute("COMMIT")
+        return self._row(claimed)
+
+    def claim_due(self, *, limit: int, owner: str) -> list[dict[str, Any]]:
+        self._ensure_schema()
+        now = _now()
+        with self._connect() as conn:
+            ids = [
+                int(row[0])
+                for row in conn.execute(
+                    """
+                    SELECT id FROM boost_post_admissions
+                    WHERE (status IN ('pending', 'retry') AND next_attempt_at <= ?)
+                       OR (status = 'processing' AND COALESCE(locked_until, 0) <= ?)
+                    ORDER BY next_attempt_at, id
+                    LIMIT ?
+                    """,
+                    (now, now, max(1, int(limit))),
+                ).fetchall()
+            ]
+        claimed = [self.claim_one(row_id, owner=owner) for row_id in ids]
+        return [row for row in claimed if row is not None]
+
+    def mark_approved(self, admission_id: int, result: dict[str, Any]) -> dict[str, Any]:
+        self._ensure_schema()
+        now = _now()
+        charged = int(result.get("charged_points") or result.get("points_charged") or 0)
+        if charged not in {4, 8}:
+            raise ValueError("Boost admission returned an unexpected charged_points value")
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE boost_post_admissions
+                SET status = 'approved', locked_by = NULL, locked_until = NULL,
+                    backend_admission_id = ?, base_cost_points = ?, charged_points = ?,
+                    discount_applied = ?, new_balance = ?, backend_result_json = ?,
+                    rejection_reason = NULL, last_error = NULL, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    str(result.get("admission_id") or result.get("id") or ""),
+                    int(result.get("base_cost_points") or 8),
+                    charged,
+                    1 if bool(result.get("discount_applied")) else 0,
+                    result.get("new_balance"),
+                    json.dumps(result, sort_keys=True, default=str),
+                    now,
+                    int(admission_id),
+                ),
+            )
+        return self.get_by_id(admission_id)
+
+    def mark_rejected(
+        self,
+        admission_id: int,
+        *,
+        status: str,
+        reason: str,
+        result: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        if status not in {
+            "rejected_insufficient_points",
+            "rejected_member_unlinked",
+            "rejected_invalid",
+        }:
+            raise ValueError("Invalid boost rejection status")
+        self._ensure_schema()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE boost_post_admissions
+                SET status = ?, locked_by = NULL, locked_until = NULL,
+                    rejection_reason = ?, backend_result_json = ?, updated_at = ?
+                    , decision_notified_at = NULL, dm_notified_at = NULL
+                WHERE id = ?
+                """,
+                (
+                    status,
+                    reason,
+                    json.dumps(result, sort_keys=True, default=str) if result else None,
+                    _now(),
+                    int(admission_id),
+                ),
+            )
+        return self.get_by_id(admission_id)
+
+    def mark_retry(
+        self,
+        admission_id: int,
+        *,
+        error: str,
+        max_attempts: int,
+    ) -> dict[str, Any]:
+        row = self.get_by_id(admission_id)
+        attempt_count = int(row.get("attempt_count") or 0)
+        status = "blocked" if attempt_count >= max(1, int(max_attempts)) else "retry"
+        self._ensure_schema()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE boost_post_admissions
+                SET status = ?, next_attempt_at = ?, locked_by = NULL,
+                    locked_until = NULL, last_error = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (
+                    status,
+                    _now() + _retry_delay(attempt_count),
+                    error[:1000],
+                    _now(),
+                    int(admission_id),
+                ),
+            )
+        return self.get_by_id(admission_id)
+
+    def mark_notification(self, admission_id: int, *, dm: bool = False) -> None:
+        column = "dm_notified_at" if dm else "decision_notified_at"
+        self._ensure_schema()
+        with self._connect() as conn:
+            conn.execute(
+                f"UPDATE boost_post_admissions SET {column} = ?, updated_at = ? WHERE id = ?",
+                (_now(), _now(), int(admission_id)),
+            )
+
+    def mark_pending_notification(self, admission_id: int) -> None:
+        self._ensure_schema()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE boost_post_admissions
+                SET pending_notified_at = ?, updated_at = ?
+                WHERE id = ?
+                """,
+                (_now(), _now(), int(admission_id)),
+            )
+
+    def mark_deleted(
+        self,
+        admission_id: int,
+        *,
+        ok: bool,
+        error: str | None = None,
+    ) -> dict[str, Any]:
+        self._ensure_schema()
+        status = "deleted" if ok else "delete_failed"
+        now = _now()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE boost_post_admissions
+                SET status = ?, deleted_at = ?, last_error = COALESCE(?, last_error), updated_at = ?
+                WHERE id = ?
+                """,
+                (status, now if ok else None, error, now, int(admission_id)),
+            )
+        return self.get_by_id(admission_id)
+
+    def mark_removed(self, channel_id: str, root_message_ts: str) -> dict[str, Any] | None:
+        self._ensure_schema()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                UPDATE boost_post_admissions
+                SET status = 'removed_by_author', locked_by = NULL, locked_until = NULL,
+                    updated_at = ?
+                WHERE channel_id = ? AND root_message_ts = ? AND status != 'deleted'
+                """,
+                (_now(), channel_id, root_message_ts),
+            )
+        return self.get(channel_id, root_message_ts)
+
+    def get_by_id(self, admission_id: int) -> dict[str, Any]:
+        self._ensure_schema()
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT * FROM boost_post_admissions WHERE id = ?",
+                (int(admission_id),),
+            ).fetchone()
+        result = self._row(row)
+        if result is None:
+            raise KeyError(f"Unknown boost admission {admission_id}")
+        return result
+
+
+_stores: dict[str, BoostPostAdmissionStore] = {}
+_stores_lock = threading.RLock()
+
+
+def get_boost_post_store() -> BoostPostAdmissionStore:
+    settings = get_settings()
+    db_path = str(getattr(settings, "BOOST_LINK_LOVE_DB_PATH", "data/link_love_awards.db"))
+    with _stores_lock:
+        if db_path not in _stores:
+            _stores[db_path] = BoostPostAdmissionStore(db_path)
+        return _stores[db_path]
+
+
+def boost_reward_admission_decision(
+    channel_id: str,
+    root_message_ts: str,
+    *,
+    store: BoostPostAdmissionStore | None = None,
+) -> str:
+    """Return ``legacy``, ``approved``, ``pending``, or ``rejected``."""
+
+    try:
+        settings = get_settings()
+    except (RuntimeError, ValueError):
+        # Direct library/test callers may run without an application Settings
+        # instance. The production app validates Settings before any worker or
+        # Slack event starts, so no enabled enforcement deployment reaches this
+        # compatibility path.
+        return "legacy"
+    if not bool(getattr(settings, "BOOST_POST_MODERATION_ENABLED", False)):
+        return "legacy"
+    if channel_id != str(getattr(settings, "BOOST_LINK_LOVE_CHANNEL_ID", "") or ""):
+        return "rejected"
+    try:
+        cutoff = float(str(getattr(settings, "BOOST_POST_ENFORCEMENT_CUTOFF_TS", "") or "0"))
+        root_ts = float(root_message_ts)
+    except (TypeError, ValueError):
+        return "rejected"
+    if root_ts < cutoff:
+        return "legacy"
+    admission = (store or get_boost_post_store()).get(channel_id, root_message_ts)
+    if not admission:
+        return "pending"
+    status = str(admission.get("status") or "")
+    if status == "approved":
+        return "approved"
+    if status in TERMINAL_REJECTION_STATUSES:
+        return "rejected"
+    return "pending"
+
+
+def _backend_error_payload(exc: Exception) -> tuple[str, dict[str, Any]]:
+    if not isinstance(exc, httpx.HTTPStatusError) or exc.response is None:
+        return "", {}
+    try:
+        payload = exc.response.json()
+    except ValueError:
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+    code = str(
+        payload.get("code")
+        or payload.get("error_code")
+        or payload.get("error")
+        or ""
+    ).strip().lower()
+    return code, payload
+
+
+def _rejection_from_code(code: str, payload: dict[str, Any]) -> tuple[str, str] | None:
+    normalized = code.replace("-", "_").replace(" ", "_")
+    reason = str(payload.get("message") or payload.get("detail") or code or "Post rejected")
+    if normalized in {"insufficient_points", "insufficient_balance", "not_enough_points"}:
+        return "rejected_insufficient_points", reason
+    if normalized in {"member_unlinked", "slack_user_not_found", "member_not_found"}:
+        return "rejected_member_unlinked", reason
+    if normalized in {"invalid_post", "invalid_social_url", "ineligible_post"}:
+        return "rejected_invalid", reason
+    return None
+
+
+def _approval_notice(admission: dict[str, Any]) -> str:
+    charged = int(admission.get("charged_points") or 0)
+    balance = admission.get("new_balance")
+    discount = bool(admission.get("discount_applied"))
+    discount_text = " Your Australian startup monthly-update discount was applied." if discount else ""
+    balance_text = f" New balance: {balance}." if balance is not None else ""
+    return f":white_check_mark: Approved — {charged} Roo points deducted.{discount_text}{balance_text}"
+
+
+def _rejection_notice(admission: dict[str, Any]) -> str:
+    poster = str(admission.get("poster_slack_id") or "")
+    status = str(admission.get("status") or "")
+    if status == "rejected_insufficient_points":
+        return (
+            f"<@{poster}> this boost was not approved because you do not have enough Roo points. "
+            "I will remove the post; earn or top up points, then post it again."
+        )
+    if status == "rejected_member_unlinked":
+        return (
+            f"<@{poster}> I could not connect this Slack account to a Roo points account. "
+            "I will remove the post; link your account, then try again."
+        )
+    return f"<@{poster}> this post is not eligible for boosting, so I will remove it."
+
+
+def _post_decision_notice(
+    admission: dict[str, Any],
+    *,
+    store: BoostPostAdmissionStore,
+    text: str,
+    post_message_fn: Callable[..., Any] | None = None,
+) -> None:
+    if admission.get("decision_notified_at") is not None:
+        return
+    if post_message_fn is None:
+        from .slack_client import post_message
+
+        post_message_fn = post_message
+    try:
+        post_message_fn(
+            channel=str(admission["channel_id"]),
+            thread_ts=str(admission["root_message_ts"]),
+            text=text,
+        )
+        store.mark_notification(int(admission["id"]))
+    except Exception as exc:  # noqa: BLE001 - Slack SDK errors vary by transport.
+        print(
+            "BOOST_POST_NOTICE_FAILED "
+            f"admission_id={admission.get('id')} error_type={exc.__class__.__name__}"
+        )
+
+
+def _post_pending_notice(
+    admission: dict[str, Any],
+    *,
+    store: BoostPostAdmissionStore,
+    post_message_fn: Callable[..., Any] | None = None,
+) -> None:
+    if admission.get("pending_notified_at") is not None:
+        return
+    if post_message_fn is None:
+        from .slack_client import post_message
+
+        post_message_fn = post_message
+    try:
+        post_message_fn(
+            channel=str(admission["channel_id"]),
+            thread_ts=str(admission["root_message_ts"]),
+            text=(
+                f"<@{admission['poster_slack_id']}> approval is pending while I verify the "
+                "Roo points charge. Please wait for an approved message before anyone engages."
+            ),
+        )
+        store.mark_pending_notification(int(admission["id"]))
+    except Exception as exc:  # noqa: BLE001 - Slack SDK errors vary by transport.
+        print(
+            "BOOST_POST_PENDING_NOTICE_FAILED "
+            f"admission_id={admission.get('id')} error_type={exc.__class__.__name__}"
+        )
+
+
+def _dm_rejection(
+    admission: dict[str, Any],
+    *,
+    store: BoostPostAdmissionStore,
+    text: str,
+    send_dm_fn: Callable[..., Any] | None = None,
+) -> None:
+    if admission.get("dm_notified_at") is not None:
+        return
+    if send_dm_fn is None:
+        from .slack_client import send_dm
+
+        send_dm_fn = send_dm
+    try:
+        send_dm_fn(str(admission["poster_slack_id"]), text)
+        store.mark_notification(int(admission["id"]), dm=True)
+    except Exception as exc:  # noqa: BLE001 - Slack SDK errors vary by transport.
+        print(
+            "BOOST_POST_DM_FAILED "
+            f"admission_id={admission.get('id')} error_type={exc.__class__.__name__}"
+        )
+
+
+def _moderate_rejected_root(
+    admission: dict[str, Any],
+    *,
+    store: BoostPostAdmissionStore,
+    delete_fn: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    settings = get_settings()
+    if not bool(getattr(settings, "BOOST_POST_AUTO_DELETE_ENABLED", False)):
+        return admission
+    if delete_fn is None:
+        from .slack_moderation import delete_boost_root_as_moderator
+
+        delete_fn = delete_boost_root_as_moderator
+    result = delete_fn(
+        channel_id=str(admission["channel_id"]),
+        message_ts=str(admission["root_message_ts"]),
+        reason_code=str(admission["status"]),
+    )
+    return store.mark_deleted(
+        int(admission["id"]),
+        ok=bool(getattr(result, "ok", False)),
+        error=getattr(result, "error_code", None),
+    )
+
+
+async def process_boost_post_admission(
+    admission: dict[str, Any],
+    *,
+    store: BoostPostAdmissionStore | None = None,
+    client: Any = None,
+    claimed: bool = False,
+    owner: str | None = None,
+    post_message_fn: Callable[..., Any] | None = None,
+    send_dm_fn: Callable[..., Any] | None = None,
+    delete_fn: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    store = store or get_boost_post_store()
+    settings = get_settings()
+    worker = owner or f"roo-boost-{uuid4().hex}"
+    current = admission if claimed else store.claim_one(int(admission["id"]), owner=worker)
+    if current is None:
+        return {"status": "not_due"}
+    client = client or MLAIBackendClient()
+    try:
+        result = await client.admit_boost_post(
+            submission_key=str(current["submission_key"]),
+            workspace_id=str(current["workspace_id"]),
+            channel_id=str(current["channel_id"]),
+            root_message_ts=str(current["root_message_ts"]),
+            poster_slack_id=str(current["poster_slack_id"]),
+            root_text=str(current.get("root_text") or ""),
+            social_post_url=str(current.get("social_post_url") or ""),
+            timeout=float(getattr(settings, "BOOST_POST_DECISION_TIMEOUT_SECONDS", 30.0)),
+        )
+        backend_status = str(result.get("status") or "approved").strip().lower()
+        if backend_status in {"approved", "charged", "already_approved"}:
+            approved = store.mark_approved(int(current["id"]), result)
+            _post_decision_notice(
+                approved,
+                store=store,
+                text=_approval_notice(approved),
+                post_message_fn=post_message_fn,
+            )
+            return {"status": "approved", "admission": store.get_by_id(int(current["id"]))}
+        rejection = _rejection_from_code(backend_status, result)
+        if rejection is None:
+            raise ValueError(f"Unexpected boost admission status: {backend_status}")
+        rejected = store.mark_rejected(
+            int(current["id"]), status=rejection[0], reason=rejection[1], result=result
+        )
+    except Exception as exc:  # noqa: BLE001 - backend errors are classified below.
+        code, payload = _backend_error_payload(exc)
+        rejection = _rejection_from_code(code, payload)
+        if rejection is not None:
+            rejected = store.mark_rejected(
+                int(current["id"]), status=rejection[0], reason=rejection[1], result=payload
+            )
+        else:
+            retryable = isinstance(
+                exc,
+                (MLAIBackendUnavailableError, httpx.TransportError, httpx.TimeoutException),
+            ) or (isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code >= 500)
+            error = f"{exc.__class__.__name__}: {exc}"
+            updated = store.mark_retry(
+                int(current["id"]),
+                error=error,
+                max_attempts=int(getattr(settings, "BOOST_POST_MAX_RETRY_ATTEMPTS", 5)),
+            )
+            print(
+                "BOOST_POST_ADMISSION_RETRY "
+                f"admission_id={current.get('id')} status={updated.get('status')} "
+                f"retryable={retryable} error_type={exc.__class__.__name__}"
+            )
+            _post_pending_notice(
+                updated,
+                store=store,
+                post_message_fn=post_message_fn,
+            )
+            refreshed = store.get_by_id(int(updated["id"]))
+            if refreshed["status"] == "blocked" and refreshed.get("dm_notified_at") is None:
+                _dm_rejection(
+                    refreshed,
+                    store=store,
+                    text=(
+                        "I could not confirm the Roo points charge after several attempts. "
+                        "Your boost remains unapproved and helper rewards are blocked. "
+                        "Please contact a Roo admin before reposting."
+                    ),
+                    send_dm_fn=send_dm_fn,
+                )
+                refreshed = store.get_by_id(int(updated["id"]))
+            return {"status": str(refreshed["status"]), "admission": refreshed, "error": error}
+
+    notice = _rejection_notice(rejected)
+    _post_decision_notice(
+        rejected, store=store, text=notice, post_message_fn=post_message_fn
+    )
+    refreshed = store.get_by_id(int(rejected["id"]))
+    _dm_rejection(refreshed, store=store, text=notice, send_dm_fn=send_dm_fn)
+    refreshed = store.get_by_id(int(rejected["id"]))
+    moderated = _moderate_rejected_root(refreshed, store=store, delete_fn=delete_fn)
+    return {"status": str(moderated["status"]), "admission": moderated}
+
+
+async def handle_boost_root_post(
+    event: dict[str, Any],
+    *,
+    workspace_id: str,
+    store: BoostPostAdmissionStore | None = None,
+    client: Any = None,
+    **process_kwargs: Any,
+) -> dict[str, Any]:
+    settings = get_settings()
+    if not bool(getattr(settings, "BOOST_POST_MODERATION_ENABLED", False)):
+        return {"status": "ignored", "reason": "moderation_disabled"}
+    if event.get("thread_ts") or event.get("bot_id") or event.get("subtype"):
+        return {"status": "ignored", "reason": "not_human_root"}
+    channel_id = str(event.get("channel") or "").strip()
+    root_message_ts = str(event.get("ts") or "").strip()
+    poster_slack_id = str(event.get("user") or "").strip()
+    if channel_id != str(getattr(settings, "BOOST_LINK_LOVE_CHANNEL_ID", "") or ""):
+        return {"status": "ignored", "reason": "wrong_channel"}
+    if not workspace_id or not root_message_ts or not poster_slack_id:
+        return {"status": "ignored", "reason": "missing_required_event_fields"}
+    try:
+        if float(root_message_ts) < float(settings.BOOST_POST_ENFORCEMENT_CUTOFF_TS):
+            return {"status": "ignored", "reason": "before_enforcement_cutoff"}
+    except (TypeError, ValueError):
+        return {"status": "ignored", "reason": "invalid_message_ts"}
+
+    root_text = str(event.get("text") or "")
+    store = store or get_boost_post_store()
+    admission = store.record_root(
+        workspace_id=workspace_id,
+        channel_id=channel_id,
+        root_message_ts=root_message_ts,
+        poster_slack_id=poster_slack_id,
+        root_text=root_text,
+        social_post_url=extract_social_post_url(root_text) or "",
+    )
+    return await process_boost_post_admission(
+        admission,
+        store=store,
+        client=client,
+        **process_kwargs,
+    )
+
+
+async def handle_boost_root_edit(
+    event: dict[str, Any],
+    *,
+    store: BoostPostAdmissionStore | None = None,
+    post_message_fn: Callable[..., Any] | None = None,
+    send_dm_fn: Callable[..., Any] | None = None,
+    delete_fn: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    message = event.get("message") or {}
+    channel_id = str(event.get("channel") or "")
+    root_ts = str(message.get("ts") or "")
+    if not channel_id or not root_ts or message.get("thread_ts"):
+        return {"status": "ignored"}
+    text = str(message.get("text") or "")
+    store = store or get_boost_post_store()
+    admission = store.get(channel_id, root_ts)
+    if admission is None:
+        return {"status": "ignored", "reason": "unknown_root"}
+    old_url = str(admission.get("social_post_url") or "")
+    new_url = extract_social_post_url(text) or ""
+    updated = store.update_root_text(
+        channel_id=channel_id,
+        root_message_ts=root_ts,
+        root_text=text,
+        social_post_url=new_url,
+    )
+    if str(admission.get("status") or "") == "approved" and new_url != old_url:
+        rejected = store.mark_rejected(
+            int(admission["id"]),
+            status="rejected_invalid",
+            reason="approved boost root changed its social post URL",
+        )
+        notice = (
+            f"<@{rejected['poster_slack_id']}> the approved link was changed. "
+            "To prevent a paid boost being swapped for a different post, I will remove this root. "
+            "Post the new link separately for a new approval."
+        )
+        _post_decision_notice(
+            rejected,
+            store=store,
+            text=notice,
+            post_message_fn=post_message_fn,
+        )
+        refreshed = store.get_by_id(int(rejected["id"]))
+        _dm_rejection(refreshed, store=store, text=notice, send_dm_fn=send_dm_fn)
+        moderated = _moderate_rejected_root(
+            store.get_by_id(int(rejected["id"])),
+            store=store,
+            delete_fn=delete_fn,
+        )
+        return {"status": str(moderated["status"]), "admission": moderated}
+    return {"status": "updated", "admission": updated}
+
+
+def mark_boost_root_removed(
+    channel_id: str,
+    root_message_ts: str,
+    *,
+    store: BoostPostAdmissionStore | None = None,
+) -> dict[str, Any] | None:
+    return (store or get_boost_post_store()).mark_removed(channel_id, root_message_ts)
+
+
+async def process_due_boost_posts_once(
+    *,
+    store: BoostPostAdmissionStore | None = None,
+    client: Any = None,
+    limit: int = 20,
+    **process_kwargs: Any,
+) -> list[dict[str, Any]]:
+    store = store or get_boost_post_store()
+    owner = f"roo-boost-worker-{uuid4().hex}"
+    claimed = store.claim_due(limit=limit, owner=owner)
+    results = []
+    for admission in claimed:
+        results.append(
+            await process_boost_post_admission(
+                admission,
+                store=store,
+                client=client,
+                claimed=True,
+                owner=owner,
+                **process_kwargs,
+            )
+        )
+    return results
+
+
+async def boost_post_retry_loop() -> None:
+    settings = get_settings()
+    poll_seconds = max(1.0, float(getattr(settings, "BOOST_POST_RETRY_POLL_SECONDS", 15.0)))
+    while True:
+        try:
+            await process_due_boost_posts_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - keep the durable worker alive.
+            print(f"BOOST_POST_WORKER_ERROR error_type={exc.__class__.__name__}")
+        await asyncio.sleep(poll_seconds)

--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -2966,6 +2966,40 @@ class MLAIBackendClient:
         response.raise_for_status()
         return response.json()
 
+    async def admit_boost_post(
+        self,
+        *,
+        submission_key: str,
+        workspace_id: str,
+        channel_id: str,
+        root_message_ts: str,
+        poster_slack_id: str,
+        root_text: str,
+        social_post_url: Optional[str] = None,
+        timeout: float = 30.0,
+    ) -> dict:
+        """Atomically price and debit one boost post in mlai-backend."""
+
+        payload = {
+            "submission_key": str(submission_key),
+            "workspace_id": str(workspace_id),
+            "channel_id": str(channel_id),
+            "root_message_ts": str(root_message_ts),
+            "poster_slack_id": self._clean_slack_id(poster_slack_id),
+            "root_text": str(root_text or ""),
+            "social_post_url": str(social_post_url or ""),
+            "source": "roo_slack_event",
+        }
+        response = await self._request(
+            "POST",
+            f"{self._points_base}/boost-posts/admissions/",
+            json=payload,
+            timeout=max(1.0, float(timeout)),
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
     async def award_first_channel_post(
         self,
         slack_user_id: str,

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -47,6 +47,9 @@ class Settings(BaseSettings):
     SLACK_RECEIPT_TTL_SECONDS: int = 10 * 60
     SLACK_RECEIPTS_DB_PATH: str = "data/slack_request_receipts.db"
     SLACK_CONTEXTUAL_STATE_DB_PATH: str = "data/slack_contextual_responses.db"
+    SLACK_MODERATOR_USER_TOKEN: Optional[str] = None
+    SLACK_MODERATOR_USER_ID: str = ""
+    SLACK_MODERATOR_TEAM_ID: str = ""
 
     # Context-aware channel replies. Disabled by default and restricted to an
     # explicit channel allowlist before any untagged message can be considered.
@@ -133,11 +136,18 @@ class Settings(BaseSettings):
     ROO_POINTS_STRIPE_CHECKOUT_HOSTS: str = "checkout.stripe.com"
     BOOST_LINK_LOVE_ENABLED: bool = True
     BOOST_LINK_LOVE_CHANNEL_NAME: str = "boost-my-startup"
+    BOOST_LINK_LOVE_CHANNEL_ID: str = ""
     BOOST_LINK_LOVE_DB_PATH: str = "data/link_love_awards.db"
     BOOST_LINK_LOVE_NOTIFICATION_DELAY_SECONDS: int = 60
     BOOST_LINK_LOVE_RETRY_POLL_SECONDS: float = 15.0
     BOOST_LINK_LOVE_MAX_RETRY_ATTEMPTS: int = 5
     BOOST_LINK_LOVE_MAX_ROOT_AGE_DAYS: int = 7
+    BOOST_POST_MODERATION_ENABLED: bool = False
+    BOOST_POST_AUTO_DELETE_ENABLED: bool = False
+    BOOST_POST_ENFORCEMENT_CUTOFF_TS: str = ""
+    BOOST_POST_DECISION_TIMEOUT_SECONDS: float = 30.0
+    BOOST_POST_RETRY_POLL_SECONDS: float = 15.0
+    BOOST_POST_MAX_RETRY_ATTEMPTS: int = 5
     START_HERE_INTRO_ENABLED: bool = True
     START_HERE_INTRO_CHANNEL_NAME: str = "_start-here"
     START_HERE_INTRO_DB_PATH: str = "data/start_here_introductions.db"
@@ -320,6 +330,52 @@ class Settings(BaseSettings):
                 raise ValueError(
                     "VICTOR_AI_BACKEND_TIMEOUT_SECONDS must be between 1 and 60"
                 )
+
+        boost_channel_id = str(self.BOOST_LINK_LOVE_CHANNEL_ID or "").strip()
+        moderator_user_id = str(self.SLACK_MODERATOR_USER_ID or "").strip()
+        moderator_team_id = str(self.SLACK_MODERATOR_TEAM_ID or "").strip()
+        cutoff_ts = str(self.BOOST_POST_ENFORCEMENT_CUTOFF_TS or "").strip()
+        if boost_channel_id and not re.fullmatch(r"C[A-Z0-9]+", boost_channel_id):
+            raise ValueError("BOOST_LINK_LOVE_CHANNEL_ID must be a public Slack channel ID")
+        if moderator_user_id and not re.fullmatch(r"[UW][A-Z0-9]+", moderator_user_id):
+            raise ValueError("SLACK_MODERATOR_USER_ID is invalid")
+        if moderator_team_id and not re.fullmatch(r"T[A-Z0-9]+", moderator_team_id):
+            raise ValueError("SLACK_MODERATOR_TEAM_ID is invalid")
+        if cutoff_ts and not re.fullmatch(r"\d{8,}\.\d+", cutoff_ts):
+            raise ValueError("BOOST_POST_ENFORCEMENT_CUTOFF_TS must be a Slack timestamp")
+        if not 1 <= self.BOOST_POST_DECISION_TIMEOUT_SECONDS <= 120:
+            raise ValueError("BOOST_POST_DECISION_TIMEOUT_SECONDS must be between 1 and 120")
+        if not 1 <= self.BOOST_POST_RETRY_POLL_SECONDS <= 300:
+            raise ValueError("BOOST_POST_RETRY_POLL_SECONDS must be between 1 and 300")
+        if not 1 <= self.BOOST_POST_MAX_RETRY_ATTEMPTS <= 20:
+            raise ValueError("BOOST_POST_MAX_RETRY_ATTEMPTS must be between 1 and 20")
+        if self.BOOST_POST_MODERATION_ENABLED:
+            if self.ROO_SURFACE != "public":
+                raise ValueError("Boost-post moderation is available only on Public Roo")
+            if not self.BOOST_LINK_LOVE_ENABLED:
+                raise ValueError("Boost-post moderation requires BOOST_LINK_LOVE_ENABLED")
+            if not boost_channel_id:
+                raise ValueError("Boost-post moderation requires BOOST_LINK_LOVE_CHANNEL_ID")
+            if not cutoff_ts:
+                raise ValueError(
+                    "Boost-post moderation requires BOOST_POST_ENFORCEMENT_CUTOFF_TS"
+                )
+            if not self.MLAI_BACKEND_URL:
+                raise ValueError("Boost-post moderation requires MLAI_BACKEND_URL")
+        if self.BOOST_POST_AUTO_DELETE_ENABLED:
+            if not self.BOOST_POST_MODERATION_ENABLED:
+                raise ValueError("Boost-post auto-delete requires moderation to be enabled")
+            if not self.SLACK_MODERATOR_USER_TOKEN:
+                raise ValueError("Boost-post auto-delete requires SLACK_MODERATOR_USER_TOKEN")
+            if not moderator_user_id or not moderator_team_id:
+                raise ValueError(
+                    "Boost-post auto-delete requires moderator user and team IDs"
+                )
+            token = str(self.SLACK_MODERATOR_USER_TOKEN)
+            if not (token.startswith("xoxp-") or token.startswith("xoxe.xoxp-")):
+                raise ValueError("SLACK_MODERATOR_USER_TOKEN must be a Slack user token")
+        if self.ROO_SURFACE == "admin" and self.SLACK_MODERATOR_USER_TOKEN:
+            raise ValueError("Admin Roo cannot receive the Slack moderator user token")
 
         enabled_skills = self.enabled_skill_names
         invalid_skill_names = {

--- a/roo-standalone/roo/link_love.py
+++ b/roo-standalone/roo/link_love.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 import sqlite3
 import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import uuid4
 
 import httpx
@@ -23,6 +25,15 @@ DEFAULT_PROCESSING_LEASE_SECONDS = 90.0
 DEFAULT_MAX_RETRY_ATTEMPTS = 5
 DEFAULT_MAX_ROOT_AGE_DAYS = 7
 SECONDS_PER_DAY = 24 * 60 * 60
+SUPPORTED_SOCIAL_HOSTS = (
+    "linkedin.com",
+    "lnkd.in",
+    "x.com",
+    "twitter.com",
+    "instagram.com",
+    "facebook.com",
+)
+TRACKING_QUERY_KEYS = {"fbclid", "gclid", "lipi", "trk", "trackingid"}
 
 
 def _now() -> float:
@@ -55,6 +66,43 @@ def link_love_max_root_age_seconds() -> float:
     except Exception:
         days = DEFAULT_MAX_ROOT_AGE_DAYS
     return max(0.0, days) * SECONDS_PER_DAY
+
+
+def extract_social_post_url(text: str) -> Optional[str]:
+    """Return a stable supported social-post URL without fetching content."""
+
+    candidates = re.findall(r"https?://[^\s<>|]+", str(text or ""), flags=re.IGNORECASE)
+    candidates.extend(
+        match.group(1)
+        for match in re.finditer(
+            r"<(https?://[^>|]+)(?:\|[^>]+)?>", str(text or ""), re.IGNORECASE
+        )
+    )
+    for candidate in candidates:
+        candidate = candidate.rstrip(".,;:!?)\\]}\"")
+        try:
+            parts = urlsplit(candidate)
+            host = (parts.hostname or "").lower().rstrip(".")
+            port = parts.port
+        except ValueError:
+            continue
+        if not any(
+            host == allowed or host.endswith(f".{allowed}")
+            for allowed in SUPPORTED_SOCIAL_HOSTS
+        ):
+            continue
+        netloc = host
+        if port and port not in {80, 443}:
+            netloc = f"{host}:{port}"
+        filtered_query = [
+            (key, value)
+            for key, value in parse_qsl(parts.query, keep_blank_values=True)
+            if not key.lower().startswith("utm_")
+            and key.lower() not in TRACKING_QUERY_KEYS
+        ]
+        path = parts.path.rstrip("/") or "/"
+        return urlunsplit(("https", netloc, path, urlencode(filtered_query), ""))
+    return None
 
 
 def slack_timestamp_to_epoch_seconds(slack_ts: str) -> float:
@@ -742,6 +790,23 @@ async def process_link_love_award(
     max_retry_attempts: Optional[int] = None,
 ) -> dict[str, Any]:
     store = store or get_link_love_store()
+    from .boost_moderation import boost_reward_admission_decision
+
+    admission_decision = boost_reward_admission_decision(
+        str(award.get("channel_id") or ""),
+        str(award.get("root_message_ts") or ""),
+    )
+    if admission_decision not in {"legacy", "approved"}:
+        error = f"boost root admission is {admission_decision}"
+        if admission_decision == "rejected":
+            updated = store.mark_blocked(int(award["id"]), error=error)
+            return {"status": "blocked_admission", "award": updated, "error": error}
+        updated = store.mark_retryable_failure(
+            int(award["id"]),
+            error=error,
+            max_attempts=max_retry_attempts or link_love_max_retry_attempts(),
+        )
+        return {"status": "pending_admission", "award": updated, "error": error}
     client = client or _build_backend_client()
     if bot_user_id is None:
         from .slack_client import get_bot_user_id
@@ -823,6 +888,14 @@ async def handle_link_love_reply(
     reply_text = str(event.get("text") or "")
     if not channel_id or not root_message_ts or not reply_message_ts or not slack_user_id:
         return {"status": "ignored", "reason": "missing_required_event_fields"}
+
+    from .boost_moderation import boost_reward_admission_decision
+
+    admission_decision = boost_reward_admission_decision(channel_id, root_message_ts)
+    if admission_decision == "pending":
+        return {"status": "ignored", "reason": "boost_admission_pending"}
+    if admission_decision == "rejected":
+        return {"status": "ignored", "reason": "boost_admission_rejected"}
 
     if store.get_reply_check(channel_id, reply_message_ts):
         return {"status": "duplicate_reply"}

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -59,7 +59,14 @@ from .slack_client import (
     send_dm,
 )
 from .coworking_booking_intents import coworking_booking_retry_loop
+from .boost_moderation import (
+    boost_post_retry_loop,
+    handle_boost_root_edit,
+    handle_boost_root_post,
+    mark_boost_root_removed,
+)
 from .link_love import handle_link_love_reply, link_love_retry_loop
+from .slack_moderation import validate_slack_moderator_configuration
 from .start_here_introductions import (
     handle_start_here_intro,
     normalize_intro_event,
@@ -1814,6 +1821,7 @@ async def lifespan(app: FastAPI):
     validate_runtime_security(settings)
     app.state.startup_complete = False
     coworking_retry_task: Optional[asyncio.Task] = None
+    boost_post_retry_task: Optional[asyncio.Task] = None
     link_love_task: Optional[asyncio.Task] = None
     start_here_intro_task: Optional[asyncio.Task] = None
     jobs_scheduler_task: Optional[asyncio.Task] = None
@@ -1831,6 +1839,19 @@ async def lifespan(app: FastAPI):
         if settings.BOOST_LINK_LOVE_ENABLED:
             link_love_task = asyncio.create_task(link_love_retry_loop())
             app.state.link_love_task = link_love_task
+        if getattr(settings, "BOOST_POST_MODERATION_ENABLED", False):
+            if getattr(settings, "BOOST_POST_AUTO_DELETE_ENABLED", False):
+                moderator_status = await asyncio.to_thread(
+                    validate_slack_moderator_configuration,
+                    settings=settings,
+                )
+                print(
+                    "   Slack boost moderator verified "
+                    f"team_id={moderator_status['team_id']} "
+                    f"user_id={moderator_status['user_id']}"
+                )
+            boost_post_retry_task = asyncio.create_task(boost_post_retry_loop())
+            app.state.boost_post_retry_task = boost_post_retry_task
         if getattr(settings, "START_HERE_INTRO_ENABLED", True):
             start_here_intro_task = asyncio.create_task(start_here_intro_retry_loop())
             app.state.start_here_intro_task = start_here_intro_task
@@ -1863,6 +1884,10 @@ async def lifespan(app: FastAPI):
             coworking_retry_task.cancel()
             with suppress(asyncio.CancelledError):
                 await coworking_retry_task
+        if boost_post_retry_task:
+            boost_post_retry_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await boost_post_retry_task
         if link_love_task:
             link_love_task.cancel()
             with suppress(asyncio.CancelledError):
@@ -2083,8 +2108,33 @@ async def slack_events(
         asyncio.create_task(_handle_reaction_added(event))
         return JSONResponse(status_code=200, content={})
 
+    if event_type == "message" and event.get("subtype") == "message_deleted":
+        boost_channel_id = str(
+            getattr(settings, "BOOST_LINK_LOVE_CHANNEL_ID", "") or ""
+        )
+        deleted_ts = str(event.get("deleted_ts") or "")
+        if (
+            getattr(settings, "BOOST_POST_MODERATION_ENABLED", False)
+            and boost_channel_id
+            and event.get("channel") == boost_channel_id
+            and deleted_ts
+        ):
+            mark_boost_root_removed(boost_channel_id, deleted_ts)
+        return JSONResponse(status_code=200, content={})
+
     if event_type == "message" and event.get("subtype") == "message_changed":
         from .slack_client import get_channel_id
+
+        boost_channel_id = str(
+            getattr(settings, "BOOST_LINK_LOVE_CHANNEL_ID", "") or ""
+        )
+        if (
+            getattr(settings, "BOOST_POST_MODERATION_ENABLED", False)
+            and boost_channel_id
+            and event.get("channel") == boost_channel_id
+        ):
+            asyncio.create_task(handle_boost_root_edit(event))
+            return JSONResponse(status_code=200, content={})
 
         try:
             settings = get_settings()
@@ -2130,18 +2180,33 @@ async def slack_events(
             settings = get_settings()
             boost_link_love_enabled = settings.BOOST_LINK_LOVE_ENABLED
             boost_channel_name = settings.BOOST_LINK_LOVE_CHANNEL_NAME
+            configured_boost_channel_id = str(
+                getattr(settings, "BOOST_LINK_LOVE_CHANNEL_ID", "") or ""
+            )
         except Exception as exc:
             print(f"⚠️ Link-love config unavailable; skipping boost channel routing: {exc}")
             boost_link_love_enabled = False
             boost_channel_name = "boost-my-startup"
+            configured_boost_channel_id = ""
 
         if boost_link_love_enabled:
-            boost_channel_id = get_channel_id(boost_channel_name)
+            boost_channel_id = configured_boost_channel_id or get_channel_id(
+                boost_channel_name
+            )
             if boost_channel_id and event.get("channel") == boost_channel_id:
                 thread_ts = str(event.get("thread_ts") or "")
                 message_ts = str(event.get("ts") or "")
                 if thread_ts and message_ts and thread_ts != message_ts:
                     asyncio.create_task(handle_link_love_reply(event))
+                elif not thread_ts:
+                    asyncio.create_task(
+                        handle_boost_root_post(
+                            event,
+                            workspace_id=str(
+                                payload.get("team_id") or payload.get("team") or ""
+                            ),
+                        )
+                    )
                 return JSONResponse(status_code=200, content={})
         
         is_dm = event.get("channel_type") == "im"

--- a/roo-standalone/roo/slack_moderation.py
+++ b/roo-standalone/roo/slack_moderation.py
@@ -1,0 +1,192 @@
+"""Narrow Slack moderation capability for paid boost root posts.
+
+The ordinary Roo bot token must never be used for member-authored deletions.
+This module is the only runtime location that loads the optional Workspace
+Admin user token, and every delete is hard-bound to one configured channel.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .config import Settings, get_settings
+
+_moderator_client: Any = None
+
+
+@dataclass(frozen=True)
+class ModeratorDeleteResult:
+    ok: bool
+    status: str
+    channel_id: str
+    message_ts: str
+    error_code: str | None = None
+
+
+def get_moderator_slack_client(*, settings: Settings | None = None) -> Any:
+    """Return a Slack client authenticated as the configured admin member."""
+
+    global _moderator_client
+    resolved = settings or get_settings()
+    token = str(resolved.SLACK_MODERATOR_USER_TOKEN or "").strip()
+    if not token:
+        raise RuntimeError("Slack moderator user token is not configured")
+    if _moderator_client is None:
+        from slack_sdk import WebClient
+
+        _moderator_client = WebClient(token=token)
+    return _moderator_client
+
+
+def validate_slack_moderator_configuration(
+    *,
+    settings: Settings | None = None,
+    bot_client: Any = None,
+    moderator_client: Any = None,
+) -> dict[str, str]:
+    """Prove that the moderator token is the expected admin in Roo's team."""
+
+    resolved = settings or get_settings()
+    if not resolved.BOOST_POST_AUTO_DELETE_ENABLED:
+        return {"status": "disabled"}
+
+    if bot_client is None:
+        from .slack_client import get_slack_client
+
+        bot_client = get_slack_client()
+    moderator_client = moderator_client or get_moderator_slack_client(settings=resolved)
+
+    bot_auth = bot_client.auth_test()
+    moderator_auth = moderator_client.auth_test()
+    bot_team_id = str(bot_auth.get("team_id") or "")
+    moderator_team_id = str(moderator_auth.get("team_id") or "")
+    moderator_user_id = str(moderator_auth.get("user_id") or "")
+    expected_team_id = str(resolved.SLACK_MODERATOR_TEAM_ID or "")
+    expected_user_id = str(resolved.SLACK_MODERATOR_USER_ID or "")
+
+    if not bot_auth.get("ok") or not moderator_auth.get("ok"):
+        raise RuntimeError("Slack moderator identity verification failed")
+    if bot_team_id != expected_team_id or moderator_team_id != expected_team_id:
+        raise RuntimeError("Slack moderator token belongs to the wrong workspace")
+    if moderator_user_id != expected_user_id:
+        raise RuntimeError("Slack moderator token belongs to the wrong user")
+
+    profile_response = bot_client.users_info(user=moderator_user_id)
+    profile = profile_response.get("user") or {}
+    if not profile_response.get("ok") or not (
+        bool(profile.get("is_admin")) or bool(profile.get("is_owner"))
+    ):
+        raise RuntimeError("Configured Slack moderator is not a Workspace Admin or Owner")
+
+    return {
+        "status": "ready",
+        "team_id": expected_team_id,
+        "user_id": expected_user_id,
+    }
+
+
+def delete_boost_root_as_moderator(
+    *,
+    channel_id: str,
+    message_ts: str,
+    reason_code: str,
+    settings: Settings | None = None,
+    client: Any = None,
+    get_message_fn: Callable[[str, str], dict[str, Any] | None] | None = None,
+) -> ModeratorDeleteResult:
+    """Delete one verified top-level root in the configured boost channel."""
+
+    resolved = settings or get_settings()
+    channel_id = str(channel_id or "").strip()
+    message_ts = str(message_ts or "").strip()
+    reason_code = str(reason_code or "").strip().lower()
+
+    if not resolved.BOOST_POST_AUTO_DELETE_ENABLED:
+        return ModeratorDeleteResult(False, "disabled", channel_id, message_ts, "disabled")
+    if channel_id != str(resolved.BOOST_LINK_LOVE_CHANNEL_ID or "").strip():
+        return ModeratorDeleteResult(
+            False,
+            "refused",
+            channel_id,
+            message_ts,
+            "channel_not_allowlisted",
+        )
+    if not re.fullmatch(r"\d{8,}\.\d+", message_ts):
+        return ModeratorDeleteResult(
+            False,
+            "refused",
+            channel_id,
+            message_ts,
+            "invalid_message_ts",
+        )
+    if not re.fullmatch(r"[a-z0-9][a-z0-9_:-]{1,79}", reason_code):
+        return ModeratorDeleteResult(
+            False,
+            "refused",
+            channel_id,
+            message_ts,
+            "invalid_reason_code",
+        )
+
+    if get_message_fn is None:
+        from .slack_client import get_message
+
+        get_message_fn = get_message
+    message = get_message_fn(channel_id, message_ts)
+    if not message:
+        return ModeratorDeleteResult(
+            False,
+            "refused",
+            channel_id,
+            message_ts,
+            "message_not_found",
+        )
+    thread_ts = str(message.get("thread_ts") or "").strip()
+    if thread_ts and thread_ts != message_ts:
+        return ModeratorDeleteResult(
+            False,
+            "refused",
+            channel_id,
+            message_ts,
+            "not_root_message",
+        )
+
+    try:
+        moderator_client = client or get_moderator_slack_client(settings=resolved)
+        response = moderator_client.chat_delete(channel=channel_id, ts=message_ts)
+        if not response.get("ok"):
+            error_code = str(response.get("error") or "delete_failed")
+            print(
+                "BOOST_POST_DELETE_FAILED "
+                f"channel_id={channel_id} message_ts={message_ts} "
+                f"reason={reason_code} error_code={error_code}"
+            )
+            return ModeratorDeleteResult(
+                False,
+                "failed",
+                channel_id,
+                message_ts,
+                error_code,
+            )
+        print(
+            "BOOST_POST_DELETED "
+            f"channel_id={channel_id} message_ts={message_ts} reason={reason_code}"
+        )
+        return ModeratorDeleteResult(True, "deleted", channel_id, message_ts)
+    except Exception as exc:  # noqa: BLE001 - Slack SDK errors vary by transport.
+        error_code = exc.__class__.__name__
+        print(
+            "BOOST_POST_DELETE_FAILED "
+            f"channel_id={channel_id} message_ts={message_ts} "
+            f"reason={reason_code} error_type={error_code}"
+        )
+        return ModeratorDeleteResult(
+            False,
+            "failed",
+            channel_id,
+            message_ts,
+            error_code,
+        )

--- a/roo-standalone/roo/tests/test_boost_moderation.py
+++ b/roo-standalone/roo/tests/test_boost_moderation.py
@@ -1,0 +1,281 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from roo import boost_moderation as module
+from roo import link_love
+from roo.boost_moderation import (
+    BoostPostAdmissionStore,
+    boost_reward_admission_decision,
+    handle_boost_root_edit,
+    handle_boost_root_post,
+)
+from roo.slack_moderation import ModeratorDeleteResult
+
+
+def moderation_settings(**overrides):
+    values = {
+        "BOOST_POST_MODERATION_ENABLED": True,
+        "BOOST_POST_AUTO_DELETE_ENABLED": False,
+        "BOOST_LINK_LOVE_CHANNEL_ID": "CBOOST123",
+        "BOOST_POST_ENFORCEMENT_CUTOFF_TS": "1700000000.000000",
+        "BOOST_POST_DECISION_TIMEOUT_SECONDS": 30.0,
+        "BOOST_POST_MAX_RETRY_ATTEMPTS": 5,
+        "BOOST_POST_RETRY_POLL_SECONDS": 15.0,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def root_event(**overrides):
+    values = {
+        "type": "message",
+        "channel": "CBOOST123",
+        "ts": "1800000000.123456",
+        "user": "UPOSTER1",
+        "text": "Please boost https://www.linkedin.com/posts/example-123",
+    }
+    values.update(overrides)
+    return values
+
+
+class ApprovedClient:
+    def __init__(self):
+        self.calls = []
+
+    async def admit_boost_post(self, **payload):
+        self.calls.append(payload)
+        return {
+            "status": "approved",
+            "admission_id": "admission-1",
+            "base_cost_points": 8,
+            "charged_points": 4,
+            "discount_applied": True,
+            "new_balance": 16,
+        }
+
+
+@pytest.mark.asyncio
+async def test_root_admission_is_durable_idempotent_and_posts_discount_notice(
+    tmp_path, monkeypatch
+):
+    settings = moderation_settings()
+    monkeypatch.setattr(module, "get_settings", lambda: settings)
+    store = BoostPostAdmissionStore(tmp_path / "admissions.db")
+    client = ApprovedClient()
+    notices = []
+
+    first = await handle_boost_root_post(
+        root_event(),
+        workspace_id="TTEAM123",
+        store=store,
+        client=client,
+        post_message_fn=lambda **kwargs: notices.append(kwargs),
+    )
+    duplicate = await handle_boost_root_post(
+        root_event(),
+        workspace_id="TTEAM123",
+        store=store,
+        client=client,
+        post_message_fn=lambda **kwargs: notices.append(kwargs),
+    )
+
+    assert first["status"] == "approved"
+    assert duplicate["status"] == "not_due"
+    assert len(client.calls) == 1
+    assert client.calls[0]["submission_key"] == (
+        "boost-post:TTEAM123:CBOOST123:1800000000.123456"
+    )
+    admission = store.get("CBOOST123", "1800000000.123456")
+    assert admission["charged_points"] == 4
+    assert admission["discount_applied"] == 1
+    assert len(notices) == 1
+    assert "monthly-update discount" in notices[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_insufficient_points_is_committed_before_root_is_deleted(tmp_path, monkeypatch):
+    settings = moderation_settings(BOOST_POST_AUTO_DELETE_ENABLED=True)
+    monkeypatch.setattr(module, "get_settings", lambda: settings)
+    store = BoostPostAdmissionStore(tmp_path / "admissions.db")
+
+    class InsufficientClient:
+        async def admit_boost_post(self, **payload):
+            return {
+                "status": "insufficient_points",
+                "message": "Needs 8 points but balance is 3",
+            }
+
+    status_seen_by_delete = []
+
+    def delete_fn(**kwargs):
+        status_seen_by_delete.append(
+            store.get(kwargs["channel_id"], kwargs["message_ts"])["status"]
+        )
+        return ModeratorDeleteResult(
+            True, "deleted", kwargs["channel_id"], kwargs["message_ts"]
+        )
+
+    result = await handle_boost_root_post(
+        root_event(),
+        workspace_id="TTEAM123",
+        store=store,
+        client=InsufficientClient(),
+        post_message_fn=lambda **kwargs: None,
+        send_dm_fn=lambda *args, **kwargs: None,
+        delete_fn=delete_fn,
+    )
+
+    assert status_seen_by_delete == ["rejected_insufficient_points"]
+    assert result["status"] == "deleted"
+    assert boost_reward_admission_decision(
+        "CBOOST123", "1800000000.123456", store=store
+    ) == "rejected"
+
+
+@pytest.mark.asyncio
+async def test_ambiguous_backend_failure_retries_without_deleting(tmp_path, monkeypatch):
+    settings = moderation_settings(BOOST_POST_AUTO_DELETE_ENABLED=True)
+    monkeypatch.setattr(module, "get_settings", lambda: settings)
+    store = BoostPostAdmissionStore(tmp_path / "admissions.db")
+
+    class TimeoutClient:
+        async def admit_boost_post(self, **payload):
+            request = httpx.Request("POST", "https://backend.test/admit")
+            raise httpx.ReadTimeout("timed out", request=request)
+
+    deletes = []
+    result = await handle_boost_root_post(
+        root_event(),
+        workspace_id="TTEAM123",
+        store=store,
+        client=TimeoutClient(),
+        delete_fn=lambda **kwargs: deletes.append(kwargs),
+    )
+
+    assert result["status"] == "retry"
+    assert deletes == []
+    assert boost_reward_admission_decision(
+        "CBOOST123", "1800000000.123456", store=store
+    ) == "pending"
+
+
+def test_reward_decision_preserves_pre_cutoff_roots(tmp_path, monkeypatch):
+    settings = moderation_settings()
+    monkeypatch.setattr(module, "get_settings", lambda: settings)
+    store = BoostPostAdmissionStore(tmp_path / "admissions.db")
+
+    assert boost_reward_admission_decision(
+        "CBOOST123", "1600000000.000001", store=store
+    ) == "legacy"
+    assert boost_reward_admission_decision(
+        "CBOOST123", "1800000000.000001", store=store
+    ) == "pending"
+
+
+@pytest.mark.asyncio
+async def test_approved_root_cannot_swap_to_a_different_link(tmp_path, monkeypatch):
+    settings = moderation_settings(BOOST_POST_AUTO_DELETE_ENABLED=True)
+    monkeypatch.setattr(module, "get_settings", lambda: settings)
+    store = BoostPostAdmissionStore(tmp_path / "admissions.db")
+    await handle_boost_root_post(
+        root_event(),
+        workspace_id="TTEAM123",
+        store=store,
+        client=ApprovedClient(),
+        post_message_fn=lambda **kwargs: None,
+    )
+    deleted = []
+
+    result = await handle_boost_root_edit(
+        {
+            "channel": "CBOOST123",
+            "message": {
+                "ts": "1800000000.123456",
+                "text": "Swap https://www.linkedin.com/posts/different-456",
+            },
+        },
+        store=store,
+        post_message_fn=lambda **kwargs: None,
+        send_dm_fn=lambda *args, **kwargs: None,
+        delete_fn=lambda **kwargs: (
+            deleted.append(kwargs)
+            or ModeratorDeleteResult(
+                True, "deleted", kwargs["channel_id"], kwargs["message_ts"]
+            )
+        ),
+    )
+
+    assert result["status"] == "deleted"
+    assert len(deleted) == 1
+
+
+@pytest.mark.asyncio
+async def test_link_love_never_settles_after_paid_root_is_removed(tmp_path, monkeypatch):
+    settings = moderation_settings()
+    monkeypatch.setattr(module, "get_settings", lambda: settings)
+    admission_store = BoostPostAdmissionStore(tmp_path / "admissions.db")
+    monkeypatch.setattr(module, "get_boost_post_store", lambda: admission_store)
+    award_store = link_love.LinkLoveAwardStore(tmp_path / "awards.db")
+    reply = {
+        "type": "message",
+        "channel": "CBOOST123",
+        "thread_ts": "1800000000.123456",
+        "ts": "1800000001.123456",
+        "user": "UHELPER1",
+        "text": "Liked and commented",
+    }
+
+    pending = await link_love.handle_link_love_reply(reply, store=award_store)
+    assert pending == {"status": "ignored", "reason": "boost_admission_pending"}
+
+    admission = admission_store.record_root(
+        workspace_id="TTEAM123",
+        channel_id="CBOOST123",
+        root_message_ts="1800000000.123456",
+        poster_slack_id="UPOSTER1",
+        root_text="Boost https://www.linkedin.com/posts/example-123",
+        social_post_url="https://www.linkedin.com/posts/example-123",
+    )
+    admission_store.claim_one(int(admission["id"]), owner="test")
+    admission_store.mark_approved(
+        int(admission["id"]),
+        {
+            "status": "approved",
+            "admission_id": "admission-1",
+            "base_cost_points": 8,
+            "charged_points": 8,
+            "discount_applied": False,
+            "new_balance": 10,
+        },
+    )
+
+    created, award = award_store.create_award(
+        channel_id="CBOOST123",
+        root_message_ts="1800000000.123456",
+        slack_user_id="UHELPER1",
+        root_author_slack_id="UPOSTER1",
+        source_reply_message_ts="1800000001.123456",
+    )
+    assert created is True
+
+    admission_store.mark_removed("CBOOST123", "1800000000.123456")
+
+    class NoAwardClient:
+        async def system_award_points(self, **kwargs):
+            raise AssertionError("No helper points may escape an unapproved root")
+
+    processed = await link_love.process_link_love_award(
+        award,
+        store=award_store,
+        client=NoAwardClient(),
+        bot_user_id="UROO",
+    )
+
+    assert processed["status"] == "blocked_admission"
+    assert processed["award"]["status"] == "blocked"

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -98,6 +98,43 @@ async def test_circuit_breaker_probes_readiness_before_main_request(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_admit_boost_post_uses_strict_roo_key_headers(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured.update(method=method, endpoint=endpoint, kwargs=kwargs)
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(
+            201,
+            request=request,
+            json={"status": "approved", "charged_points": 8},
+        )
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="admin-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.admit_boost_post(
+        submission_key="boost-post:TTEAM123:CBOOST123:1800000000.123456",
+        workspace_id="TTEAM123",
+        channel_id="CBOOST123",
+        root_message_ts="1800000000.123456",
+        poster_slack_id="<@UPOSTER1>",
+        root_text="Boost this",
+        social_post_url="https://www.linkedin.com/posts/example-123",
+    )
+
+    assert result["status"] == "approved"
+    assert captured["method"] == "POST"
+    assert captured["endpoint"] == "/api/v1/points/boost-posts/admissions/"
+    assert captured["kwargs"]["json"]["poster_slack_id"] == "UPOSTER1"
+    assert "use_admin_headers" not in captured["kwargs"]
+
+
+@pytest.mark.asyncio
 async def test_trigger_repo_scan_sends_request_source(monkeypatch):
     captured = {}
 

--- a/roo-standalone/roo/tests/test_slack_moderation.py
+++ b/roo-standalone/roo/tests/test_slack_moderation.py
@@ -1,0 +1,107 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from roo.slack_moderation import (
+    delete_boost_root_as_moderator,
+    validate_slack_moderator_configuration,
+)
+
+
+def settings(**overrides):
+    values = {
+        "BOOST_POST_AUTO_DELETE_ENABLED": True,
+        "BOOST_LINK_LOVE_CHANNEL_ID": "CBOOST123",
+        "SLACK_MODERATOR_USER_TOKEN": "xoxp-secret-never-log-this",
+        "SLACK_MODERATOR_TEAM_ID": "TTEAM123",
+        "SLACK_MODERATOR_USER_ID": "UADMIN123",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class DeleteClient:
+    def __init__(self):
+        self.calls = []
+
+    def chat_delete(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"ok": True}
+
+
+def test_delete_is_hard_scoped_to_configured_channel_and_root_message():
+    client = DeleteClient()
+
+    wrong_channel = delete_boost_root_as_moderator(
+        channel_id="COTHER123",
+        message_ts="1800000000.123456",
+        reason_code="insufficient_points",
+        settings=settings(),
+        client=client,
+        get_message_fn=lambda *args: {"ts": "1800000000.123456"},
+    )
+    reply = delete_boost_root_as_moderator(
+        channel_id="CBOOST123",
+        message_ts="1800000000.123456",
+        reason_code="insufficient_points",
+        settings=settings(),
+        client=client,
+        get_message_fn=lambda *args: {
+            "ts": "1800000000.123456",
+            "thread_ts": "1700000000.999999",
+        },
+    )
+
+    assert wrong_channel.error_code == "channel_not_allowlisted"
+    assert reply.error_code == "not_root_message"
+    assert client.calls == []
+
+
+def test_delete_uses_moderator_client_only_after_root_is_verified():
+    client = DeleteClient()
+    result = delete_boost_root_as_moderator(
+        channel_id="CBOOST123",
+        message_ts="1800000000.123456",
+        reason_code="rejected_insufficient_points",
+        settings=settings(),
+        client=client,
+        get_message_fn=lambda *args: {
+            "ts": "1800000000.123456",
+            "thread_ts": "1800000000.123456",
+        },
+    )
+
+    assert result.ok
+    assert client.calls == [{"channel": "CBOOST123", "ts": "1800000000.123456"}]
+
+
+def test_startup_validation_proves_workspace_user_and_admin_role():
+    class BotClient:
+        def auth_test(self):
+            return {"ok": True, "team_id": "TTEAM123"}
+
+        def users_info(self, **kwargs):
+            assert kwargs == {"user": "UADMIN123"}
+            return {"ok": True, "user": {"is_admin": True}}
+
+    class ModeratorClient:
+        def auth_test(self):
+            return {
+                "ok": True,
+                "team_id": "TTEAM123",
+                "user_id": "UADMIN123",
+            }
+
+    result = validate_slack_moderator_configuration(
+        settings=settings(),
+        bot_client=BotClient(),
+        moderator_client=ModeratorClient(),
+    )
+
+    assert result == {
+        "status": "ready",
+        "team_id": "TTEAM123",
+        "user_id": "UADMIN123",
+    }

--- a/roo-standalone/roo/tests/test_surface_security.py
+++ b/roo-standalone/roo/tests/test_surface_security.py
@@ -81,6 +81,40 @@ def test_victor_ai_skill_fails_closed_for_disabled_or_invalid_configuration():
         )
 
 
+def test_boost_post_moderation_is_disabled_by_default_and_fails_closed():
+    configured = settings()
+    assert not configured.BOOST_POST_MODERATION_ENABLED
+    assert not configured.BOOST_POST_AUTO_DELETE_ENABLED
+
+    with pytest.raises(ValidationError, match="requires BOOST_LINK_LOVE_CHANNEL_ID"):
+        settings(
+            BOOST_POST_MODERATION_ENABLED=True,
+            BOOST_POST_ENFORCEMENT_CUTOFF_TS="1800000000.000000",
+            MLAI_BACKEND_URL="https://backend.test",
+        )
+
+    with pytest.raises(ValidationError, match="requires SLACK_MODERATOR_USER_TOKEN"):
+        settings(
+            BOOST_POST_MODERATION_ENABLED=True,
+            BOOST_POST_AUTO_DELETE_ENABLED=True,
+            BOOST_LINK_LOVE_CHANNEL_ID="CBOOST123",
+            BOOST_POST_ENFORCEMENT_CUTOFF_TS="1800000000.000000",
+            MLAI_BACKEND_URL="https://backend.test",
+        )
+
+    configured = settings(
+        BOOST_POST_MODERATION_ENABLED=True,
+        BOOST_POST_AUTO_DELETE_ENABLED=True,
+        BOOST_LINK_LOVE_CHANNEL_ID="CBOOST123",
+        BOOST_POST_ENFORCEMENT_CUTOFF_TS="1800000000.000000",
+        MLAI_BACKEND_URL="https://backend.test",
+        SLACK_MODERATOR_USER_TOKEN="xoxp-synthetic",
+        SLACK_MODERATOR_USER_ID="UADMIN123",
+        SLACK_MODERATOR_TEAM_ID="TTEAM123",
+    )
+    assert configured.BOOST_POST_AUTO_DELETE_ENABLED
+
+
 @pytest.mark.parametrize(
     "overrides",
     (


### PR DESCRIPTION
## Summary
- admit direct boost-channel roots through the backend before rewards can settle
- comment approval, pending, or rejection decisions in the Slack thread
- delete rejected roots through a tightly allowlisted Workspace Admin user token
- preserve pre-cutoff campaigns and block link-love rewards for unapproved roots

## Verification
- 422 CI/relevant regression tests pass
- 9 focused moderation/deletion tests pass
- Python compilation and diff checks pass