### PR TITLE
Add Roo event finance audit

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -1722,6 +1722,32 @@ class MLAIBackendClient:
         self._raise_for_status_or_backend_unavailable(response)
         return response.json()
 
+    async def get_event_finance_audit(
+        self,
+        slack_user_id: str,
+        *,
+        since: str,
+        until: str,
+        domain: str = "mlai.au",
+    ) -> dict:
+        """Get the read-only event revenue/cost completeness audit."""
+        response = await self._request(
+            "GET",
+            "/api/v1/integrations/reconciliation/event-finance-audit",
+            params={
+                "slack_user_id": self._clean_slack_id(slack_user_id),
+                "domain": str(domain or "mlai.au").strip().lower(),
+                "since": since,
+                "until": until,
+            },
+            timeout=90.0,
+            transport_retries=1,
+            retry_backoff_seconds=0.25,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
     async def get_data_catalog(self, requester_slack_id: str) -> dict:
         """Get the requester's curated read-only data resource catalog."""
         response = await self._request(

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -82,6 +82,7 @@ class Settings(BaseSettings):
     ROO_API_KEY: Optional[str] = None
     INTERNAL_API_KEY: Optional[str] = None
     INTERNAL_MENTION_API_KEY: Optional[str] = None
+    RECONCILIATION_DOMAIN: str = "mlai.au"
     LINEAR_DEFAULT_TEAM: Optional[str] = None
 
     # Public/Admin trust boundary. Admin starts with no skills and no private

--- a/roo-standalone/roo/routing_eval/cases/event_finance_audit.yaml
+++ b/roo-standalone/roo/routing_eval/cases/event_finance_audit.yaml
@@ -1,0 +1,12 @@
+- id: event-finance-audit-user-phrase
+  text: "for all the events we have, they should usually have ticket sales and sponsorship as revenue, and catering and contractors as costs. audit all events in the last 6 months and tell me which have these and which are missing"
+  expect:
+    skill: reconciliation-report
+    action: audit_event_finances
+    params_subset: {months: 6}
+  tags: [event-finance-audit, v2]
+
+- id: event-finance-audit-missing-categories
+  text: "which recent events are missing sponsorship revenue, catering, or contractor expenses?"
+  expect: {skill: reconciliation-report, action: audit_event_finances}
+  tags: [event-finance-audit, v2, paraphrase]

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -5913,6 +5913,14 @@ Chunk {index} source: {label}
         the report, posts a summary, and uploads the Cowork brief (.md) + audit
         workbook (.xlsx) to the thread.
         """
+        if str(params.get("action") or "").strip().lower() == "audit_event_finances":
+            return await self._execute_event_finance_audit(
+                params=params,
+                user_id=user_id,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+            )
+
         settings = get_settings()
         if not getattr(settings, "MLAI_BACKEND_URL", None):
             return (
@@ -6009,6 +6017,251 @@ Chunk {index} source: {label}
                 "uploaded_filenames": uploaded,
             },
         }
+
+    async def _execute_event_finance_audit(
+        self,
+        *,
+        params: dict,
+        user_id: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+    ) -> Any:
+        """Audit recent events for expected revenue and cost evidence."""
+        settings = get_settings()
+        if not getattr(settings, "MLAI_BACKEND_URL", None):
+            return (
+                "The event finance audit needs mlai-backend to be configured. "
+                "Ask the team to set `MLAI_BACKEND_URL`."
+            )
+        if not channel_id:
+            return "I need a Slack channel or DM to upload the event finance audit."
+
+        since, until = self._resolve_event_finance_audit_period(params)
+        if since > until:
+            return "The audit start date needs to be on or before the end date."
+
+        from roo.clients.mlai_backend import MLAIBackendClient, MLAIBackendUnavailableError
+
+        backend_client = MLAIBackendClient(
+            base_url=settings.MLAI_BACKEND_URL,
+            api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY,
+            internal_api_key=(
+                settings.INTERNAL_API_KEY
+                or settings.ROO_API_KEY
+                or settings.MLAI_API_KEY
+            ),
+        )
+        try:
+            audit = await backend_client.get_event_finance_audit(
+                user_id,
+                since=since.isoformat(),
+                until=until.isoformat(),
+                domain=getattr(settings, "RECONCILIATION_DOMAIN", "mlai.au"),
+            )
+        except MLAIBackendUnavailableError:
+            return "I'm having trouble reaching mlai-backend for the event finance audit right now. Try again in a tick."
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            detail = self._extract_luma_http_error_detail(exc)
+            if status_code == 403:
+                return (
+                    "Sorry mate, you'll need to be a Points Admin (`admin`, `committee`, "
+                    "or `portfolio_lead`) to run the event finance audit. 🔒"
+                )
+            return detail or f"mlai-backend returned HTTP {status_code} for the event finance audit."
+
+        from ..slack_client import upload_file
+
+        filename = f"event-finance-audit-{since.isoformat()}-to-{until.isoformat()}.md"
+        upload_file(
+            channel=channel_id,
+            content=self._event_finance_audit_markdown(audit),
+            filename=filename,
+            title="Event finance completeness audit",
+            thread_ts=thread_ts,
+        )
+        return {
+            "message": self._format_event_finance_audit(audit, filename),
+            "data": {
+                "action": "event_finance_audit",
+                "period_start": audit.get("period_start"),
+                "period_end": audit.get("period_end"),
+                "event_count": (audit.get("summary") or {}).get("event_count"),
+                "complete_count": (audit.get("summary") or {}).get("complete_count"),
+                "incomplete_count": (audit.get("summary") or {}).get("incomplete_count"),
+                "uploaded_filenames": [filename],
+                "xero_writes": bool(audit.get("xero_writes", False)),
+            },
+        }
+
+    def _resolve_event_finance_audit_period(
+        self,
+        params: dict,
+    ) -> tuple[date, date]:
+        until_text = self._clean_optional_iso_date(params.get("until"))
+        until = date.fromisoformat(until_text) if until_text else date.today()
+        since_text = self._clean_optional_iso_date(params.get("since"))
+        if since_text:
+            return date.fromisoformat(since_text), until
+        try:
+            months = int(params.get("months") or 6)
+        except (TypeError, ValueError):
+            months = 6
+        months = max(1, min(months, 24))
+        month_index = until.year * 12 + until.month - 1 - months
+        since_year, since_month_zero = divmod(month_index, 12)
+        since_month = since_month_zero + 1
+        since_day = min(until.day, calendar.monthrange(since_year, since_month)[1])
+        return date(since_year, since_month, since_day), until
+
+    @staticmethod
+    def _markdown_cell(value: Any) -> str:
+        return str(value or "").replace("|", "\\|").replace("\n", " ").strip()
+
+    def _event_finance_audit_markdown(self, audit: dict) -> str:
+        summary = audit.get("summary") or {}
+        requirements = audit.get("required_categories") or []
+        labels = {item.get("key"): item.get("label") for item in requirements}
+        lines = [
+            "# Event finance completeness audit",
+            "",
+            f"Period: {audit.get('period_start')} to {audit.get('period_end')}",
+            "",
+            (
+                f"Events: {summary.get('event_count', 0)}; complete: "
+                f"{summary.get('complete_count', 0)}; incomplete: "
+                f"{summary.get('incomplete_count', 0)}."
+            ),
+            "",
+            "> Missing means no tracked evidence was found in the period. It does not prove the event had no such revenue or cost.",
+            "",
+            "| Event | Date | Ticket sales | Sponsorship | Catering | Contractors | Missing |",
+            "|---|---|---:|---:|---:|---:|---|",
+        ]
+        symbols = {"present": "Yes", "missing": "Missing"}
+        for event in audit.get("events") or []:
+            categories = event.get("categories") or {}
+            start_at = str(event.get("start_at") or "")[:10] or "—"
+            missing = ", ".join(
+                str(labels.get(key) or key) for key in event.get("missing_categories") or []
+            ) or "—"
+            lines.append(
+                "| "
+                + " | ".join(
+                    [
+                        self._markdown_cell(event.get("event_name")),
+                        start_at,
+                        symbols.get((categories.get("ticket_sales") or {}).get("status"), "Missing"),
+                        symbols.get((categories.get("sponsorship_revenue") or {}).get("status"), "Missing"),
+                        symbols.get((categories.get("catering_cost") or {}).get("status"), "Missing"),
+                        symbols.get((categories.get("contractor_cost") or {}).get("status"), "Missing"),
+                        self._markdown_cell(missing),
+                    ]
+                )
+                + " |"
+            )
+
+        lines.extend(["", "## Evidence", ""])
+        for event in audit.get("events") or []:
+            lines.append(f"### {event.get('event_name')}")
+            lines.append("")
+            for requirement in requirements:
+                category = (event.get("categories") or {}).get(requirement.get("key")) or {}
+                evidence = category.get("evidence") or []
+                if not evidence:
+                    lines.append(f"- {requirement.get('label')}: **Missing**")
+                    continue
+                observations = []
+                for item in evidence:
+                    amount = int(item.get("amount_cents") or 0) / 100
+                    if item.get("source_type") == "xero_bank_transaction_line":
+                        context = "; ".join(
+                            value
+                            for value in (
+                                str(item.get("date") or ""),
+                                str(item.get("account_name") or item.get("account_code") or ""),
+                                str(item.get("contact_name") or ""),
+                                str(item.get("description") or ""),
+                                str(item.get("reference") or ""),
+                            )
+                            if value
+                        )
+                    else:
+                        context = f"{item.get('source_type')} {item.get('source_id')}"
+                    observations.append(f"AUD {amount:,.2f} ({context})")
+                lines.append(
+                    f"- {requirement.get('label')}: **Present** — "
+                    + "; ".join(observations)
+                )
+            lines.append("")
+
+        warnings = audit.get("account_resolution_warnings") or []
+        if warnings:
+            lines.extend(
+                [
+                    "## Account resolution warnings",
+                    "",
+                    "The following category accounts could not be resolved from Xero: "
+                    + ", ".join(warnings),
+                    "",
+                ]
+            )
+        lines.extend(["## Limitations", ""])
+        lines.extend(f"- {item}" for item in audit.get("limitations") or [])
+        lines.extend(["", "This audit is read-only and made no Xero writes.", ""])
+        return "\n".join(lines)
+
+    def _format_event_finance_audit(self, audit: dict, filename: str) -> str:
+        summary = audit.get("summary") or {}
+        event_count = int(summary.get("event_count") or 0)
+        if not event_count:
+            return (
+                f"*Event finance audit* — no events were found from {audit.get('period_start')} "
+                f"to {audit.get('period_end')}.\n📎 Uploaded `{filename}`.\n"
+                "Read-only: no Xero changes were made."
+            )
+        missing_counts = summary.get("missing_counts") or {}
+        labels = {
+            "ticket_sales": "ticket sales",
+            "sponsorship_revenue": "sponsorship",
+            "catering_cost": "catering",
+            "contractor_cost": "contractors",
+        }
+        lines = [
+            f"*Event finance audit* — {audit.get('period_start')} to {audit.get('period_end')}",
+            (
+                f"✅ {summary.get('complete_count', 0)} of {event_count} event(s) have all four "
+                f"categories; ⚠️ {summary.get('incomplete_count', 0)} are missing evidence."
+            ),
+            "Missing across events: "
+            + ", ".join(
+                f"{labels[key]} {int(missing_counts.get(key) or 0)}"
+                for key in labels
+            )
+            + ".",
+        ]
+        incomplete = [
+            event
+            for event in audit.get("events") or []
+            if event.get("completeness_status") == "incomplete"
+        ]
+        for event in incomplete[:10]:
+            missing = ", ".join(
+                labels.get(key, key) for key in event.get("missing_categories") or []
+            )
+            lines.append(f"• {event.get('event_name')}: missing {missing}")
+        if len(incomplete) > 10:
+            lines.append(f"• …and {len(incomplete) - 10} more in the attachment.")
+        if audit.get("account_resolution_warnings"):
+            lines.append("⚠️ One or more expected Xero accounts could not be resolved; see the attachment.")
+        lines.extend(
+            [
+                "",
+                f"📎 Uploaded `{filename}` with every event and its evidence.",
+                "Read-only: no Xero changes were made. “Missing” means no tracked evidence in the period, not proof the category did not exist.",
+            ]
+        )
+        return "\n".join(lines)
 
     def _resolve_reconciliation_days(self, params: dict) -> int:
         raw = params.get("days")

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -539,3 +539,41 @@ async def test_confirm_article_topic_includes_requested_by_when_provided(monkeyp
 
     assert captured["json"]["slack_user_id"] == "U0AQV5X9G0J"
     assert captured["json"]["requested_by_slack_user_id"] == "U05QPB483K9"
+
+
+@pytest.mark.asyncio
+async def test_event_finance_audit_uses_read_only_bounded_endpoint(monkeypatch):
+    captured = {}
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured.update(method=method, endpoint=endpoint, kwargs=kwargs)
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(
+            200,
+            request=request,
+            json={"summary": {"event_count": 3}, "xero_writes": False},
+        )
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.get_event_finance_audit(
+        "<@UADMIN>",
+        since="2026-02-02",
+        until="2026-08-02",
+        domain="MLAI.AU",
+    )
+
+    assert captured["method"] == "GET"
+    assert captured["endpoint"] == "/api/v1/integrations/reconciliation/event-finance-audit"
+    assert captured["kwargs"]["params"] == {
+        "slack_user_id": "UADMIN",
+        "domain": "mlai.au",
+        "since": "2026-02-02",
+        "until": "2026-08-02",
+    }
+    assert result["xero_writes"] is False

--- a/roo-standalone/roo/tests/test_reconciliation_report.py
+++ b/roo-standalone/roo/tests/test_reconciliation_report.py
@@ -43,8 +43,74 @@ def _report(**overrides):
     return report
 
 
+def _audit(**overrides):
+    audit = {
+        "schema_version": 1,
+        "audit_version": "reconciliation-event-finance-audit-v1",
+        "period_start": "2026-02-02",
+        "period_end": "2026-08-02",
+        "required_categories": [
+            {"key": "ticket_sales", "label": "Ticket sales", "kind": "revenue"},
+            {"key": "sponsorship_revenue", "label": "Sponsorship revenue", "kind": "revenue"},
+            {"key": "catering_cost", "label": "Catering cost", "kind": "cost"},
+            {"key": "contractor_cost", "label": "Contractor cost", "kind": "cost"},
+        ],
+        "events": [
+            {
+                "event_name": "Complete Gala",
+                "start_at": "2026-06-10T10:00:00+00:00",
+                "completeness_status": "complete",
+                "present_categories": ["ticket_sales", "sponsorship_revenue", "catering_cost", "contractor_cost"],
+                "missing_categories": [],
+                "categories": {
+                    "ticket_sales": {
+                        "status": "present",
+                        "evidence": [{"source_type": "luma_event", "source_id": "evt-1", "amount_cents": 10000}],
+                    },
+                    "sponsorship_revenue": {
+                        "status": "present",
+                        "evidence": [{"source_type": "xero_bank_transaction_line", "source_id": "bt-1:0", "amount_cents": 50000, "date": "2026-06-11", "account_name": "Sponsorships & Grants", "contact_name": "Sponsor Co"}],
+                    },
+                    "catering_cost": {"status": "present", "evidence": [{"source_type": "xero_bank_transaction_line", "source_id": "bt-2:0", "amount_cents": 20000, "account_name": "Catering / Food & Beverages"}]},
+                    "contractor_cost": {"status": "present", "evidence": [{"source_type": "xero_bank_transaction_line", "source_id": "bt-3:0", "amount_cents": 30000, "account_name": "Contractor Expenses"}]},
+                },
+            },
+            {
+                "event_name": "Ticket Only Night",
+                "start_at": "2026-07-01T10:00:00+00:00",
+                "completeness_status": "incomplete",
+                "present_categories": ["ticket_sales"],
+                "missing_categories": ["sponsorship_revenue", "catering_cost", "contractor_cost"],
+                "categories": {
+                    "ticket_sales": {"status": "present", "evidence": [{"source_type": "luma_event", "source_id": "evt-2", "amount_cents": 7500}]},
+                    "sponsorship_revenue": {"status": "missing", "evidence": []},
+                    "catering_cost": {"status": "missing", "evidence": []},
+                    "contractor_cost": {"status": "missing", "evidence": []},
+                },
+            },
+        ],
+        "summary": {
+            "event_count": 2,
+            "complete_count": 1,
+            "incomplete_count": 1,
+            "missing_counts": {
+                "ticket_sales": 0,
+                "sponsorship_revenue": 1,
+                "catering_cost": 1,
+                "contractor_cost": 1,
+            },
+        },
+        "account_resolution_warnings": [],
+        "limitations": ["Missing means no tracked evidence was found in this period."],
+        "xero_writes": False,
+    }
+    audit.update(overrides)
+    return audit
+
+
 class FakeReconBackendClient:
     report = _report()
+    audit = _audit()
     unavailable = False
     status_code = None
     calls = []
@@ -62,6 +128,16 @@ class FakeReconBackendClient:
             raise httpx.HTTPStatusError("backend error", request=request, response=response)
         return self.report
 
+    async def get_event_finance_audit(self, slack_user_id, **kwargs):
+        self.__class__.calls.append({"method": "audit", "slack_user_id": slack_user_id, **kwargs})
+        if self.unavailable:
+            raise backend_module.MLAIBackendUnavailableError("backend unavailable")
+        if self.status_code:
+            request = httpx.Request("GET", "https://backend.test/api/v1/integrations/reconciliation/event-finance-audit")
+            response = httpx.Response(self.status_code, json={"error": f"backend {self.status_code}"}, request=request)
+            raise httpx.HTTPStatusError("backend error", request=request, response=response)
+        return self.audit
+
 
 def _settings(**overrides):
     values = {
@@ -69,6 +145,7 @@ def _settings(**overrides):
         "MLAI_API_KEY": "api-key",
         "ROO_API_KEY": "roo-api-key",
         "INTERNAL_API_KEY": "internal-key",
+        "RECONCILIATION_DOMAIN": "mlai.au",
     }
     values.update(overrides)
     return SimpleNamespace(**values)
@@ -76,6 +153,7 @@ def _settings(**overrides):
 
 def _reset(monkeypatch, *, uploaded=None, settings_overrides=None):
     FakeReconBackendClient.report = _report()
+    FakeReconBackendClient.audit = _audit()
     FakeReconBackendClient.unavailable = False
     FakeReconBackendClient.status_code = None
     FakeReconBackendClient.calls = []
@@ -195,3 +273,60 @@ async def test_rate_limited(monkeypatch):
     FakeReconBackendClient.status_code = 429
     result = await _run(executor)
     assert "rate-limited" in result.lower() or "429" in result
+
+
+@pytest.mark.asyncio
+async def test_event_finance_audit_uses_six_calendar_months_and_uploads_markdown(monkeypatch):
+    uploaded = []
+    executor = _reset(monkeypatch, uploaded=uploaded)
+
+    result = await _run(
+        executor,
+        text="audit all events in the last 6 months for ticket sales, sponsorship, catering and contractors",
+        params={"action": "audit_event_finances", "months": 6, "until": "2026-08-02"},
+    )
+
+    call = FakeReconBackendClient.calls[0]
+    assert call == {
+        "method": "audit",
+        "slack_user_id": "UADMIN",
+        "since": "2026-02-02",
+        "until": "2026-08-02",
+        "domain": "mlai.au",
+    }
+    assert len(uploaded) == 1
+    assert uploaded[0]["filename"] == "event-finance-audit-2026-02-02-to-2026-08-02.md"
+    assert "| Complete Gala | 2026-06-10 | Yes | Yes | Yes | Yes |" in uploaded[0]["content"]
+    assert "Ticket Only Night: missing sponsorship, catering, contractors" in result["message"]
+    assert "Read-only" in result["message"]
+    assert result["data"]["action"] == "event_finance_audit"
+    assert result["data"]["xero_writes"] is False
+
+
+@pytest.mark.asyncio
+async def test_event_finance_audit_preserves_explicit_since(monkeypatch):
+    executor = _reset(monkeypatch, uploaded=[])
+
+    await _run(
+        executor,
+        params={
+            "action": "audit_event_finances",
+            "since": "2026-03-01",
+            "until": "2026-08-02",
+        },
+    )
+
+    assert FakeReconBackendClient.calls[0]["since"] == "2026-03-01"
+
+
+@pytest.mark.asyncio
+async def test_event_finance_audit_non_admin_message(monkeypatch):
+    executor = _reset(monkeypatch, uploaded=[])
+    FakeReconBackendClient.status_code = 403
+
+    result = await _run(
+        executor,
+        params={"action": "audit_event_finances", "until": "2026-08-02"},
+    )
+
+    assert "Points Admin" in result

--- a/roo-standalone/skills/reconciliation_report/SKILL.md
+++ b/roo-standalone/skills/reconciliation_report/SKILL.md
@@ -1,23 +1,26 @@
 ---
 name: reconciliation-report
-description: Generate the Luma→Stripe reconciliation report — who bought tickets for which event, how much, and which Stripe payout each landed in — for Points Admins to reconcile in Xero.
+description: Generate Luma→Stripe reconciliation reports or audit recent events for expected ticket sales, sponsorship, catering, and contractor evidence in Xero.
 routing:
   use_when: >
     A Points Admin asks for a reconciliation or ticket-sales/payout report that
-    combines Luma and Stripe: e.g. "reconcile the last 30 days of Luma events and
-    Stripe sales", "which payments are inside our Stripe payouts / bank deposits",
-    "monthly ticket reconciliation report". Produces a brief + workbook to
-    reconcile the Stripe payouts against the bank feed in Xero.
+    combines Luma and Stripe, or asks to audit events for expected finance
+    categories: ticket sales and sponsorship revenue, plus catering and contractor
+    costs. Examples include "reconcile the last 30 days", "which payments are in
+    our Stripe payouts", and "audit all events in the last six months and tell me
+    which are missing ticket sales, sponsorship, catering, or contractors".
   avoid_when: >
     Attendee registration counts or check-ins only (luma-events). General curated
     data questions (mlai-data-query). Points balances, tasks, awards, or coworking
-    reports (mlai-points). Anything not about Luma ticket payments settling to the
-    bank via Stripe payouts.
+    reports (mlai-points). General accounting questions that do not ask for event
+    reconciliation, event finance completeness, or Stripe payout evidence.
   examples:
     - {text: "give me a report of the last 30 days of luma events and stripe sales", action: generate_report}
     - {text: "which payments are in the stripe payouts that hit our bank account?", action: generate_report}
     - {text: "reconciliation report for June please", action: generate_report}
     - {text: "reconcile luma ticket sales against stripe for the last month", action: generate_report}
+    - {text: "audit all events in the last 6 months for ticket sales, sponsorship, catering and contractor costs", action: audit_event_finances}
+    - {text: "which recent events are missing sponsorship revenue or contractor expenses?", action: audit_event_finances}
   negative_examples:
     - {text: "how many people checked in to the AI Engineer event?", instead: luma-events}
     - {text: "what's my points balance?", instead: mlai-points}
@@ -29,16 +32,21 @@ actions:
       days: {type: integer, description: "Rolling window in days (default 30, max 92)."}
       since: {type: string, description: "Optional window start YYYY-MM-DD (overrides days)."}
       until: {type: string, description: "Optional window end YYYY-MM-DD."}
+  - name: audit_event_finances
+    description: Audit recent events for expected ticket sales, sponsorship, catering, and contractor evidence and upload the full findings.
+    params:
+      months: {type: integer, description: "Rolling calendar-month window (default 6, max 24)."}
+      since: {type: string, description: "Optional window start YYYY-MM-DD (overrides months)."}
+      until: {type: string, description: "Optional window end YYYY-MM-DD (default today)."}
 requires_auth: true
 ---
 
 # Reconciliation Report Skill
 
-Generates MLAI's monthly Luma→Stripe reconciliation report so a Points Admin can
-reconcile the batched Stripe payouts against the Xero bank feed. Because Luma
-processes card payments through MLAI's own Stripe account, a Luma ticket sale and
-a Stripe charge are two views of the same transaction; Stripe settles them to the
-bank as batched payouts — the payout is what gets reconciled.
+Generates MLAI's monthly Luma→Stripe reconciliation report and a separate
+event-finance completeness audit for Points Admins. The audit checks each selected
+Luma event, Humanitix event, and event found through Xero tracking for evidence of
+the categories MLAI normally expects.
 
 ## Capabilities
 
@@ -48,27 +56,30 @@ bank as batched payouts — the payout is what gets reconciled.
   buyers, gross/fees, and the net that hit the bank.
 - Upload the **Cowork brief** (markdown) and the **audit workbook** (xlsx) to the
   thread so they can be handed to Claude Cowork for the Xero reconcile.
+- Audit a rolling six-calendar-month window (or explicit dates) for ticket sales,
+  sponsorship revenue, catering costs, and contractor costs.
+- Upload a PII-minimized markdown audit showing every event, present/missing
+  categories, and the evidence behind each present category.
 
 ## Parameters
 
-- **action**: `generate_report`.
+- **action**: `generate_report` or `audit_event_finances`.
 - **days**: Rolling window size in days. Default 30, capped at 92.
-- **since** / **until**: Optional explicit window (`YYYY-MM-DD`); `since` overrides `days`.
+- **months**: Audit window in calendar months. Default 6, capped at 24.
+- **since** / **until**: Optional explicit window (`YYYY-MM-DD`); `since` overrides the rolling window.
 
 ## Workflow
 
 1. Confirm the requester is a Points Admin (mlai-backend also enforces this).
-2. Ask mlai-backend for the report with the requester's Slack ID.
-3. Post a concise Slack summary: number of payouts, total deposited, and any
-   payouts with warnings (refunds, unmatched charges).
-4. Upload the brief (`.md`) and, when present, the workbook (`.xlsx`) to the thread.
-5. Tell the admin they can hand the brief to Claude Cowork to reconcile in Xero —
-   the API only prepares; a human clicks the final confirm in Xero.
+2. Ask mlai-backend for the requested report or event audit with the requester's Slack ID.
+3. Post a concise Slack summary and upload the full evidence to the thread.
+4. State that "missing" means no tracked evidence in the selected period, not
+   proof that the category did not exist.
 
 ## Security & guardrails
 
 - **Points Admins only.** Non-admins are politely refused; mlai-backend re-checks.
-- **Read-only** against Luma and Stripe. This skill never moves money, writes to
-  Stripe/Luma, or finalises a Xero reconcile.
+- **Read-only** against Luma, Humanitix, Stripe, and Xero. This skill never moves
+  money, writes to a provider, or finalises a Xero reconcile.
 - Roo holds no Luma/Stripe keys — mlai-backend owns API access and role enforcement.
 - The report contains buyer PII (emails); never store it permanently or echo keys.


### PR DESCRIPTION
## What changed
- extend the reconciliation skill with an `audit_event_finances` action
- default to a six-calendar-month window with explicit-date overrides
- call the new read-only backend audit endpoint
- post a concise Slack summary and upload a full Markdown evidence report
- add routing examples/eval cases for the requested natural-language prompt

## Why
Points Admins should be able to tag Roo in Slack and audit recent events for ticket sales, sponsorship, catering, and contractor evidence.

## Validation
- focused Roo executor/backend client tests (29 passed)
- routing gate and catalog tests (6 passed)
- combined focused suite (35 passed)
- `git diff --check`

The local live v2 routing eval could not call an LLM because no API key is configured in the shell; production routing will be smoke-tested after deploy.