### PR TITLE
Route eligible admins from public Slack channels

### DIFF
--- a/roo-standalone/docs/admin-roo-deployment.md
+++ b/roo-standalone/docs/admin-roo-deployment.md
@@ -151,9 +151,13 @@ After deployment, verify in Slack:
 
 - an eligible committee member can ask an internal-memory question in a DM or
   approved private channel;
+- when the reviewed manifest contains `public_channels:pilot_admins`, an
+  eligible committee member can also ask in any public channel; Roo adds a
+  warning that everyone in the channel can read the answer;
 - that same member's points request still uses the normal Public Roo flow;
 - other PointsAdmin classes and unmapped users receive a generic denial;
-- public-channel internal-memory requests are denied before backend retrieval;
+- public-channel internal-memory requests from non-pilot actors are denied
+  before backend retrieval;
 - a mixed memory-plus-action request asks to split the tasks; and
 - normal Public Roo behavior is unchanged.
 

--- a/roo-standalone/roo/admin_pilot_config.py
+++ b/roo-standalone/roo/admin_pilot_config.py
@@ -10,8 +10,10 @@ from typing import Any, Mapping
 
 
 _ACTOR_RE = re.compile(r"^slack:[UW][A-Z0-9]{1,63}$")
+PUBLIC_PILOT_ADMIN_CONTEXT = "public_channels:pilot_admins"
 _CONTEXT_RE = re.compile(
-    r"^(?:dm:[UW][A-Z0-9]{1,63}|channel:G[A-Z0-9]{1,63})$"
+    r"^(?:dm:[UW][A-Z0-9]{1,63}|channel:G[A-Z0-9]{1,63}|"
+    r"public_channels:pilot_admins)$"
 )
 
 
@@ -45,7 +47,7 @@ def admin_pilot_config_report(
     organization_domain: str,
     now: datetime | None = None,
 ) -> dict[str, Any]:
-    """Compare effective Roo settings with an exact private pilot manifest."""
+    """Compare effective Roo settings with an exact pilot manifest."""
 
     now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
     blockers: list[str] = []

--- a/roo-standalone/roo/admin_pilot_smoke.py
+++ b/roo-standalone/roo/admin_pilot_smoke.py
@@ -7,7 +7,10 @@ from typing import Any, Awaitable, Callable, Mapping
 
 import httpx
 
