### PR TITLE
Allow any boost campaign content

### DIFF
--- a/roo-standalone/roo/boost_moderation.py
+++ b/roo-standalone/roo/boost_moderation.py
@@ -22,7 +22,7 @@ import httpx
 
 from .clients.mlai_backend import MLAIBackendClient, MLAIBackendUnavailableError
 from .config import get_settings
-from .link_love import extract_social_post_url
+from .link_love import extract_boost_url
 
 DEFAULT_PROCESSING_LEASE_SECONDS = 90.0
 TERMINAL_REJECTION_STATUSES = {
@@ -555,7 +555,7 @@ def _rejection_notice(admission: dict[str, Any]) -> str:
             f"<@{poster}> I couldn't approve this boost because you don't have enough Roo points. "
             f"{balance_detail}{discount_detail}"
             "I'll remove this message so nobody engages with an unapproved campaign. "
-            "Earn enough points, then create a new top-level post with the social link. "
+            "Earn enough points, then create a new top-level post with the campaign. "
             "You can DM me “what's my points balance?” at any time."
         )
     if status == "rejected_member_unlinked":
@@ -567,11 +567,10 @@ def _rejection_notice(admission: dict[str, Any]) -> str:
             "new top-level post."
         )
     return (
-        f"<@{poster}> I couldn't approve this boost because I couldn't find a supported social "
-        "link in the message. To qualify, create a new top-level post containing a direct "
-        "LinkedIn or lnkd.in, X/Twitter, Instagram, or Facebook link. General website, product, "
-        "signup, and article links aren't eligible right now. I'll remove this message; add a "
-        "supported social link and try again."
+        f"<@{poster}> I couldn't process this boost because some required Slack information was "
+        "missing or invalid. No Roo points were charged. I'll remove this message; create a new "
+        "top-level post and try again. Any website or social link is allowed. If this happens "
+        "again, please ask an MLAI admin for help."
     )
 
 
