### PR TITLE
Package Admin production check scripts

### DIFF
--- a/roo-standalone/Dockerfile
+++ b/roo-standalone/Dockerfile
@@ -18,6 +18,7 @@ COPY roo/ ./roo/
 COPY skills/ ./skills/
 COPY ops/ ./ops/
 COPY bridge/ ./bridge/
+COPY scripts/ ./scripts/
 
 EXPOSE 8000
 

--- a/roo-standalone/roo/tests/test_ai_security.py
+++ b/roo-standalone/roo/tests/test_ai_security.py
@@ -493,6 +493,7 @@ def test_admin_production_deploy_is_enforced_without_staging_or_shadow():
     admin_compose = (
         REPO_ROOT / "roo-standalone/docker-compose.admin.yml"
     ).read_text()
+    dockerfile = (REPO_ROOT / "roo-standalone/Dockerfile").read_text()
     nginx = (REPO_ROOT / "roo-standalone/nginx/roo.conf").read_text()
 
     assert "push:" in workflow
@@ -524,6 +525,7 @@ def test_admin_production_deploy_is_enforced_without_staging_or_shadow():
     assert "ADMIN_ROO_OPENAI_API_KEY" not in workflow
     assert "roo-admin-gateway" in public_compose
     assert "roo-admin-gateway" in admin_compose
+    assert "COPY scripts/ ./scripts/" in dockerfile
     assert "ports:" not in admin_compose
     assert "roo.admin_worker:app" in admin_compose
     assert "location = /admin/slack/events" not in nginx


### PR DESCRIPTION
## Summary
- copy the governed production check scripts into the Roo image
- assert the Admin production Dockerfile keeps packaging them

## Verification
- built the Roo standalone Dockerfile successfully
- verified all three production check scripts exist inside the image
- git diff --check
- targeted Admin production deployment security test passed