-from .admin_pilot_config import admin_pilot_config_report
+from .admin_pilot_config import (
+    PUBLIC_PILOT_ADMIN_CONTEXT,
+    admin_pilot_config_report,
+)
 from .backend_identity import (
     BackendActorContext,
     BackendIdentityError,
@@ -111,6 +114,10 @@ async def admin_pilot_signed_smoke_report(
         for reference in approval_manifest["allowed_slack_contexts"]
         if reference.startswith("dm:")
     ]
+    public_channels_for_pilot_admins = (
+        PUBLIC_PILOT_ADMIN_CONTEXT
+        in approval_manifest["allowed_slack_contexts"]
+    )
     probe_request = probe or (
         lambda context: _live_probe(settings, context)
     )
@@ -137,6 +144,11 @@ async def admin_pilot_signed_smoke_report(
         allowed_statuses.append(
             await status_for(actor_id, "DPILOTSMOKECHECK")
         )
+    if public_channels_for_pilot_admins:
+        for actor_id in actor_ids:
+            allowed_statuses.append(
+                await status_for(actor_id, "CPILOTSMOKECHECK")
+            )
 
     synthetic_actor_id = "UPILOTSMOKEDENY"
     while synthetic_actor_id in actor_ids:
@@ -158,17 +170,31 @@ async def admin_pilot_signed_smoke_report(
         denied_statuses.append(
             await status_for(actor_id, synthetic_private_channel_id)
         )
+        if not public_channels_for_pilot_admins:
+            denied_statuses.append(
+                await status_for(actor_id, synthetic_public_channel_id)
+            )
+    if public_channels_for_pilot_admins:
         denied_statuses.append(
-            await status_for(actor_id, synthetic_public_channel_id)
+            await status_for(
+                synthetic_actor_id,
+                synthetic_public_channel_id,
+            )
         )
 
     approved_context = (
         private_channel_ids[0]
         if private_channel_ids
-        else "DPILOTSMOKECHECK"
+        else (
+            "DPILOTSMOKECHECK"
+            if dm_actor_ids
+            else "CPILOTSMOKECHECK"
+        )
     )
     approved_actor = (
-        actor_ids[0] if private_channel_ids else dm_actor_ids[0]
+        actor_ids[0]
+        if private_channel_ids or public_channels_for_pilot_admins
+        else dm_actor_ids[0]
     )
     public_client = MLAIBackendClient(
         base_url=settings.MLAI_BACKEND_URL,

--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -550,17 +550,17 @@ class RooAgent:
                 "skill_used": "admin-brain",
                 "data": {"admin_brain": True, "routed_surface": "admin"},
             }
-        if not str(channel_id).startswith(("D", "G")):
+        if not str(channel_id).startswith(("C", "D", "G")):
             return {
                 "message": (
                     "I can only use internal organisational memory in an approved "
-                    "DM or private Slack channel."
+                    "Slack context."
                 ),
                 "skill_used": "admin-brain",
                 "data": {
                     "admin_brain": True,
                     "routed_surface": "admin",
-                    "reason": "private_context_required",
+                    "reason": "slack_context_unsupported",
                 },
             }
 
@@ -637,9 +637,27 @@ class RooAgent:
             }
         data = dict(result.get("data") or {})
         data["routed_surface"] = "admin"
+        public_channel_delivery = str(channel_id).startswith("C")
+        data["public_channel_delivery"] = public_channel_delivery
+        message = result["message"]
+        blocks = result.get("blocks")
+        if public_channel_delivery:
+            warning = (
+                "*⚠️ Admin Roo answer posted publicly — everyone in this "
+                "channel can read it.*"
+            )
+            message = f"{warning}\n\n{message}"
+            if isinstance(blocks, list):
+                blocks = [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": warning},
+                    },
+                    *blocks,
+                ]
         return {
-            "message": result["message"],
-            "blocks": result.get("blocks"),
+            "message": message,
+            "blocks": blocks,
             "suppress_post": bool(result.get("suppress_post")),
             "skill_used": "admin-brain",
             "data": data,

--- a/roo-standalone/roo/tests/test_admin_pilot_config.py
+++ b/roo-standalone/roo/tests/test_admin_pilot_config.py
@@ -112,7 +112,7 @@ def test_shadow_mode_fails_the_production_config_gate():
     assert "admin_shadow_mode_must_remain_disabled" in report["blockers"]
 
 
-def test_public_channel_approval_and_expiry_fail_closed():
+def test_literal_public_channel_id_and_expiry_fail_closed():
     now = datetime.now(timezone.utc)
     manifest = approval_manifest(now)
     manifest["allowed_slack_contexts"] = ["channel:CPUBLIC123"]
@@ -131,3 +131,21 @@ def test_public_channel_approval_and_expiry_fail_closed():
     assert not report["ready"]
     assert "approval_not_current" in report["blockers"]
     assert "approval_private_contexts_invalid" in report["blockers"]
+
+
+def test_actor_bound_public_channel_scope_is_valid():
+    now = datetime.now(timezone.utc)
+    manifest = approval_manifest(now)
+    manifest["allowed_slack_contexts"].append(
+        "public_channels:pilot_admins"
+    )
+
+    report = admin_pilot_config_report(
+        configured_settings(),
+        manifest,
+        organization_domain="mlai.au",
+        now=now,
+    )
+
+    assert report["ready"]
+    assert report["blockers"] == []

--- a/roo-standalone/roo/tests/test_admin_pilot_smoke.py
+++ b/roo-standalone/roo/tests/test_admin_pilot_smoke.py
@@ -49,6 +49,7 @@ def approval_manifest():
         "allowed_slack_contexts": [
             "dm:UADMIN123",
             "channel:GADMIN123",
+            "public_channels:pilot_admins",
         ],
         "approved_providers": ["google_drive"],
         "approved_source_scopes": {
@@ -74,7 +75,11 @@ async def test_signed_smoke_checks_allow_deny_and_public_client_boundaries():
         if (
             context.acting_slack_user_id == "UADMIN123"
             and context.slack_channel_id
-            in {"GADMIN123", "DPILOTSMOKECHECK"}
+            in {
+                "GADMIN123",
+                "DPILOTSMOKECHECK",
+                "CPILOTSMOKECHECK",
+            }
         ):
             return 200
         if context.acting_slack_user_id == "UPILOTSMOKEDENY":
@@ -91,13 +96,13 @@ async def test_signed_smoke_checks_allow_deny_and_public_client_boundaries():
 
     assert report["ready"]
     assert report["metrics"] == {
-        "expected_allow_cases": 2,
-        "allowed_cases": 2,
+        "expected_allow_cases": 3,
+        "allowed_cases": 3,
         "expected_deny_cases": 4,
         "denied_cases": 4,
         "public_client_isolated": True,
     }
-    assert len(calls) == 6
+    assert len(calls) == 7
     rendered = str(report)
     assert "UADMIN123" not in rendered
     assert "GADMIN123" not in rendered

--- a/roo-standalone/roo/tests/test_unified_admin_routing.py
+++ b/roo-standalone/roo/tests/test_unified_admin_routing.py
@@ -180,7 +180,7 @@ def test_admin_task_uses_content_free_eligibility_then_internal_dispatch(monkeyp
     assert captured["dispatch"]["context"] == _context()
 
 
-def test_admin_route_fails_closed_for_non_private_context_or_denied_actor(monkeypatch):
+def test_admin_route_checks_public_context_and_fails_closed_for_denied_actor(monkeypatch):
     agent = _agent()
     calls = []
 
@@ -205,8 +205,8 @@ def test_admin_route_fails_closed_for_non_private_context_or_denied_actor(monkey
                 thread_ts="1700000000.123",
             )
         )
-    assert public_result["data"]["reason"] == "private_context_required"
-    assert calls == []
+    assert public_result["data"]["reason"] == "committee_policy_denied"
+    assert calls == ["eligibility"]
 
     with use_backend_actor_context(_context()):
         denied_result = asyncio.run(
@@ -219,4 +219,61 @@ def test_admin_route_fails_closed_for_non_private_context_or_denied_actor(monkey
             )
         )
     assert denied_result["data"]["reason"] == "committee_policy_denied"
-    assert calls == ["eligibility"]
+    assert calls == ["eligibility", "eligibility"]
+
+
+def test_eligible_admin_task_dispatches_in_public_channel_with_warning(monkeypatch):
+    agent = _agent()
+    captured = {}
+
+    class EligibleClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def get_admin_routing_eligibility(self):
+            return {"admin_brain_eligible": True}
+
+    class FakeDispatchClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def dispatch(self, **kwargs):
+            captured["dispatch"] = kwargs
+            return {
+                "result": {
+                    "message": "*🔒 Internal organisational memory*\nAnswer",
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {"type": "mrkdwn", "text": "Answer"},
+                        }
+                    ],
+                    "data": {"query_id": "q-public"},
+                },
+                "destination": {
+                    "channel_id": "CPUBLIC123",
+                    "thread_ts": "1700000000.123",
+                    "requester_user_id": "UADMIN123",
+                },
+            }
+
+    monkeypatch.setattr("roo.agent.get_settings", _settings)
+    monkeypatch.setattr("roo.agent.MLAIBackendClient", EligibleClient)
+    monkeypatch.setattr("roo.agent.AdminDispatchClient", FakeDispatchClient)
+
+    with use_backend_actor_context(_context("CPUBLIC123")):
+        result = asyncio.run(
+            agent._execute_unified_admin_brain(
+                text="Summarise committee decisions",
+                params={},
+                user_id="UADMIN123",
+                channel_id="CPUBLIC123",
+                thread_ts="1700000000.123",
+            )
+        )
+
+    assert result["data"]["routed_surface"] == "admin"
+    assert result["data"]["public_channel_delivery"] is True
+    assert "everyone in this channel can read it" in result["message"]
+    assert "everyone in this channel can read it" in str(result["blocks"][0])
+    assert captured["dispatch"]["context"] == _context("CPUBLIC123")

--- a/roo-standalone/roo/tests/test_unified_admin_smoke.py
+++ b/roo-standalone/roo/tests/test_unified_admin_smoke.py
@@ -36,7 +36,11 @@ def _manifest():
         "approval_status": "approved",
         "review_due_at": (now + timedelta(days=30)).isoformat(),
         "pilot_admin_refs": ["slack:UADMIN123"],
-        "allowed_slack_contexts": ["dm:UADMIN123", "channel:GADMIN123"],
+        "allowed_slack_contexts": [
+            "dm:UADMIN123",
+            "channel:GADMIN123",
+            "public_channels:pilot_admins",
+        ],
     }
 
 