@@ -812,7 +811,7 @@ async def handle_boost_root_post(
         root_message_ts=root_message_ts,
         poster_slack_id=poster_slack_id,
         root_text=root_text,
-        social_post_url=extract_social_post_url(root_text) or "",
+        social_post_url=extract_boost_url(root_text) or "",
     )
     return await process_boost_post_admission(
         admission,
@@ -840,39 +839,13 @@ async def handle_boost_root_edit(
     admission = store.get(channel_id, root_ts)
     if admission is None:
         return {"status": "ignored", "reason": "unknown_root"}
-    old_url = str(admission.get("social_post_url") or "")
-    new_url = extract_social_post_url(text) or ""
+    new_url = extract_boost_url(text) or ""
     updated = store.update_root_text(
         channel_id=channel_id,
         root_message_ts=root_ts,
         root_text=text,
         social_post_url=new_url,
     )
-    if str(admission.get("status") or "") == "approved" and new_url != old_url:
-        rejected = store.mark_rejected(
-            int(admission["id"]),
-            status="rejected_invalid",
-            reason="approved boost root changed its social post URL",
-        )
-        notice = (
-            f"<@{rejected['poster_slack_id']}> the approved link was changed. "
-            "To prevent a paid boost being swapped for a different post, I will remove this root. "
-            "Post the new link separately for a new approval."
-        )
-        _post_decision_notice(
-            rejected,
-            store=store,
-            text=notice,
-            post_message_fn=post_message_fn,
-        )
-        refreshed = store.get_by_id(int(rejected["id"]))
-        _dm_rejection(refreshed, store=store, text=notice, send_dm_fn=send_dm_fn)
-        moderated = _moderate_rejected_root(
-            store.get_by_id(int(rejected["id"])),
-            store=store,
-            delete_fn=delete_fn,
-        )
-        return {"status": str(moderated["status"]), "admission": moderated}
     return {"status": "updated", "admission": updated}
 
 

--- a/roo-standalone/roo/boost_moderation.py
+++ b/roo-standalone/roo/boost_moderation.py
@@ -520,20 +520,59 @@ def _approval_notice(admission: dict[str, Any]) -> str:
     return f":white_check_mark: Approved — {charged} Roo points deducted.{discount_text}{balance_text}"
 
 
+def _backend_result(admission: dict[str, Any]) -> dict[str, Any]:
+    """Return the stored backend decision without trusting its shape."""
+
+    raw = admission.get("backend_result_json")
+    if isinstance(raw, dict):
+        return raw
+    try:
+        parsed = json.loads(str(raw or "{}"))
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
 def _rejection_notice(admission: dict[str, Any]) -> str:
     poster = str(admission.get("poster_slack_id") or "")
     status = str(admission.get("status") or "")
     if status == "rejected_insufficient_points":
+        result = _backend_result(admission)
+        required = result.get("charged_points")
+        available = result.get("new_balance", result.get("balance_before"))
+        if required is not None and available is not None:
+            balance_detail = (
+                f"This boost costs {required} Roo points, and you currently have {available}. "
+            )
+        else:
+            balance_detail = "Your Roo points balance is below the price of this boost. "
+        discount_detail = (
+            "Your 50% Australian-startup monthly-update discount was included in that price. "
+            if bool(result.get("discount_applied"))
+            else ""
+        )
         return (
-            f"<@{poster}> this boost was not approved because you do not have enough Roo points. "
-            "I will remove the post; earn or top up points, then post it again."
+            f"<@{poster}> I couldn't approve this boost because you don't have enough Roo points. "
+            f"{balance_detail}{discount_detail}"
+            "I'll remove this message so nobody engages with an unapproved campaign. "
+            "Earn enough points, then create a new top-level post with the social link. "
+            "You can DM me “what's my points balance?” at any time."
         )
     if status == "rejected_member_unlinked":
         return (
-            f"<@{poster}> I could not connect this Slack account to a Roo points account. "
-            "I will remove the post; link your account, then try again."
+            f"<@{poster}> I couldn't approve this boost because I can't match your Slack profile "
+            "to a Roo Points account, so I can't check or charge your balance. I'll remove this "
+            "message. DM me “what's my points balance?” to check whether I can see your account. "
+            "If I still can't find it, ask an MLAI admin to link your Slack profile, then create a "
+            "new top-level post."
         )
-    return f"<@{poster}> this post is not eligible for boosting, so I will remove it."
+    return (
+        f"<@{poster}> I couldn't approve this boost because I couldn't find a supported social "
+        "link in the message. To qualify, create a new top-level post containing a direct "
+        "LinkedIn or lnkd.in, X/Twitter, Instagram, or Facebook link. General website, product, "
+        "signup, and article links aren't eligible right now. I'll remove this message; add a "
+        "supported social link and try again."
+    )
 
 
 def _post_decision_notice(

--- a/roo-standalone/roo/link_love.py
+++ b/roo-standalone/roo/link_love.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
-from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from urllib.parse import urlsplit, urlunsplit
 from uuid import uuid4
 
 import httpx
@@ -25,17 +25,6 @@ DEFAULT_PROCESSING_LEASE_SECONDS = 90.0
 DEFAULT_MAX_RETRY_ATTEMPTS = 5
 DEFAULT_MAX_ROOT_AGE_DAYS = 7
 SECONDS_PER_DAY = 24 * 60 * 60
-SUPPORTED_SOCIAL_HOSTS = (
-    "linkedin.com",
-    "lnkd.in",
-    "x.com",
-    "twitter.com",
-    "instagram.com",
-    "facebook.com",
-)
-TRACKING_QUERY_KEYS = {"fbclid", "gclid", "lipi", "trk", "trackingid"}
-
-
 def _now() -> float:
     return time.time()
 
@@ -68,8 +57,8 @@ def link_love_max_root_age_seconds() -> float:
     return max(0.0, days) * SECONDS_PER_DAY
 
 
-def extract_social_post_url(text: str) -> Optional[str]:
-    """Return a stable supported social-post URL without fetching content."""
+def extract_boost_url(text: str) -> Optional[str]:
+    """Return the first HTTP(S) campaign URL without restricting its domain."""
 
     candidates = re.findall(r"https?://[^\s<>|]+", str(text or ""), flags=re.IGNORECASE)
     candidates.extend(
@@ -82,27 +71,25 @@ def extract_social_post_url(text: str) -> Optional[str]:
         candidate = candidate.rstrip(".,;:!?)\\]}\"")
         try:
             parts = urlsplit(candidate)
+            scheme = parts.scheme.lower()
             host = (parts.hostname or "").lower().rstrip(".")
             port = parts.port
         except ValueError:
             continue
-        if not any(
-            host == allowed or host.endswith(f".{allowed}")
-            for allowed in SUPPORTED_SOCIAL_HOSTS
-        ):
+        if scheme not in {"http", "https"} or not host:
             continue
-        netloc = host
+        netloc = f"[{host}]" if ":" in host else host
         if port and port not in {80, 443}:
-            netloc = f"{host}:{port}"
-        filtered_query = [
-            (key, value)
-            for key, value in parse_qsl(parts.query, keep_blank_values=True)
-            if not key.lower().startswith("utm_")
-            and key.lower() not in TRACKING_QUERY_KEYS
-        ]
+            netloc = f"{netloc}:{port}"
         path = parts.path.rstrip("/") or "/"
-        return urlunsplit(("https", netloc, path, urlencode(filtered_query), ""))
+        return urlunsplit((scheme, netloc, path, parts.query, parts.fragment))
     return None
+
+
+def extract_social_post_url(text: str) -> Optional[str]:
+    """Backward-compatible alias for callers that still use the old name."""
+
+    return extract_boost_url(text)
 
 
 def slack_timestamp_to_epoch_seconds(slack_ts: str) -> float:

--- a/roo-standalone/roo/tests/test_boost_moderation.py
+++ b/roo-standalone/roo/tests/test_boost_moderation.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -58,6 +59,58 @@ class ApprovedClient:
             "discount_applied": True,
             "new_balance": 16,
         }
+
+
+def test_invalid_post_notice_explains_supported_links_and_retry() -> None:
+    notice = module._rejection_notice(
+        {
+            "poster_slack_id": "UPOSTER1",
+            "status": "rejected_invalid",
+            "rejection_reason": "Missing required fields: social_post_url",
+        }
+    )
+
+    assert "couldn't find a supported social link" in notice
+    assert "LinkedIn or lnkd.in" in notice
+    assert "X/Twitter, Instagram, or Facebook" in notice
+    assert (
+        "General website, product, signup, and article links aren't eligible" in notice
+    )
+    assert "create a new top-level post" in notice
+
+
+def test_insufficient_points_notice_shows_price_balance_and_discount() -> None:
+    notice = module._rejection_notice(
+        {
+            "poster_slack_id": "UPOSTER1",
+            "status": "rejected_insufficient_points",
+            "backend_result_json": json.dumps(
+                {
+                    "charged_points": 4,
+                    "new_balance": 3,
+                    "discount_applied": True,
+                }
+            ),
+        }
+    )
+
+    assert "costs 4 Roo points" in notice
+    assert "currently have 3" in notice
+    assert "50% Australian-startup monthly-update discount" in notice
+    assert "what's my points balance?" in notice
+
+
+def test_unlinked_member_notice_explains_how_to_fix_account_link() -> None:
+    notice = module._rejection_notice(
+        {
+            "poster_slack_id": "UPOSTER1",
+            "status": "rejected_member_unlinked",
+        }
+    )
+
+    assert "can't match your Slack profile to a Roo Points account" in notice
+    assert "what's my points balance?" in notice
+    assert "ask an MLAI admin to link your Slack profile" in notice
 
 
 @pytest.mark.asyncio

--- a/roo-standalone/roo/tests/test_boost_moderation.py
+++ b/roo-standalone/roo/tests/test_boost_moderation.py
@@ -61,7 +61,17 @@ class ApprovedClient:
         }
 
 
-def test_invalid_post_notice_explains_supported_links_and_retry() -> None:
+def test_boost_url_accepts_any_http_or_https_domain() -> None:
+    assert link_love.extract_boost_url(
+        "Share https://example.com/product?id=12&utm_source=slack#pricing"
+    ) == "https://example.com/product?id=12&utm_source=slack#pricing"
+    assert link_love.extract_boost_url("Read http://news.example.org/story/") == (
+        "http://news.example.org/story"
+    )
+    assert link_love.extract_boost_url("No campaign link here") is None
+
+
+def test_invalid_post_notice_explains_internal_validation_and_retry() -> None:
     notice = module._rejection_notice(
         {
             "poster_slack_id": "UPOSTER1",
@@ -70,12 +80,9 @@ def test_invalid_post_notice_explains_supported_links_and_retry() -> None:
         }
     )
 
-    assert "couldn't find a supported social link" in notice
-    assert "LinkedIn or lnkd.in" in notice
-    assert "X/Twitter, Instagram, or Facebook" in notice
-    assert (
-        "General website, product, signup, and article links aren't eligible" in notice
-    )
+    assert "required Slack information was missing or invalid" in notice
+    assert "No Roo points were charged" in notice
+    assert "Any website or social link is allowed" in notice
     assert "create a new top-level post" in notice
 
 
@@ -149,6 +156,27 @@ async def test_root_admission_is_durable_idempotent_and_posts_discount_notice(
     assert admission["discount_applied"] == 1
     assert len(notices) == 1
     assert "monthly-update discount" in notices[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_root_without_a_link_is_still_eligible_for_points_admission(
+    tmp_path, monkeypatch
+):
+    settings = moderation_settings()
+    monkeypatch.setattr(module, "get_settings", lambda: settings)
+    store = BoostPostAdmissionStore(tmp_path / "admissions.db")
+    client = ApprovedClient()
+
+    result = await handle_boost_root_post(
+        root_event(text="Please help boost my startup update"),
+        workspace_id="TTEAM123",
+        store=store,
+        client=client,
+        post_message_fn=lambda **kwargs: None,
+    )
+
+    assert result["status"] == "approved"
+    assert client.calls[0]["social_post_url"] == ""
 
 
 @pytest.mark.asyncio
@@ -232,7 +260,9 @@ def test_reward_decision_preserves_pre_cutoff_roots(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_approved_root_cannot_swap_to_a_different_link(tmp_path, monkeypatch):
+async def test_approved_root_can_change_to_any_link_without_another_charge(
+    tmp_path, monkeypatch
+):
     settings = moderation_settings(BOOST_POST_AUTO_DELETE_ENABLED=True)
     monkeypatch.setattr(module, "get_settings", lambda: settings)
     store = BoostPostAdmissionStore(tmp_path / "admissions.db")
@@ -250,7 +280,7 @@ async def test_approved_root_cannot_swap_to_a_different_link(tmp_path, monkeypat
             "channel": "CBOOST123",
             "message": {
                 "ts": "1800000000.123456",
-                "text": "Swap https://www.linkedin.com/posts/different-456",
+                "text": "Swap https://example.com/products/different-456",
             },
         },
         store=store,
@@ -264,8 +294,11 @@ async def test_approved_root_cannot_swap_to_a_different_link(tmp_path, monkeypat
         ),
     )
 
-    assert result["status"] == "deleted"
-    assert len(deleted) == 1
+    assert result["status"] == "updated"
+    assert deleted == []
+    admission = store.get("CBOOST123", "1800000000.123456")
+    assert admission["status"] == "approved"
+    assert admission["social_post_url"] == "https://example.com/products/different-456"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Accept campaign URLs from any HTTP or HTTPS domain.
- Allow boost posts with no URL.
- Allow approved posts to edit or replace their campaign URL without deletion or a second charge.
- Expand rejection guidance for insufficient balances and unlinked points accounts.

## Why

`#boost-my-startup` admission should be based on the poster's Roo Points balance, not the type or domain of their campaign content.

## Impact

Any website, product, signup, article, or social link can be boosted. Posts remain priced at 8 Roo Points, or 4 when the existing Australian-startup monthly-update discount applies.

## Validation

- 54 focused Roo moderation, reward-gating, Slack deletion, and backend-client tests passed.
- Python compilation and `git diff --check` passed.