### PR TITLE
Fix Admin Roo evidence status for citation-free abstentions

### DIFF
--- a/roo-standalone/roo/admin_brain.py
+++ b/roo-standalone/roo/admin_brain.py
@@ -154,18 +154,33 @@ def build_admin_brain_response(
     warnings = list(dict.fromkeys(warnings))
     freshness = payload.get("freshness") if isinstance(payload.get("freshness"), dict) else {}
     latest = _display_datetime(freshness.get("latest_evidence_at"))
-    as_of = _display_datetime(freshness.get("as_of"))
     stale = bool(freshness.get("contains_stale_memory")) or "stale_memory" in (
         payload.get("warnings") or []
     )
+    citations = [
+        citation
+        for citation in list(payload.get("citations") or [])[:5]
+        if isinstance(citation, dict)
+    ]
+    has_citations = bool(citations)
     sufficiency = str(payload.get("evidence_sufficiency") or "unknown").replace("_", " ")
     confidence = payload.get("confidence")
     try:
         confidence_text = f"{max(0, min(float(confidence), 1)):.0%} confidence"
     except (TypeError, ValueError):
         confidence_text = "confidence unavailable"
-    freshness_label = "⚠️ Contains stale memory" if stale else "✅ Current authorised evidence"
-    time_label = latest or as_of or "time unavailable"
+    if not has_citations:
+        evidence_context = (
+            "⚪ No authorised evidence selected · "
+            f"{slack_safe_text(sufficiency.title())} evidence · {confidence_text}"
+        )
+    else:
+        freshness_label = "⚠️ Contains stale memory" if stale else "✅ Current authorised evidence"
+        time_label = latest or "time unavailable"
+        evidence_context = (
+            f"{freshness_label} · Latest evidence: {slack_safe_text(time_label)} · "
+            f"{slack_safe_text(sufficiency.title())} evidence · {confidence_text}"
+        )
 
     blocks: list[dict] = []
     for index, chunk in enumerate(_chunk_text(answer)):
@@ -182,10 +197,7 @@ def build_admin_brain_response(
             "elements": [
                 {
                     "type": "mrkdwn",
-                    "text": (
-                        f"{freshness_label} · Latest evidence: {slack_safe_text(time_label)} · "
-                        f"{slack_safe_text(sufficiency.title())} evidence · {confidence_text}"
-                    ),
+                    "text": evidence_context,
                 }
             ],
         }
@@ -202,9 +214,7 @@ def build_admin_brain_response(
         )
 
     citation_lines = []
-    for citation in list(payload.get("citations") or [])[:5]:
-        if not isinstance(citation, dict):
-            continue
+    for citation in citations:
         label = slack_safe_text(
             citation.get("label") or citation.get("provider") or "Source",
             limit=180,

--- a/roo-standalone/roo/admin_brain.py
+++ b/roo-standalone/roo/admin_brain.py
@@ -161,6 +161,10 @@ def build_admin_brain_response(
         citation
         for citation in list(payload.get("citations") or [])[:5]
         if isinstance(citation, dict)
+        and any(
+            citation.get(field)
+            for field in ("source_id", "source_version_id", "source_url", "label")
+        )
     ]
     has_citations = bool(citations)
     sufficiency = str(payload.get("evidence_sufficiency") or "unknown").replace("_", " ")

--- a/roo-standalone/roo/tests/test_admin_brain.py
+++ b/roo-standalone/roo/tests/test_admin_brain.py
@@ -159,6 +159,67 @@ def test_admin_brain_blocks_escape_mentions_and_render_citations_and_feedback():
     }
 
 
+def test_admin_brain_does_not_present_request_time_as_latest_evidence():
+    payload = {
+        "query_id": "query-abstained",
+        "answer": "I do not have enough authorised evidence to answer that reliably.",
+        "confidence": 0,
+        "evidence_sufficiency": "insufficient",
+        "freshness": {
+            "as_of": "2026-08-02T05:04:00+00:00",
+            "latest_evidence_at": None,
+            "contains_stale_memory": False,
+        },
+        "warnings": [],
+        "citations": [],
+    }
+
+    result = build_admin_brain_response(
+        payload,
+        requester_user_id="UADMIN123",
+    )
+
+    rendered = str(result["blocks"])
+    assert "No authorised evidence selected" in rendered
+    assert "Current authorised evidence" not in rendered
+    assert "Latest evidence" not in rendered
+    assert "02 Aug 2026" not in rendered
+
+
+def test_admin_brain_labels_real_cited_evidence_with_its_timestamp():
+    payload = {
+        "query_id": "query-answered",
+        "answer": "The committee approved the launch.",
+        "confidence": 0.88,
+        "evidence_sufficiency": "sufficient",
+        "freshness": {
+            "as_of": "2026-08-02T05:04:00+00:00",
+            "latest_evidence_at": "2026-07-20T08:30:00+00:00",
+            "contains_stale_memory": False,
+        },
+        "warnings": [],
+        "citations": [
+            {
+                "provider": "google_drive",
+                "label": "Committee meeting notes",
+                "source_url": "https://drive.example/document/committee",
+                "occurred_at": "2026-07-20T08:30:00+00:00",
+            }
+        ],
+    }
+
+    result = build_admin_brain_response(
+        payload,
+        requester_user_id="UADMIN123",
+    )
+
+    rendered = str(result["blocks"])
+    assert "Current authorised evidence" in rendered
+    assert "Latest evidence" in rendered
+    assert "20 Jul 2026" in rendered
+    assert "02 Aug 2026" not in rendered
+
+
 @pytest.mark.asyncio
 async def test_executor_returns_grounded_blocks_and_never_calls_generic_fallback(monkeypatch):
     configured = _settings()

--- a/roo-standalone/roo/tests/test_admin_brain.py
+++ b/roo-standalone/roo/tests/test_admin_brain.py
@@ -171,7 +171,7 @@ def test_admin_brain_does_not_present_request_time_as_latest_evidence():
             "contains_stale_memory": False,
         },
         "warnings": [],
-        "citations": [],
+        "citations": [{}],
     }
 
     result = build_admin_brain_response(


### PR DESCRIPTION
## What changed

- citation-free responses now display “No authorised evidence selected”
- request time is no longer presented as “Latest evidence”
- the green current-evidence state requires a usable citation
- genuine cited and stale evidence retain their existing freshness presentation
- adds regression coverage for insufficient, citation-free, current cited, stale, and empty-citation-record responses

## Root cause

When retrieval selected no evidence, Roo fell back from `latest_evidence_at` to the query `as_of` timestamp and still rendered a green current-evidence label. This made an abstention look like it had fresh supporting evidence.

## Validation

- 416 official Roo security/routing tests passed
- Admin Brain tests passed after rebase
- Python compilation passed
- public/admin/bridge Compose rendering passed
- nginx configuration validation passed