@@ -48,7 +52,11 @@ async def test_route_smoke_accepts_only_eligible_private_cases():
         calls.append(context)
         if context.acting_slack_user_id != "UADMIN123":
             return 401, False
-        if context.slack_channel_id in {"GADMIN123", "DPILOTROUTECHECK"}:
+        if context.slack_channel_id in {
+            "GADMIN123",
+            "DPILOTROUTECHECK",
+            "CPILOTROUTECHECK",
+        }:
             return 200, True
         return 200, False
 
@@ -63,12 +71,12 @@ async def test_route_smoke_accepts_only_eligible_private_cases():
 
     assert report["ready"]
     assert report["metrics"] == {
-        "expected_allow_cases": 2,
-        "eligible_cases": 2,
+        "expected_allow_cases": 3,
+        "eligible_cases": 3,
         "expected_deny_cases": 3,
         "denied_cases": 3,
     }
-    assert len(calls) == 5
+    assert len(calls) == 6
     assert "UADMIN123" not in str(report)
 
 

--- a/roo-standalone/roo/unified_admin_smoke.py
+++ b/roo-standalone/roo/unified_admin_smoke.py
@@ -6,7 +6,10 @@ from typing import Awaitable, Callable
 
 import httpx
 
-from .admin_pilot_config import admin_pilot_config_report
+from .admin_pilot_config import (
+    PUBLIC_PILOT_ADMIN_CONTEXT,
+    admin_pilot_config_report,
+)
 from .backend_identity import BackendActorContext
 from .clients.mlai_backend import MLAIBackendClient, MLAIBackendUnavailableError
 
