### PR TITLE
Wait for Nginx before Admin ingress probes

### DIFF
--- a/.github/workflows/deploy-admin-production.yml
+++ b/.github/workflows/deploy-admin-production.yml
@@ -216,6 +216,16 @@ jobs:
             # starts, regardless of which serialized main workflow runs first.
             cd "$PUBLIC_DEPLOY_DIR/roo-standalone"
             docker compose up -d --no-deps --force-recreate nginx
+            nginx_ready=0
+            for attempt in $(seq 1 18); do
+              if curl --silent --show-error --fail --max-time 5 \
+                http://127.0.0.1/healthz/ready >/dev/null; then
+                nginx_ready=1
+                break
+              fi
+              sleep 2
+            done
+            test "$nginx_ready" = "1"
             for path in /admin/slack/events /admin/slack/actions /admin/healthz/ready; do
               status="$(curl --silent --show-error --max-time 5 \
                 --output /dev/null --write-out '%{http_code}' \

--- a/roo-standalone/roo/tests/test_ai_security.py
+++ b/roo-standalone/roo/tests/test_ai_security.py
@@ -511,6 +511,10 @@ def test_admin_production_deploy_is_enforced_without_staging_or_shadow():
     assert "check_admin_pilot_config.py" in workflow
     assert "check_admin_pilot_access.py" in workflow
     assert "contextual_shadow_mode" in workflow
+    assert "nginx_ready=0" in workflow
+    assert workflow.index("nginx_ready=0") < workflow.index(
+        "for path in /admin/slack/events"
+    )
     assert "ROO_ADMIN_INTERNAL_ONLY=true" in workflow
     assert "ROO_UNIFIED_ADMIN_ROUTING_ENABLED" in workflow
     assert "ROO_ADMIN_ROUTER_API_KEY" in workflow


### PR DESCRIPTION
## Summary
- wait for the recreated public Nginx proxy to report ready before probing removed Admin routes
- keep the existing fail-closed 404 assertions
- cover ordering in the production deployment security test

## Verification
- workflow YAML parses successfully
- 
- .                                                                        [100%]
1 passed, 47 deselected in 0.59s