@@ -67,7 +70,12 @@ async def unified_admin_route_smoke_report(
 
     actor_ids = [value.split(":", 1)[1] for value in approval_manifest["pilot_admin_refs"]]
     contexts = []
+    public_channels_for_pilot_admins = False
     for value in approval_manifest["allowed_slack_contexts"]:
+        if value == PUBLIC_PILOT_ADMIN_CONTEXT:
+            public_channels_for_pilot_admins = True
+            contexts.append("CPILOTROUTECHECK")
+            continue
         kind, identifier = value.split(":", 1)
         if kind == "channel":
             contexts.append(identifier)
@@ -105,7 +113,10 @@ async def unified_admin_route_smoke_report(
         denied.append(await decision(synthetic_actor, contexts[0]))
     for actor_id in actor_ids:
         denied.append(await decision(actor_id, "GROUTESMOKEDENY"))
-        denied.append(await decision(actor_id, "CROUTESMOKEDENY"))
+        if not public_channels_for_pilot_admins:
+            denied.append(await decision(actor_id, "CROUTESMOKEDENY"))
+    if public_channels_for_pilot_admins:
+        denied.append(await decision(synthetic_actor, "CROUTESMOKEDENY"))
 
     report["metrics"] = {
         "expected_allow_cases": len(allowed),


### PR DESCRIPTION
## What changed

- Let public Slack channel IDs reach the backend's content-free Admin Roo eligibility decision.
- Dispatch only when the backend confirms the caller and context are eligible.
- Add a prominent warning to public Admin Roo answers stating that everyone in the channel can read them.
- Extend configuration and signed-route smoke gates for `public_channels:pilot_admins`, including non-admin denial and Public Roo isolation checks.

## Why

The Roo gateway previously rejected every public channel before it could evaluate an authorised committee admin. This enables the single `@Roo` experience while leaving ordinary public requests on Public Roo.

## Validation

- Official Admin trust-boundary selection: 87 passed.
- Focused public-routing/config/smoke selection: 16 passed.
- `python -m compileall -q roo bridge` passed.
- `git diff --check` passed.
