### PR TITLE
Add treasurer-backed Xero reconciliation workflow

### DIFF
--- a/roo-standalone/.env.example
+++ b/roo-standalone/.env.example
@@ -38,6 +38,10 @@ MLAI_BACKEND_URL=https://api.mlai.au/api/v1
 MLAI_API_KEY=
 ROO_API_KEY=
 INTERNAL_API_KEY=
+# Optional standalone bookkeeper trigger. It syncs the dedicated treasurer
+# mailbox and posts exact-preview approval cards in the private review channel.
+RECONCILIATION_AGENT_URL=
+RECONCILIATION_AGENT_TIMEOUT_SECONDS=30
 # Optional legacy service-to-service mention endpoint. When empty, /api/mention
 # returns 404. Never configure this on Admin Roo.
 INTERNAL_MENTION_API_KEY=

--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -11,7 +11,7 @@ import re
 import secrets
 import time
 from typing import Optional, Dict, Any, List, Union
-from urllib.parse import urlparse
+from urllib.parse import quote, urlparse
 from uuid import UUID, uuid4
 
 import httpx
@@ -1747,6 +1747,269 @@ class MLAIBackendClient:
         )
         self._raise_for_status_or_backend_unavailable(response)
         return response.json()
+
+    async def get_statement_reconciliation_readiness(
+        self,
+        slack_user_id: str,
+        *,
+        domain: str = "mlai.au",
+    ) -> dict:
+        """Check queue freshness, monthly context and Xero write configuration."""
+        response = await self._request(
+            "GET",
+            "/api/v1/integrations/reconciliation/readiness",
+            params={
+                "slack_user_id": self._clean_slack_id(slack_user_id),
+                "domain": str(domain or "mlai.au").strip().lower(),
+            },
+            timeout=30.0,
+            transport_retries=1,
+            retry_backoff_seconds=0.25,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def start_statement_reconciliation_run(
+        self,
+        slack_user_id: str,
+        *,
+        domain: str = "mlai.au",
+        instruction: Optional[str] = None,
+        statement_line_ids: Optional[List[str]] = None,
+    ) -> dict:
+        """Start a preview-only Xero statement reconciliation agent run."""
+        payload: Dict[str, Any] = {
+            "slack_user_id": self._clean_slack_id(slack_user_id),
+            "domain": str(domain or "mlai.au").strip().lower(),
+        }
+        if instruction:
+            payload["instruction"] = str(instruction).strip()
+        if statement_line_ids:
+            payload["statement_line_ids"] = [
+                str(item).strip() for item in statement_line_ids if str(item).strip()
+            ]
+        response = await self._request(
+            "POST",
+            "/api/v1/integrations/reconciliation/agent-runs",
+            json=payload,
+            timeout=30.0,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def get_statement_reconciliation_outcomes(
+        self,
+        slack_user_id: str,
+        *,
+        domain: str = "mlai.au",
+        limit: int = 50,
+    ) -> dict:
+        """Get confirmed human outcomes and read-only learning candidates."""
+        response = await self._request(
+            "GET",
+            "/api/v1/integrations/reconciliation/outcomes",
+            params={
+                "slack_user_id": self._clean_slack_id(slack_user_id),
+                "domain": str(domain or "mlai.au").strip().lower(),
+                "limit": max(1, min(int(limit), 200)),
+            },
+            timeout=30.0,
+            transport_retries=1,
+            retry_backoff_seconds=0.25,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def decide_statement_reconciliation_learning_candidate(
+        self,
+        slack_user_id: str,
+        candidate_id: str,
+        *,
+        candidate_version: str,
+        decision: str,
+        reason: Optional[str] = None,
+        domain: str = "mlai.au",
+    ) -> dict:
+        """Explicitly promote or reject one previously reviewed learning candidate."""
+        payload = {
+            "slack_user_id": self._clean_slack_id(slack_user_id),
+            "domain": str(domain or "mlai.au").strip().lower(),
+            "candidate_version": str(candidate_version or "").strip(),
+            "decision": str(decision or "").strip().lower(),
+            "confirm": True,
+        }
+        if reason:
+            payload["reason"] = str(reason).strip()
+        response = await self._request(
+            "POST",
+            (
+                "/api/v1/integrations/reconciliation/learning-candidates/"
+                f"{quote(str(candidate_id).strip(), safe='')}"
+            ),
+            json=payload,
+            timeout=30.0,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def get_statement_reconciliation_run(
+        self,
+        slack_user_id: str,
+        run_id: str,
+        *,
+        domain: str = "mlai.au",
+    ) -> dict:
+        """Get the current state and suggestions for one reconciliation run."""
+        response = await self._request(
+            "GET",
+            f"/api/v1/integrations/reconciliation/agent-runs/{quote(str(run_id).strip(), safe='')}",
+            params={
+                "slack_user_id": self._clean_slack_id(slack_user_id),
+                "domain": str(domain or "mlai.au").strip().lower(),
+            },
+            timeout=30.0,
+            transport_retries=1,
+            retry_backoff_seconds=0.25,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def retry_statement_reconciliation_run(
+        self,
+        slack_user_id: str,
+        run_id: str,
+        *,
+        domain: str = "mlai.au",
+    ) -> dict:
+        """Retry only the context-analysis dispatch for an existing durable run."""
+        response = await self._request(
+            "POST",
+            (
+                "/api/v1/integrations/reconciliation/agent-runs/"
+                f"{quote(str(run_id).strip(), safe='')}/retry"
+            ),
+            json={
+                "slack_user_id": self._clean_slack_id(slack_user_id),
+                "domain": str(domain or "mlai.au").strip().lower(),
+                "confirm": True,
+            },
+            timeout=30.0,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def preview_statement_reconciliation_run(
+        self,
+        slack_user_id: str,
+        run_id: str,
+        *,
+        domain: str = "mlai.au",
+    ) -> dict:
+        """Build current write previews without recording approval or writing Xero."""
+        response = await self._request(
+            "GET",
+            f"/api/v1/integrations/reconciliation/agent-runs/{quote(str(run_id).strip(), safe='')}/preview",
+            params={
+                "slack_user_id": self._clean_slack_id(slack_user_id),
+                "domain": str(domain or "mlai.au").strip().lower(),
+            },
+            timeout=30.0,
+            transport_retries=1,
+            retry_backoff_seconds=0.25,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def approve_ready_statement_reconciliation_run(
+        self,
+        slack_user_id: str,
+        run_id: str,
+        *,
+        domain: str = "mlai.au",
+        decision_request_id: Optional[str] = None,
+    ) -> dict:
+        """Record an explicit admin approval for every currently ready preview."""
+        payload = {
+            "slack_user_id": self._clean_slack_id(slack_user_id),
+            "domain": str(domain or "mlai.au").strip().lower(),
+            "confirm": True,
+            "approve_all_ready": True,
+            "decision_request_id": decision_request_id or f"roo-{uuid4().hex}",
+        }
+        response = await self._request(
+            "POST",
+            f"/api/v1/integrations/reconciliation/agent-runs/{quote(str(run_id).strip(), safe='')}/decisions",
+            json=payload,
+            timeout=30.0,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def reject_statement_reconciliation_suggestions(
+        self,
+        slack_user_id: str,
+        run_id: str,
+        suggestion_ids: List[int],
+        *,
+        reason: str,
+        domain: str = "mlai.au",
+        decision_request_id: Optional[str] = None,
+    ) -> dict:
+        """Record an explicit admin rejection for selected run suggestions."""
+        payload = {
+            "slack_user_id": self._clean_slack_id(slack_user_id),
+            "domain": str(domain or "mlai.au").strip().lower(),
+            "confirm": True,
+            "decision_request_id": decision_request_id or f"roo-{uuid4().hex}",
+            "decisions": [
+                {"suggestion_id": int(item), "decision": "reject", "reason": str(reason).strip()}
+                for item in suggestion_ids
+            ],
+        }
+        response = await self._request(
+            "POST",
+            f"/api/v1/integrations/reconciliation/agent-runs/{quote(str(run_id).strip(), safe='')}/decisions",
+            json=payload,
+            timeout=30.0,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
+    async def execute_approved_statement_reconciliation_run(
+        self,
+        slack_user_id: str,
+        run_id: str,
+        *,
+        domain: str = "mlai.au",
+        suggestion_ids: Optional[List[int]] = None,
+    ) -> dict:
+        """Write only explicitly approved, unchanged suggestions to Xero."""
+        payload: Dict[str, Any] = {
+            "slack_user_id": self._clean_slack_id(slack_user_id),
+            "domain": str(domain or "mlai.au").strip().lower(),
+            "confirm": True,
+        }
+        if suggestion_ids:
+            payload["suggestion_ids"] = [int(item) for item in suggestion_ids]
+        response = await self._request(
+            "POST",
+            f"/api/v1/integrations/reconciliation/agent-runs/{quote(str(run_id).strip(), safe='')}/execute",
+            json=payload,
+            timeout=60.0,
+            circuit_breaker=True,
+        )
+        self._raise_for_status_or_backend_unavailable(response)
+        return response.json()
+
 
     async def get_data_catalog(self, requester_slack_id: str) -> dict:
         """Get the requester's curated read-only data resource catalog."""

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -83,6 +83,8 @@ class Settings(BaseSettings):
     INTERNAL_API_KEY: Optional[str] = None
     INTERNAL_MENTION_API_KEY: Optional[str] = None
     RECONCILIATION_DOMAIN: str = "mlai.au"
+    RECONCILIATION_AGENT_URL: Optional[str] = None
+    RECONCILIATION_AGENT_TIMEOUT_SECONDS: float = 30.0
     LINEAR_DEFAULT_TEAM: Optional[str] = None
 
     # Public/Admin trust boundary. Admin starts with no skills and no private

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -5907,13 +5907,9 @@ Chunk {index} source: {label}
         channel_id: Optional[str],
         thread_ts: Optional[str],
     ) -> Any:
-        """Execute the Luma→Stripe reconciliation report skill through mlai-backend.
-
-        Read-only and Points-Admin gated (mlai-backend enforces the role). Fetches
-        the report, posts a summary, and uploads the Cowork brief (.md) + audit
-        workbook (.xlsx) to the thread.
-        """
-        if str(params.get("action") or "").strip().lower() == "audit_event_finances":
+        """Execute Points-Admin reporting or guarded Xero reconciliation actions."""
+        action = str(params.get("action") or "generate_report").strip().lower()
+        if action == "audit_event_finances":
             return await self._execute_event_finance_audit(
                 params=params,
                 user_id=user_id,
@@ -5924,10 +5920,10 @@ Chunk {index} source: {label}
         settings = get_settings()
         if not getattr(settings, "MLAI_BACKEND_URL", None):
             return (
-                "The reconciliation report needs mlai-backend to be configured. "
+                "Reconciliation needs mlai-backend to be configured. "
                 "Ask the team to set `MLAI_BACKEND_URL`."
             )
-        if not channel_id:
+        if action == "generate_report" and not channel_id:
             return "I need a Slack channel or DM to upload the reconciliation report."
 
         from roo.clients.mlai_backend import MLAIBackendClient, MLAIBackendUnavailableError
@@ -5941,6 +5937,18 @@ Chunk {index} source: {label}
                 or settings.MLAI_API_KEY
             ),
         )
+
+        if action != "generate_report":
+            return await self._execute_statement_reconciliation_action(
+                action=action,
+                text=text,
+                params=params,
+                user_id=user_id,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                settings=settings,
+                backend_client=backend_client,
+            )
 
         days = self._resolve_reconciliation_days(params)
         since = self._clean_optional_iso_date(params.get("since"))
@@ -6262,6 +6270,516 @@ Chunk {index} source: {label}
             ]
         )
         return "\n".join(lines)
+
+    async def _execute_statement_reconciliation_action(
+        self,
+        *,
+        action: str,
+        text: str,
+        params: dict,
+        user_id: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+        settings: Any,
+        backend_client: Any,
+    ) -> Any:
+        """Run the preview → approval → execution contract for Xero writes."""
+        from roo.clients.mlai_backend import MLAIBackendUnavailableError
+
+        valid_actions = {
+            "check_reconciliation_readiness",
+            "start_statement_reconciliation",
+            "reconciliation_outcomes",
+            "decide_reconciliation_rule_candidate",
+            "status_statement_reconciliation",
+            "retry_statement_reconciliation",
+            "preview_statement_reconciliation",
+            "approve_ready_reconciliation",
+            "reject_reconciliation_suggestions",
+            "execute_approved_reconciliation",
+        }
+        if action not in valid_actions:
+            return "I couldn't identify that reconciliation action. Ask me to check readiness, start, preview, approve, reject, or execute a run."
+
+        domain = str(params.get("domain") or "mlai.au").strip().lower()
+        run_id = str(params.get("run_id") or "").strip()
+        if action not in {
+            "check_reconciliation_readiness",
+            "start_statement_reconciliation",
+            "reconciliation_outcomes",
+            "decide_reconciliation_rule_candidate",
+        } and not run_id:
+            return "Please include the reconciliation run ID so I operate on the exact preview you reviewed."
+
+        try:
+            if action == "check_reconciliation_readiness":
+                result = await backend_client.get_statement_reconciliation_readiness(
+                    user_id,
+                    domain=domain,
+                )
+                return {
+                    "message": self._format_statement_reconciliation_readiness(result),
+                    "data": {"action": action, **result},
+                }
+
+            if action == "start_statement_reconciliation":
+                agent_url = str(
+                    getattr(settings, "RECONCILIATION_AGENT_URL", "") or ""
+                ).strip()
+                if agent_url:
+                    if not channel_id:
+                        return (
+                            "Start this workflow in the private Roo bookkeeping "
+                            "channel so I can post its review digest safely."
+                        )
+                    trigger = await self._trigger_reconciliation_agent_prepare(
+                        settings=settings,
+                        agent_url=agent_url,
+                        user_id=user_id,
+                        channel_id=channel_id,
+                        thread_ts=thread_ts,
+                        instruction=str(params.get("instruction") or text).strip()[:4000],
+                    )
+                    duplicate_note = (
+                        " The same request was already queued, so I did not start a duplicate."
+                        if trigger.get("duplicate")
+                        else ""
+                    )
+                    return {
+                        "message": (
+                            "I’ve started the full reconciliation preparation: the "
+                            "dedicated treasurer mailbox will sync, new invoices and "
+                            "receipts will be extracted, and every current Xero line "
+                            "will be checked against the latest monthly update and "
+                            "connected finance/event context. A detailed digest with "
+                            "exact-preview approval buttons will appear in this private "
+                            "channel. No Xero write happens until you approve a preview; "
+                            "after that, Roo creates the green match and you make the "
+                            "final Match/OK tick in Xero."
+                            + duplicate_note
+                        ),
+                        "data": {"action": action, **trigger},
+                    }
+                line_ids = self._coerce_reconciliation_statement_line_ids(
+                    params.get("statement_line_ids")
+                )
+                result = await backend_client.start_statement_reconciliation_run(
+                    user_id,
+                    domain=domain,
+                    instruction=str(params.get("instruction") or text).strip()[:4000],
+                    statement_line_ids=line_ids,
+                )
+                deterministic_count = int(
+                    result.get("deterministic_suggestion_count") or 0
+                )
+                agent_line_count = int(result.get("agent_line_count") or 0)
+                conflict_count = int(result.get("rule_conflict_count") or 0)
+                deferred_bill_count = int(result.get("deferred_bill_count") or 0)
+                summary_parts = [
+                    f"{deterministic_count} prepared from verified rules",
+                    f"{agent_line_count} sent for monthly-context analysis",
+                ]
+                if conflict_count:
+                    summary_parts.append(f"{conflict_count} rule conflicts held for review")
+                if deferred_bill_count:
+                    summary_parts.append(
+                        f"{deferred_bill_count} exact bill matches reserved for bill-payment analysis"
+                    )
+                if result.get("status") == "completed":
+                    next_step = "The preview-only run is complete; ask me to preview it now."
+                else:
+                    next_step = (
+                        "It is preview-only; ask me to preview that run once its status is completed."
+                    )
+                start_verb = (
+                    "Reused existing reconciliation run"
+                    if result.get("idempotent")
+                    else "Started reconciliation run"
+                )
+                duplicate_note = (
+                    " I did not create or dispatch a duplicate."
+                    if result.get("idempotent")
+                    else ""
+                )
+                return {
+                    "message": (
+                        f"{start_verb} `{result.get('run_id')}` against the fresh Xero queue. "
+                        f"{'; '.join(summary_parts)}.{duplicate_note} {next_step}"
+                    ),
+                    "data": {"action": action, **result},
+                }
+
+            if action == "reconciliation_outcomes":
+                try:
+                    limit = int(params.get("limit") or 50)
+                except (TypeError, ValueError):
+                    limit = 50
+                result = await backend_client.get_statement_reconciliation_outcomes(
+                    user_id,
+                    domain=domain,
+                    limit=max(1, min(limit, 200)),
+                )
+                return {
+                    "message": self._format_statement_reconciliation_outcomes(result),
+                    "data": {"action": action, **result},
+                }
+
+            if action == "decide_reconciliation_rule_candidate":
+                candidate_id = str(params.get("candidate_id") or "").strip()
+                candidate_version = str(params.get("candidate_version") or "").strip()
+                decision = str(params.get("decision") or "").strip().lower()
+                reason = str(params.get("reason") or "").strip()
+                if not candidate_id or not candidate_version:
+                    return (
+                        "Include the candidate ID and version from the reconciliation "
+                        "outcomes preview."
+                    )
+                if decision not in {"promote", "reject"}:
+                    return "Choose `promote` or `reject` for the reviewed rule candidate."
+                if decision == "reject" and not reason:
+                    return "Include a short reason for rejecting the rule candidate."
+                result = await backend_client.decide_statement_reconciliation_learning_candidate(
+                    user_id,
+                    candidate_id,
+                    candidate_version=candidate_version,
+                    decision=decision,
+                    reason=reason[:2000] or None,
+                    domain=domain,
+                )
+                if decision == "promote":
+                    rule = result.get("rule") or {}
+                    return {
+                        "message": (
+                            f"Verified reconciliation rule #{rule.get('id')} "
+                            f"`{rule.get('name')}` from candidate `{candidate_id}`"
+                            + (" (already promoted)." if result.get("idempotent") else ".")
+                            + " Future matching lines can now use this rule; no Xero transaction was created."
+                        ),
+                        "data": {"action": action, **result},
+                    }
+                return {
+                    "message": (
+                        f"Rejected rule candidate `{candidate_id}` with the supplied audit reason. "
+                        "No rule or Xero transaction was created."
+                    ),
+                    "data": {"action": action, **result},
+                }
+
+            if action == "status_statement_reconciliation":
+                result = await backend_client.get_statement_reconciliation_run(
+                    user_id, run_id, domain=domain
+                )
+                count = len(result.get("suggestions") or [])
+                retry_hint = (
+                    " The context-analysis dispatch can be retried against this run."
+                    if result.get("retry_available")
+                    else ""
+                )
+                return {
+                    "message": (
+                        f"Run `{run_id}` is *{result.get('status', 'unknown')}* with {count} suggestion(s). "
+                        f"Preview it before approving anything.{retry_hint}"
+                    ),
+                    "data": {"action": action, **result},
+                }
+
+            if action == "retry_statement_reconciliation":
+                result = await backend_client.retry_statement_reconciliation_run(
+                    user_id, run_id, domain=domain
+                )
+                if result.get("idempotent"):
+                    message = (
+                        f"Run `{run_id}` is already {result.get('status', 'queued')}; "
+                        "I did not create or dispatch a duplicate."
+                    )
+                else:
+                    message = (
+                        f"Re-queued monthly-context analysis for run `{run_id}` against its original "
+                        "fresh Xero scan. Existing deterministic suggestions were kept; no Xero "
+                        "transaction was created."
+                    )
+                return {
+                    "message": message,
+                    "data": {"action": action, **result},
+                }
+
+            if action == "preview_statement_reconciliation":
+                result = await backend_client.preview_statement_reconciliation_run(
+                    user_id, run_id, domain=domain
+                )
+                return {
+                    "message": self._format_statement_reconciliation_preview(result),
+                    "data": {"action": action, **result},
+                }
+
+            if action == "approve_ready_reconciliation":
+                result = await backend_client.approve_ready_statement_reconciliation_run(
+                    user_id, run_id, domain=domain
+                )
+                recorded = int(result.get("recorded_count") or 0)
+                requested = int(result.get("requested_count") or 0)
+                blocked = max(0, requested - recorded)
+                return {
+                    "message": (
+                        f"Approved {recorded} ready suggestion(s) in run `{run_id}`"
+                        + (f"; {blocked} were not ready and remain unapproved" if blocked else "")
+                        + ". No Xero transactions were created yet."
+                    ),
+                    "data": {"action": action, **result},
+                }
+
+            if action == "reject_reconciliation_suggestions":
+                suggestion_ids = self._coerce_reconciliation_suggestion_ids(
+                    params.get("suggestion_ids")
+                )
+                reason = str(params.get("reason") or "").strip()
+                if not suggestion_ids:
+                    return "Include the integer suggestion IDs you want to reject from the exact run preview."
+                if not reason:
+                    return "Include a short reason so the rejection is useful in the reconciliation audit trail."
+                result = await backend_client.reject_statement_reconciliation_suggestions(
+                    user_id,
+                    run_id,
+                    suggestion_ids,
+                    reason=reason[:2000],
+                    domain=domain,
+                )
+                recorded = int(result.get("recorded_count") or 0)
+                return {
+                    "message": (
+                        f"Rejected {recorded}/{len(suggestion_ids)} selected suggestion(s) in run `{run_id}`. "
+                        "No Xero transactions were created."
+                    ),
+                    "data": {"action": action, **result},
+                }
+
+            raw_suggestion_ids = params.get("suggestion_ids")
+            suggestion_ids = self._coerce_reconciliation_suggestion_ids(raw_suggestion_ids)
+            if raw_suggestion_ids not in (None, "", []) and suggestion_ids is None:
+                return "suggestion_ids must contain integer IDs from the exact run preview."
+            result = await backend_client.execute_approved_statement_reconciliation_run(
+                user_id,
+                run_id,
+                domain=domain,
+                suggestion_ids=suggestion_ids,
+            )
+            executed = int(result.get("executed_count") or 0)
+            candidates = int(result.get("approved_candidate_count") or 0)
+            failed = max(0, candidates - executed)
+            message = (
+                f"Created {executed} approved matching Xero transaction(s) from run `{run_id}`"
+                + (f"; {failed} approved item(s) were safely blocked" if failed else "")
+                + ". Open Xero and click the green Match/OK buttons to finish reconciliation."
+            )
+            return {"message": message, "data": {"action": action, **result}}
+        except MLAIBackendUnavailableError:
+            return "I'm having trouble reaching mlai-backend for reconciliation right now. Try again in a tick."
+        except httpx.HTTPStatusError as exc:
+            status_code = exc.response.status_code
+            detail = self._extract_luma_http_error_detail(exc)
+            if status_code == 403:
+                return "Sorry mate, you'll need to be a Points Admin to run Xero reconciliation. 🔒"
+            if status_code == 409:
+                if action == "decide_reconciliation_rule_candidate":
+                    return detail or "The rule candidate changed or is no longer safe to promote."
+                if "wait for completion" in detail.lower():
+                    return detail
+                return (
+                    (detail + " ") if detail else ""
+                ) + "Import the current Xero bank-feed queue with the Chrome backfill, then start a new run."
+            if status_code == 404:
+                return detail or f"I couldn't find reconciliation run `{run_id}`."
+            return detail or f"mlai-backend returned HTTP {status_code} for reconciliation."
+
+    @staticmethod
+    async def _trigger_reconciliation_agent_prepare(
+        *,
+        settings: Any,
+        agent_url: str,
+        user_id: str,
+        channel_id: str,
+        thread_ts: Optional[str],
+        instruction: str,
+    ) -> dict:
+        service_key = str(
+            getattr(settings, "MLAI_API_KEY", "")
+            or getattr(settings, "ROO_API_KEY", "")
+            or getattr(settings, "INTERNAL_API_KEY", "")
+            or ""
+        ).strip()
+        if not service_key:
+            raise ValueError(
+                "The reconciliation service key is not configured on Roo."
+            )
+        request_seed = "|".join(
+            [channel_id, str(thread_ts or ""), user_id, instruction]
+        )
+        request_id = "roo-" + hashlib.sha256(request_seed.encode()).hexdigest()[:40]
+        timeout = float(
+            getattr(settings, "RECONCILIATION_AGENT_TIMEOUT_SECONDS", 30.0)
+            or 30.0
+        )
+        async with httpx.AsyncClient(timeout=max(5.0, min(timeout, 120.0))) as client:
+            response = await client.post(
+                agent_url.rstrip("/") + "/internal/reconciliation/prepare",
+                headers={"Authorization": f"Bearer {service_key}"},
+                json={
+                    "request_id": request_id,
+                    "slack_user_id": user_id,
+                    "channel_id": channel_id,
+                    "thread_ts": str(thread_ts or ""),
+                    "instruction": instruction
+                    or "Plan every outstanding Xero reconciliation.",
+                },
+            )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict) or payload.get("accepted") is not True:
+            raise ValueError("The reconciliation service did not accept the request.")
+        return payload
+
+    @staticmethod
+    def _coerce_reconciliation_statement_line_ids(raw: Any) -> Optional[list[str]]:
+        if raw in (None, "", []):
+            return None
+        values = raw if isinstance(raw, list) else str(raw).split(",")
+        cleaned = list(dict.fromkeys(str(value).strip() for value in values if str(value).strip()))
+        return cleaned or None
+
+    @staticmethod
+    def _format_statement_reconciliation_readiness(result: dict) -> str:
+        scan = result.get("latest_statement_scan") or {}
+        monthly = result.get("monthly_context") or {}
+        candidate_count = int(scan.get("candidate_count") or 0)
+        start_state = "ready to analyse" if result.get("ready_to_start") else "not ready to analyse"
+        bank_state = (
+            "Spend/Receive Money ready"
+            if result.get("ready_to_execute_bank_transactions")
+            else "Spend/Receive Money not ready"
+        )
+        bill_state = (
+            "bill payments ready"
+            if result.get("ready_to_execute_bill_payments")
+            else "bill payments not ready"
+        )
+        context_state = (
+            f"monthly context `{monthly.get('run_id')}`"
+            if monthly.get("run_id")
+            else "no completed monthly context"
+        )
+        lines = [
+            (
+                f"*Xero reconciliation is {start_state}*: {candidate_count} current "
+                f"candidate(s), {context_state}; {bank_state}; {bill_state}."
+            )
+        ]
+        blockers = [str(item).strip() for item in result.get("blockers") or [] if str(item).strip()]
+        warnings = [str(item).strip() for item in result.get("warnings") or [] if str(item).strip()]
+        if blockers:
+            lines.append("*Blockers:* " + " ".join(blockers))
+        if warnings:
+            lines.append("*Setup notes:* " + " ".join(warnings))
+        next_action = str(result.get("recommended_next_action") or "").strip()
+        if next_action:
+            lines.append(f"*Next:* {next_action}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _coerce_reconciliation_suggestion_ids(raw: Any) -> Optional[list[int]]:
+        if raw in (None, "", []):
+            return None
+        values = raw if isinstance(raw, list) else str(raw).split(",")
+        result = []
+        for value in values:
+            try:
+                item = int(value)
+            except (TypeError, ValueError):
+                continue
+            if item not in result:
+                result.append(item)
+        return result or None
+
+    @staticmethod
+    def _format_statement_reconciliation_preview(result: dict) -> str:
+        run_id = result.get("run_id") or "unknown"
+        run_status = result.get("run_status") or "unknown"
+        ready = int(result.get("ready_count") or 0)
+        total = int(result.get("suggestion_count") or 0)
+        approved = int(result.get("approved_count") or 0)
+        lines = [
+            f"*Reconciliation preview `{run_id}`* — run {run_status}; {ready}/{total} ready, {approved} approved."
+        ]
+        for item in (result.get("results") or [])[:10]:
+            suggestion = item.get("suggestion") or {}
+            preview = item.get("preview") or {}
+            suggestion_id = suggestion.get("id")
+            description = str(suggestion.get("description") or "Needs description").strip()
+            project = (suggestion.get("project") or {}).get("tracking_option_name")
+            event = (suggestion.get("event") or {}).get("tracking_option_name")
+            allocation = project or event or "no event/project"
+            state = "ready" if preview.get("ready") else "blocked"
+            routing = suggestion.get("routing") or {}
+            route_source = routing.get("source")
+            if route_source == "verified_rule":
+                route = f"verified rule #{routing.get('verified_rule_id')}"
+            elif route_source == "exact_xero_bill":
+                route = f"exact Xero bill {routing.get('xero_bill_id')}"
+            elif route_source == "monthly_context_agent":
+                route = "monthly context"
+            elif route_source == "rule_conflict":
+                route = "rule conflict"
+            else:
+                route = str(route_source or "legacy/manual").replace("_", " ")
+            lines.append(
+                f"• #{suggestion_id} — {description[:90]} — {allocation} — {route} — {state}."
+            )
+        if total > 10:
+            lines.append(f"• …and {total - 10} more suggestion(s).")
+        if ready:
+            lines.append("Review these details, then explicitly ask me to approve the ready suggestions for this run.")
+        else:
+            lines.append("Nothing is ready to approve yet; review the blocking errors and source context.")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _format_statement_reconciliation_outcomes(result: dict) -> str:
+        confirmed = int(result.get("confirmed_reconciled_count") or 0)
+        pending = int(result.get("pending_human_match_count") or 0)
+        review_candidates = int(result.get("rule_review_candidate_count") or 0)
+        lines = [
+            f"*Reconciliation outcomes* — {confirmed} confirmed reconciled; "
+            f"{pending} still waiting for Xero Match/OK; {review_candidates} pattern(s) ready for rule review."
+        ]
+        recent = result.get("recent_confirmed") or []
+        for item in recent[:5]:
+            allocation = item.get("project_name") or item.get("event_name") or "no event/project"
+            lines.append(
+                f"• {item.get('transaction_date')} — {item.get('currency', '')} {item.get('amount')} — "
+                f"{item.get('description') or item.get('contact_name')} — {allocation}."
+            )
+        candidates = [
+            item
+            for item in result.get("learning_candidates") or []
+            if item.get("eligible_for_promotion")
+            and item.get("review_status", "pending") == "pending"
+        ]
+        if candidates:
+            lines.append("*Patterns for admin rule review:*")
+            for item in candidates[:5]:
+                rule = item.get("suggested_rule") or {}
+                allocation = rule.get("project_name") or rule.get("event_name") or "no event/project"
+                lines.append(
+                    f"• `{item.get('candidate_id')}` ({item.get('confirmed_example_count')} confirmations) — "
+                    f"{item.get('merchant_key')} → {rule.get('account_code')} - "
+                    f"{rule.get('account_name')}; {allocation}. "
+                    f"Version `{item.get('candidate_version')}`."
+                )
+        lines.append(
+            "No rule was created automatically. After reviewing a candidate and version, "
+            "an admin can explicitly promote or reject it."
+        )
+        return "\n".join(lines)
+
 
     def _resolve_reconciliation_days(self, params: dict) -> int:
         raw = params.get("days")

--- a/roo-standalone/roo/tests/test_mlai_backend_client.py
+++ b/roo-standalone/roo/tests/test_mlai_backend_client.py
@@ -541,6 +541,95 @@ async def test_confirm_article_topic_includes_requested_by_when_provided(monkeyp
     assert captured["json"]["requested_by_slack_user_id"] == "U05QPB483K9"
 
 
+
+@pytest.mark.asyncio
+async def test_statement_reconciliation_client_uses_run_scoped_guarded_endpoints(monkeypatch):
+    captured = []
+
+    async def fake_request(method, endpoint, **kwargs):
+        captured.append({"method": method, "endpoint": endpoint, **kwargs})
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(200, request=request, json={"run_id": "run/123"})
+
+    client = MLAIBackendClient(
+        base_url="https://backend.test",
+        api_key="roo-api-key",
+        internal_api_key="roo-api-key",
+    )
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    await client.get_statement_reconciliation_readiness("UADMIN")
+    await client.start_statement_reconciliation_run(
+        "UADMIN",
+        instruction="Use the Aaron AI context.",
+        statement_line_ids=["line-1"],
+    )
+    await client.retry_statement_reconciliation_run("UADMIN", "run/123")
+    await client.get_statement_reconciliation_outcomes("UADMIN", limit=25)
+    await client.decide_statement_reconciliation_learning_candidate(
+        "UADMIN",
+        "candidate/123",
+        candidate_version="version-123",
+        decision="promote",
+    )
+    await client.preview_statement_reconciliation_run("UADMIN", "run/123")
+    await client.approve_ready_statement_reconciliation_run(
+        "UADMIN", "run/123", decision_request_id="roo-decision-1"
+    )
+    await client.reject_statement_reconciliation_suggestions(
+        "UADMIN",
+        "run/123",
+        [12],
+        reason="Wrong project.",
+        decision_request_id="roo-decision-2",
+    )
+    await client.execute_approved_statement_reconciliation_run(
+        "UADMIN", "run/123", suggestion_ids=[10, 11]
+    )
+
+    assert [(item["method"], item["endpoint"]) for item in captured] == [
+        ("GET", "/api/v1/integrations/reconciliation/readiness"),
+        ("POST", "/api/v1/integrations/reconciliation/agent-runs"),
+        ("POST", "/api/v1/integrations/reconciliation/agent-runs/run%2F123/retry"),
+        ("GET", "/api/v1/integrations/reconciliation/outcomes"),
+        ("POST", "/api/v1/integrations/reconciliation/learning-candidates/candidate%2F123"),
+        ("GET", "/api/v1/integrations/reconciliation/agent-runs/run%2F123/preview"),
+        ("POST", "/api/v1/integrations/reconciliation/agent-runs/run%2F123/decisions"),
+        ("POST", "/api/v1/integrations/reconciliation/agent-runs/run%2F123/decisions"),
+        ("POST", "/api/v1/integrations/reconciliation/agent-runs/run%2F123/execute"),
+    ]
+    assert captured[0]["params"] == {
+        "slack_user_id": "UADMIN",
+        "domain": "mlai.au",
+    }
+    assert captured[1]["json"]["statement_line_ids"] == ["line-1"]
+    assert captured[2]["json"] == {
+        "slack_user_id": "UADMIN",
+        "domain": "mlai.au",
+        "confirm": True,
+    }
+    assert captured[3]["params"]["limit"] == 25
+    assert captured[4]["json"] == {
+        "slack_user_id": "UADMIN",
+        "domain": "mlai.au",
+        "candidate_version": "version-123",
+        "decision": "promote",
+        "confirm": True,
+    }
+    assert captured[6]["json"] == {
+        "slack_user_id": "UADMIN",
+        "domain": "mlai.au",
+        "confirm": True,
+        "approve_all_ready": True,
+        "decision_request_id": "roo-decision-1",
+    }
+    assert captured[7]["json"]["decisions"] == [{
+        "suggestion_id": 12,
+        "decision": "reject",
+        "reason": "Wrong project.",
+    }]
+    assert captured[8]["json"]["suggestion_ids"] == [10, 11]
+
 @pytest.mark.asyncio
 async def test_event_finance_audit_uses_read_only_bounded_endpoint(monkeypatch):
     captured = {}

--- a/roo-standalone/roo/tests/test_reconciliation_report.py
+++ b/roo-standalone/roo/tests/test_reconciliation_report.py
@@ -1,5 +1,6 @@
 import base64
 import importlib
+import json
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -114,19 +115,190 @@ class FakeReconBackendClient:
     unavailable = False
     status_code = None
     calls = []
+    operation_results = {}
 
     def __init__(self, *args, **kwargs):
         pass
 
     async def get_reconciliation_report(self, slack_user_id, **kwargs):
         self.__class__.calls.append({"slack_user_id": slack_user_id, **kwargs})
+        self._raise_if_needed("/api/v1/integrations/reconciliation/report")
+        return self.report
+
+    async def get_statement_reconciliation_readiness(self, slack_user_id, **kwargs):
+        self.__class__.calls.append({
+            "action": "readiness",
+            "slack_user_id": slack_user_id,
+            **kwargs,
+        })
+        self._raise_if_needed("/api/v1/integrations/reconciliation/readiness")
+        return self.operation_results.get("readiness", {
+            "ready_to_start": True,
+            "ready_to_execute_bank_transactions": True,
+            "ready_to_execute_bill_payments": True,
+            "tracking_ready": True,
+            "latest_statement_scan": {
+                "id": 12,
+                "fresh": True,
+                "candidate_count": 8,
+            },
+            "monthly_context": {
+                "run_id": "monthly-2026-07",
+                "status": "completed",
+            },
+            "blockers": [],
+            "warnings": [],
+            "recommended_next_action": "Start Xero reconciliation in preview-only mode.",
+        })
+
+    def _raise_if_needed(self, endpoint):
         if self.unavailable:
             raise backend_module.MLAIBackendUnavailableError("backend unavailable")
         if self.status_code:
-            request = httpx.Request("GET", "https://backend.test/api/v1/integrations/reconciliation/report")
+            request = httpx.Request("POST", f"https://backend.test{endpoint}")
             response = httpx.Response(self.status_code, json={"error": f"backend {self.status_code}"}, request=request)
             raise httpx.HTTPStatusError("backend error", request=request, response=response)
-        return self.report
+
+    async def start_statement_reconciliation_run(self, slack_user_id, **kwargs):
+        self.__class__.calls.append({"action": "start", "slack_user_id": slack_user_id, **kwargs})
+        self._raise_if_needed("/api/v1/integrations/reconciliation/agent-runs")
+        return self.operation_results.get("start", {
+            "run_id": "xero-reconciliation-123",
+            "status": "queued",
+            "dry_run": True,
+            "deterministic_suggestion_count": 1,
+            "rule_conflict_count": 0,
+            "deferred_bill_count": 0,
+            "agent_line_count": 1,
+            "valley_dispatched": True,
+        })
+
+    async def get_statement_reconciliation_outcomes(self, slack_user_id, **kwargs):
+        self.__class__.calls.append({"action": "outcomes", "slack_user_id": slack_user_id, **kwargs})
+        self._raise_if_needed("/api/v1/integrations/reconciliation/outcomes")
+        return self.operation_results.get("outcomes", {
+            "confirmed_reconciled_count": 3,
+            "pending_human_match_count": 1,
+            "rule_review_candidate_count": 1,
+            "automatic_rule_creation": False,
+            "recent_confirmed": [{
+                "transaction_date": "2026-07-20",
+                "currency": "AUD",
+                "amount": "845.00",
+                "description": "Contractor work for Present Studio.",
+                "project_name": "[Studio] Present Studio",
+            }],
+            "learning_candidates": [{
+                "candidate_id": "candidate-present-studio",
+                "candidate_version": "version-present-studio",
+                "merchant_key": "transfer to contractor one",
+                "confirmed_example_count": 2,
+                "eligible_for_rule_review": True,
+                "eligible_for_promotion": True,
+                "review_status": "pending",
+                "suggested_rule": {
+                    "account_code": "405",
+                    "account_name": "Contractor Expenses",
+                    "project_name": "[Studio] Present Studio",
+                },
+            }],
+        })
+
+    async def decide_statement_reconciliation_learning_candidate(
+        self, slack_user_id, candidate_id, **kwargs
+    ):
+        self.__class__.calls.append({
+            "action": "decide_candidate",
+            "slack_user_id": slack_user_id,
+            "candidate_id": candidate_id,
+            **kwargs,
+        })
+        self._raise_if_needed(
+            f"/api/v1/integrations/reconciliation/learning-candidates/{candidate_id}"
+        )
+        decision = kwargs["decision"]
+        return self.operation_results.get("decide_candidate", {
+            "decision": "promoted" if decision == "promote" else "rejected",
+            "idempotent": False,
+            "rule": {
+                "id": 77,
+                "name": "Learned: Contractor One",
+                "status": "verified",
+            } if decision == "promote" else None,
+        })
+
+    async def get_statement_reconciliation_run(self, slack_user_id, run_id, **kwargs):
+        self.__class__.calls.append({"action": "status", "slack_user_id": slack_user_id, "run_id": run_id, **kwargs})
+        self._raise_if_needed(f"/api/v1/integrations/reconciliation/agent-runs/{run_id}")
+        return self.operation_results.get("status", {
+            "run_id": run_id, "status": "completed", "suggestions": [{"id": 10}],
+        })
+
+    async def retry_statement_reconciliation_run(self, slack_user_id, run_id, **kwargs):
+        self.__class__.calls.append({"action": "retry", "slack_user_id": slack_user_id, "run_id": run_id, **kwargs})
+        self._raise_if_needed(f"/api/v1/integrations/reconciliation/agent-runs/{run_id}/retry")
+        return self.operation_results.get("retry", {
+            "run_id": run_id,
+            "status": "queued",
+            "valley_dispatched": True,
+            "idempotent": False,
+        })
+
+    async def preview_statement_reconciliation_run(self, slack_user_id, run_id, **kwargs):
+        self.__class__.calls.append({"action": "preview", "slack_user_id": slack_user_id, "run_id": run_id, **kwargs})
+        self._raise_if_needed(f"/api/v1/integrations/reconciliation/agent-runs/{run_id}/preview")
+        return self.operation_results.get("preview", {
+            "run_id": run_id,
+            "run_status": "completed",
+            "suggestion_count": 1,
+            "ready_count": 1,
+            "approved_count": 0,
+            "results": [{
+                "suggestion": {
+                    "id": 10,
+                    "description": "Contractor payment for Aaron AI coding",
+                    "project": {"tracking_option_name": "[Studio] Aaron AI"},
+                    "routing": {
+                        "source": "verified_rule",
+                        "verified_rule_id": 77,
+                    },
+                },
+                "preview": {"ready": True, "operation": "bank_transaction"},
+            }],
+        })
+
+    async def approve_ready_statement_reconciliation_run(self, slack_user_id, run_id, **kwargs):
+        self.__class__.calls.append({"action": "approve", "slack_user_id": slack_user_id, "run_id": run_id, **kwargs})
+        self._raise_if_needed(f"/api/v1/integrations/reconciliation/agent-runs/{run_id}/decisions")
+        return self.operation_results.get("approve", {
+            "run_id": run_id, "requested_count": 2, "recorded_count": 1,
+        })
+
+    async def reject_statement_reconciliation_suggestions(
+        self, slack_user_id, run_id, suggestion_ids, **kwargs
+    ):
+        self.__class__.calls.append({
+            "action": "reject",
+            "slack_user_id": slack_user_id,
+            "run_id": run_id,
+            "suggestion_ids": suggestion_ids,
+            **kwargs,
+        })
+        self._raise_if_needed(f"/api/v1/integrations/reconciliation/agent-runs/{run_id}/decisions")
+        return self.operation_results.get("reject", {
+            "run_id": run_id,
+            "requested_count": len(suggestion_ids),
+            "recorded_count": len(suggestion_ids),
+        })
+
+    async def execute_approved_statement_reconciliation_run(self, slack_user_id, run_id, **kwargs):
+        self.__class__.calls.append({"action": "execute", "slack_user_id": slack_user_id, "run_id": run_id, **kwargs})
+        self._raise_if_needed(f"/api/v1/integrations/reconciliation/agent-runs/{run_id}/execute")
+        return self.operation_results.get("execute", {
+            "run_id": run_id, "approved_candidate_count": 2, "executed_count": 1,
+            "human_reconciliation_required": True,
+        })
+
 
     async def get_event_finance_audit(self, slack_user_id, **kwargs):
         self.__class__.calls.append({"method": "audit", "slack_user_id": slack_user_id, **kwargs})
@@ -157,6 +329,7 @@ def _reset(monkeypatch, *, uploaded=None, settings_overrides=None):
     FakeReconBackendClient.unavailable = False
     FakeReconBackendClient.status_code = None
     FakeReconBackendClient.calls = []
+    FakeReconBackendClient.operation_results = {}
     executor = SkillExecutor()
     monkeypatch.setattr(executor_module, "get_settings", lambda: _settings(**(settings_overrides or {})))
     monkeypatch.setattr(backend_module, "MLAIBackendClient", FakeReconBackendClient)
@@ -273,6 +446,442 @@ async def test_rate_limited(monkeypatch):
     FakeReconBackendClient.status_code = 429
     result = await _run(executor)
     assert "rate-limited" in result.lower() or "429" in result
+
+
+@pytest.mark.asyncio
+async def test_start_statement_reconciliation_is_preview_only(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        text="analyse these transactions for the Aaron AI project",
+        params={
+            "action": "start_statement_reconciliation",
+            "statement_line_ids": ["line-1", "line-2"],
+        },
+        channel_id=None,
+    )
+
+    assert "Started reconciliation run `xero-reconciliation-123`" in result["message"]
+    assert "preview-only" in result["message"]
+    assert "1 prepared from verified rules" in result["message"]
+    assert "1 sent for monthly-context analysis" in result["message"]
+    assert FakeReconBackendClient.calls[0]["statement_line_ids"] == ["line-1", "line-2"]
+    assert FakeReconBackendClient.calls[0]["instruction"].startswith("analyse these transactions")
+
+
+@pytest.mark.asyncio
+async def test_start_uses_treasurer_agent_when_configured(monkeypatch):
+    executor = _reset(
+        monkeypatch,
+        settings_overrides={
+            "RECONCILIATION_AGENT_URL": "https://roo.mlai.au",
+            "RECONCILIATION_AGENT_TIMEOUT_SECONDS": 30,
+        },
+    )
+    captured = {}
+
+    async def fake_trigger(**kwargs):
+        captured.update(kwargs)
+        return {
+            "accepted": True,
+            "request_id": "roo-request-123",
+            "status": "queued",
+            "xero_writes": False,
+        }
+
+    monkeypatch.setattr(
+        executor,
+        "_trigger_reconciliation_agent_prepare",
+        fake_trigger,
+    )
+
+    result = await _run(
+        executor,
+        text=(
+            "Use the monthly updates and treasurer email to plan every "
+            "outstanding Xero transaction."
+        ),
+        params={"action": "start_statement_reconciliation"},
+    )
+
+    assert "dedicated treasurer mailbox will sync" in result["message"]
+    assert "exact-preview approval buttons" in result["message"]
+    assert "final Match/OK tick" in result["message"]
+    assert result["data"]["xero_writes"] is False
+    assert captured["agent_url"] == "https://roo.mlai.au"
+    assert captured["user_id"] == "UADMIN"
+    assert captured["channel_id"] == "C123"
+    assert FakeReconBackendClient.calls == []
+
+
+@pytest.mark.asyncio
+async def test_treasurer_agent_trigger_is_authenticated_and_idempotency_scoped(monkeypatch):
+    captured = {}
+
+    def handler(request):
+        captured["request"] = request
+        return httpx.Response(
+            202,
+            request=request,
+            json={
+                "accepted": True,
+                "request_id": "roo-backend-id",
+                "status": "queued",
+                "xero_writes": False,
+            },
+        )
+
+    real_async_client = httpx.AsyncClient
+
+    def fake_async_client(*args, **kwargs):
+        return real_async_client(
+            transport=httpx.MockTransport(handler),
+            timeout=kwargs.get("timeout"),
+        )
+
+    monkeypatch.setattr(executor_module.httpx, "AsyncClient", fake_async_client)
+    settings = _settings(
+        MLAI_API_KEY="shared-service-key",
+        RECONCILIATION_AGENT_TIMEOUT_SECONDS=30,
+    )
+
+    result = await SkillExecutor._trigger_reconciliation_agent_prepare(
+        settings=settings,
+        agent_url="https://roo.mlai.au/",
+        user_id="UADMIN",
+        channel_id="C123",
+        thread_ts="1700000000.000001",
+        instruction="Plan every outstanding line.",
+    )
+
+    request = captured["request"]
+    assert request.url == (
+        "https://roo.mlai.au/internal/reconciliation/prepare"
+    )
+    assert request.headers["Authorization"] == "Bearer shared-service-key"
+    body = json.loads(request.content)
+    assert body["slack_user_id"] == "UADMIN"
+    assert body["channel_id"] == "C123"
+    assert body["instruction"] == "Plan every outstanding line."
+    assert body["request_id"].startswith("roo-")
+    assert result["xero_writes"] is False
+
+
+@pytest.mark.asyncio
+async def test_check_reconciliation_readiness_explains_safe_next_action(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        params={"action": "check_reconciliation_readiness", "domain": "mlai.au"},
+        channel_id=None,
+    )
+
+    assert "ready to analyse" in result["message"]
+    assert "8 current candidate(s)" in result["message"]
+    assert "monthly context `monthly-2026-07`" in result["message"]
+    assert "Spend/Receive Money ready" in result["message"]
+    assert "bill payments ready" in result["message"]
+    assert "Start Xero reconciliation in preview-only mode" in result["message"]
+    assert FakeReconBackendClient.calls[0] == {
+        "action": "readiness",
+        "slack_user_id": "UADMIN",
+        "domain": "mlai.au",
+    }
+
+
+@pytest.mark.asyncio
+async def test_repeated_start_reports_reused_run_without_duplicate(monkeypatch):
+    executor = _reset(monkeypatch)
+    FakeReconBackendClient.operation_results["start"] = {
+        "run_id": "xero-reconciliation-existing",
+        "status": "queued",
+        "dry_run": True,
+        "deterministic_suggestion_count": 1,
+        "rule_conflict_count": 0,
+        "deferred_bill_count": 0,
+        "agent_line_count": 1,
+        "valley_dispatched": False,
+        "idempotent": True,
+    }
+
+    result = await _run(
+        executor,
+        params={"action": "start_statement_reconciliation"},
+        channel_id=None,
+    )
+
+    assert "Reused existing reconciliation run" in result["message"]
+    assert "did not create or dispatch a duplicate" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_start_completed_deterministic_run_can_be_previewed_immediately(monkeypatch):
+    executor = _reset(monkeypatch)
+    FakeReconBackendClient.operation_results["start"] = {
+        "run_id": "xero-reconciliation-rules",
+        "status": "completed",
+        "dry_run": True,
+        "deterministic_suggestion_count": 3,
+        "rule_conflict_count": 0,
+        "deferred_bill_count": 0,
+        "agent_line_count": 0,
+        "valley_dispatched": False,
+    }
+
+    result = await _run(
+        executor,
+        params={"action": "start_statement_reconciliation"},
+        channel_id=None,
+    )
+
+    assert "3 prepared from verified rules" in result["message"]
+    assert "0 sent for monthly-context analysis" in result["message"]
+    assert "ask me to preview it now" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_outcomes_reports_confirmed_matches_without_creating_rules(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        params={"action": "reconciliation_outcomes", "limit": 25},
+        channel_id=None,
+    )
+
+    assert "3 confirmed reconciled" in result["message"]
+    assert "1 still waiting for Xero Match/OK" in result["message"]
+    assert "[Studio] Present Studio" in result["message"]
+    assert "candidate-present-studio" in result["message"]
+    assert "version-present-studio" in result["message"]
+    assert "No rule was created automatically" in result["message"]
+    assert FakeReconBackendClient.calls[0] == {
+        "action": "outcomes",
+        "slack_user_id": "UADMIN",
+        "domain": "mlai.au",
+        "limit": 25,
+    }
+
+
+@pytest.mark.asyncio
+async def test_admin_can_explicitly_promote_reviewed_rule_candidate(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        params={
+            "action": "decide_reconciliation_rule_candidate",
+            "candidate_id": "candidate-present-studio",
+            "candidate_version": "version-present-studio",
+            "decision": "promote",
+        },
+        channel_id=None,
+    )
+
+    assert "Verified reconciliation rule #77" in result["message"]
+    assert "no Xero transaction was created" in result["message"]
+    assert FakeReconBackendClient.calls[0] == {
+        "action": "decide_candidate",
+        "slack_user_id": "UADMIN",
+        "candidate_id": "candidate-present-studio",
+        "candidate_version": "version-present-studio",
+        "decision": "promote",
+        "reason": None,
+        "domain": "mlai.au",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reject_rule_candidate_requires_a_reason(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        params={
+            "action": "decide_reconciliation_rule_candidate",
+            "candidate_id": "candidate-present-studio",
+            "candidate_version": "version-present-studio",
+            "decision": "reject",
+        },
+        channel_id=None,
+    )
+
+    assert "short reason" in result
+    assert FakeReconBackendClient.calls == []
+
+
+@pytest.mark.asyncio
+async def test_preview_shows_project_and_requires_separate_approval(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        params={"action": "preview_statement_reconciliation", "run_id": "xero-reconciliation-123"},
+        channel_id=None,
+    )
+
+    assert "1/1 ready, 0 approved" in result["message"]
+    assert "Contractor payment for Aaron AI coding" in result["message"]
+    assert "[Studio] Aaron AI" in result["message"]
+    assert "verified rule #77" in result["message"]
+    assert "explicitly ask me to approve" in result["message"]
+    assert FakeReconBackendClient.calls[0]["action"] == "preview"
+
+
+@pytest.mark.asyncio
+async def test_status_exposes_retry_for_failed_context_dispatch(monkeypatch):
+    executor = _reset(monkeypatch)
+    FakeReconBackendClient.operation_results["status"] = {
+        "run_id": "xero-reconciliation-123",
+        "status": "queued",
+        "retry_available": True,
+        "suggestions": [{"id": 10}],
+    }
+
+    result = await _run(
+        executor,
+        params={
+            "action": "status_statement_reconciliation",
+            "run_id": "xero-reconciliation-123",
+        },
+        channel_id=None,
+    )
+
+    assert "can be retried" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_retry_reuses_run_without_xero_write(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        params={
+            "action": "retry_statement_reconciliation",
+            "run_id": "xero-reconciliation-123",
+        },
+        channel_id=None,
+    )
+
+    assert "Re-queued monthly-context analysis" in result["message"]
+    assert "Existing deterministic suggestions were kept" in result["message"]
+    assert "no Xero transaction was created" in result["message"]
+    assert FakeReconBackendClient.calls[0]["action"] == "retry"
+
+
+@pytest.mark.asyncio
+async def test_retry_is_idempotent_while_run_is_already_queued(monkeypatch):
+    executor = _reset(monkeypatch)
+    FakeReconBackendClient.operation_results["retry"] = {
+        "run_id": "xero-reconciliation-123",
+        "status": "queued",
+        "valley_dispatched": False,
+        "idempotent": True,
+    }
+
+    result = await _run(
+        executor,
+        params={
+            "action": "retry_statement_reconciliation",
+            "run_id": "xero-reconciliation-123",
+        },
+        channel_id=None,
+    )
+
+    assert "did not create or dispatch a duplicate" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_approve_records_ready_but_does_not_execute(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        params={"action": "approve_ready_reconciliation", "run_id": "xero-reconciliation-123"},
+        channel_id=None,
+    )
+
+    assert "Approved 1 ready suggestion" in result["message"]
+    assert "1 were not ready" in result["message"]
+    assert "No Xero transactions were created yet" in result["message"]
+    assert [call["action"] for call in FakeReconBackendClient.calls] == ["approve"]
+
+
+@pytest.mark.asyncio
+async def test_execute_only_approved_and_keeps_human_match_step(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        params={
+            "action": "execute_approved_reconciliation",
+            "run_id": "xero-reconciliation-123",
+            "suggestion_ids": [10, 11],
+        },
+        channel_id=None,
+    )
+
+    assert "Created 1 approved matching Xero transaction" in result["message"]
+    assert "1 approved item(s) were safely blocked" in result["message"]
+    assert "green Match/OK" in result["message"]
+    assert FakeReconBackendClient.calls[0]["suggestion_ids"] == [10, 11]
+
+
+@pytest.mark.asyncio
+async def test_reject_selected_suggestions_records_reason_without_xero_write(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        params={
+            "action": "reject_reconciliation_suggestions",
+            "run_id": "xero-reconciliation-123",
+            "suggestion_ids": [10],
+            "reason": "This belongs to Present Studio.",
+        },
+        channel_id=None,
+    )
+
+    assert "Rejected 1/1 selected suggestion" in result["message"]
+    assert "No Xero transactions were created" in result["message"]
+    assert FakeReconBackendClient.calls[0] == {
+        "action": "reject",
+        "slack_user_id": "UADMIN",
+        "run_id": "xero-reconciliation-123",
+        "suggestion_ids": [10],
+        "reason": "This belongs to Present Studio.",
+        "domain": "mlai.au",
+    }
+
+
+@pytest.mark.asyncio
+async def test_statement_reconciliation_requires_exact_run_id(monkeypatch):
+    executor = _reset(monkeypatch)
+
+    result = await _run(
+        executor,
+        params={"action": "execute_approved_reconciliation"},
+        channel_id=None,
+    )
+
+    assert "exact preview" in result
+    assert FakeReconBackendClient.calls == []
+
+
+@pytest.mark.asyncio
+async def test_stale_scan_tells_admin_to_run_chrome_backfill(monkeypatch):
+    executor = _reset(monkeypatch)
+    FakeReconBackendClient.status_code = 409
+
+    result = await _run(
+        executor,
+        params={"action": "start_statement_reconciliation"},
+        channel_id=None,
+    )
+
+    assert "Chrome backfill" in result
 
 
 @pytest.mark.asyncio

--- a/roo-standalone/skills/reconciliation_report/SKILL.md
+++ b/roo-standalone/skills/reconciliation_report/SKILL.md
@@ -1,52 +1,100 @@
 ---
 name: reconciliation-report
-description: Generate Luma→Stripe reconciliation reports or audit recent events for expected ticket sales, sponsorship, catering, and contractor evidence in Xero.
+description: Admin event/Stripe reports and guarded preparation of outstanding Xero bank-feed transactions.
 routing:
   use_when: >
-    A Points Admin asks for a reconciliation or ticket-sales/payout report that
-    combines Luma and Stripe, or asks to audit events for expected finance
-    categories: ticket sales and sponsorship revenue, plus catering and contractor
-    costs. Examples include "reconcile the last 30 days", "which payments are in
-    our Stripe payouts", and "audit all events in the last six months and tell me
-    which are missing ticket sales, sponsorship, catering, or contractors".
+    A Points Admin asks for an event/Stripe audit or to inspect, plan, code, match,
+    or prepare outstanding Xero transactions using monthly and treasurer context.
   avoid_when: >
-    Attendee registration counts or check-ins only (luma-events). General curated
-    data questions (mlai-data-query). Points balances, tasks, awards, or coworking
-    reports (mlai-points). General accounting questions that do not ask for event
-    reconciliation, event finance completeness, or Stripe payout evidence.
+    Attendance only (luma-events), points (mlai-points), or unrelated accounting.
   examples:
-    - {text: "give me a report of the last 30 days of luma events and stripe sales", action: generate_report}
-    - {text: "which payments are in the stripe payouts that hit our bank account?", action: generate_report}
-    - {text: "reconciliation report for June please", action: generate_report}
-    - {text: "reconcile luma ticket sales against stripe for the last month", action: generate_report}
     - {text: "audit all events in the last 6 months for ticket sales, sponsorship, catering and contractor costs", action: audit_event_finances}
-    - {text: "which recent events are missing sponsorship revenue or contractor expenses?", action: audit_event_finances}
+    - {text: "go down all outstanding Xero transactions and plan the reconciliations", action: start_statement_reconciliation}
+    - {text: "use the monthly updates and treasurer@mlai.au email to prepare every outstanding Xero line", action: start_statement_reconciliation}
+    - {text: "preview reconciliation run xero-reconciliation-123", action: preview_statement_reconciliation, run_id: xero-reconciliation-123}
+    - {text: "execute approved reconciliation run xero-reconciliation-123", action: execute_approved_reconciliation, run_id: xero-reconciliation-123}
   negative_examples:
-    - {text: "how many people checked in to the AI Engineer event?", instead: luma-events}
-    - {text: "what's my points balance?", instead: mlai-points}
-    - {text: "how many people used the coworking space this week", instead: mlai-points}
+    - {text: "how many people checked in?", instead: luma-events}
 actions:
   - name: generate_report
-    description: Build the Luma→Stripe reconciliation pack and upload it to the thread.
+    description: Build the Luma→Stripe pack.
     params:
-      days: {type: integer, description: "Rolling window in days (default 30, max 92)."}
-      since: {type: string, description: "Optional window start YYYY-MM-DD (overrides days)."}
-      until: {type: string, description: "Optional window end YYYY-MM-DD."}
+      days: {type: integer}
+      since: {type: string}
+      until: {type: string}
   - name: audit_event_finances
-    description: Audit recent events for expected ticket sales, sponsorship, catering, and contractor evidence and upload the full findings.
+    description: Audit event revenue/cost evidence.
     params:
-      months: {type: integer, description: "Rolling calendar-month window (default 6, max 24)."}
-      since: {type: string, description: "Optional window start YYYY-MM-DD (overrides months)."}
-      until: {type: string, description: "Optional window end YYYY-MM-DD (default today)."}
+      months: {type: integer}
+      since: {type: string}
+      until: {type: string}
+  - name: start_statement_reconciliation
+    description: Start a context-enriched preview plan for current Xero lines.
+    params:
+      domain: {type: string}
+      instruction: {type: string}
+      statement_line_ids: {type: array}
+  - name: check_reconciliation_readiness
+    description: Check queue/context/Xero readiness.
+    params:
+      domain: {type: string}
+  - name: reconciliation_outcomes
+    description: Show outcomes; read-only.
+    params:
+      domain: {type: string}
+      limit: {type: integer}
+  - name: decide_reconciliation_rule_candidate
+    description: Decide reviewed rule.
+    params:
+      candidate_id: {type: string, required: true}
+      candidate_version: {type: string, required: true}
+      decision: {type: string, required: true, enum: [promote, reject]}
+      reason: {type: string}
+      domain: {type: string}
+  - name: status_statement_reconciliation
+    description: Check run.
+    params:
+      run_id: {type: string, required: true}
+      domain: {type: string}
+  - name: retry_statement_reconciliation
+    description: Retry context analysis.
+    params:
+      run_id: {type: string, required: true}
+      domain: {type: string}
+  - name: preview_statement_reconciliation
+    description: Show exact proposed Xero payloads.
+    params:
+      run_id: {type: string, required: true}
+      domain: {type: string}
+  - name: approve_ready_reconciliation
+    description: Approve ready previews; no write.
+    params:
+      run_id: {type: string, required: true}
+      domain: {type: string}
+  - name: reject_reconciliation_suggestions
+    description: Reject selected suggestions.
+    params:
+      run_id: {type: string, required: true}
+      suggestion_ids: {type: array, required: true}
+      reason: {type: string, required: true}
+      domain: {type: string}
+  - name: execute_approved_reconciliation
+    description: Write approved matches; human finalises.
+    params:
+      run_id: {type: string, required: true}
+      domain: {type: string}
+      suggestion_ids: {type: array}
 requires_auth: true
 ---
 
-# Reconciliation Report Skill
+# Reconciliation Skill
 
-Generates MLAI's monthly Luma→Stripe reconciliation report and a separate
-event-finance completeness audit for Points Admins. The audit checks each selected
-Luma event, Humanitix event, and event found through Xero tracking for evidence of
-the categories MLAI normally expects.
+Generates MLAI's Luma→Stripe report and controls a guarded Xero statement workflow.
+The agent uses the latest monthly company update and source evidence from the
+connected `treasurer@mlai.au` Gmail mailbox, Slack, Linear, Luma, Humanitix,
+Stripe, Xero and startup memory to propose contact, account, tax, event/project
+tracking and a short description. It cannot silently post: preview, admin
+approval and execution are separate run-scoped actions.
 
 ## Capabilities
 
@@ -56,30 +104,76 @@ the categories MLAI normally expects.
   buyers, gross/fees, and the net that hit the bank.
 - Upload the **Cowork brief** (markdown) and the **audit workbook** (xlsx) to the
   thread so they can be handed to Claude Cowork for the Xero reconcile.
-- Audit a rolling six-calendar-month window (or explicit dates) for ticket sales,
-  sponsorship revenue, catering costs, and contractor costs.
-- Upload a PII-minimized markdown audit showing every event, present/missing
-  categories, and the evidence behind each present category.
+- Audit recent events for ticket-sale and sponsorship revenue plus catering and
+  contractor costs, with a complete evidence attachment and no Xero writes.
+- Start a preview-only analysis of the current, freshly imported Xero bank queue.
+- Check queue freshness, monthly context, Xero write scopes and tracking setup.
+- Preview ready and blocked suggestions with event/project allocation.
+- Record a Points Admin's explicit approval for ready payloads.
+- Create matching authorised Spend/Receive Money transactions, or bill payments
+  for exact existing bills. A human still clicks green **Match/OK** in Xero.
+- Confirm completed matches from the next full Xero queue import, retain their
+  accounting and event/project allocation as historical evidence, and show
+  repeated patterns for admin review without creating rules automatically.
 
 ## Parameters
 
-- **action**: `generate_report` or `audit_event_finances`.
-- **days**: Rolling window size in days. Default 30, capped at 92.
-- **months**: Audit window in calendar months. Default 6, capped at 24.
-- **since** / **until**: Optional explicit window (`YYYY-MM-DD`); `since` overrides the rolling window.
+- **action**: one of `generate_report`, `audit_event_finances`,
+  `start_statement_reconciliation`,
+  `check_reconciliation_readiness`, `reconciliation_outcomes`,
+  `status_statement_reconciliation`,
+  `retry_statement_reconciliation`,
+  `decide_reconciliation_rule_candidate`,
+  `preview_statement_reconciliation`,
+  `approve_ready_reconciliation`, `reject_reconciliation_suggestions`, or
+  `execute_approved_reconciliation`.
+- **days**: Report window in days. Default 30, capped at 92.
+- **months**: Event-audit calendar-month window. Default 6, capped at 24.
+- **since** / **until**: Optional explicit window (`YYYY-MM-DD`).
 
-## Workflow
+## Statement workflow
 
-1. Confirm the requester is a Points Admin (mlai-backend also enforces this).
-2. Ask mlai-backend for the requested report or event audit with the requester's Slack ID.
-3. Post a concise Slack summary and upload the full evidence to the thread.
-4. State that "missing" means no tracked evidence in the selected period, not
-   proof that the category did not exist.
+1. Use `check_reconciliation_readiness`. Follow its blocker or recommended next
+   action. A human imports the full current unreconciled Xero queue using the
+   Chrome backfill; MLAI rejects stale or incomplete scans.
+2. `start_statement_reconciliation` first applies unambiguous admin-verified
+   rules deterministically. It sends only unresolved lines to the monthly-context
+   agent. A matching outstanding Xero bill always bypasses a Spend/Receive Money
+   rule and stays in the contextual bill-payment path. Repeating the same start
+   request reuses its run and never dispatches duplicate analysis.
+3. If all lines were resolved by verified rules the preview-only run completes
+   immediately. Otherwise wait for the context agent, then use
+   `preview_statement_reconciliation` and review the proposed contact,
+   account/tax, description and event/project for each item.
+   If Valley dispatch failed, `retry_statement_reconciliation` reuses the same
+   durable run and deterministic suggestions. It refuses stale or changed Xero
+   scans and will not enqueue a duplicate while the run is already queued.
+4. Only an explicit `approve_ready_reconciliation` records approvals. Blocked
+   suggestions remain unapproved. Use `reject_reconciliation_suggestions` with a
+   reason for items that need a different allocation.
+5. Only a later explicit `execute_approved_reconciliation` writes. MLAI rebuilds
+   every preview and blocks stale hashes, changed fields, duplicates or lost
+   scopes. Exact outstanding bills become bill payments instead of Spend Money.
+6. The admin opens Xero and clicks green **Match/OK**; API execution does not
+   finalise the bank reconciliation itself.
+7. Import another **complete** Xero queue scan. A match-ready line absent from
+   that scan is recorded as confirmed reconciled. `reconciliation_outcomes`
+   reports those outcomes and repeated patterns that an admin may later turn
+   into verified rules.
+8. Review the candidate ID, version, exact accounting fields and allocation.
+   `decide_reconciliation_rule_candidate` can then explicitly promote it to a
+   verified rule or reject it with a reason. A changed version must be reviewed again.
 
 ## Security & guardrails
 
 - **Points Admins only.** Non-admins are politely refused; mlai-backend re-checks.
-- **Read-only** against Luma, Humanitix, Stripe, and Xero. This skill never moves
-  money, writes to a provider, or finalises a Xero reconcile.
+- Reporting and analysis are read-only against Gmail, Slack, Linear, Luma and
+  Stripe. The execute action can write matching transactions or bill payments to
+  Xero, but cannot finalise a bank reconciliation.
+- Never combine preview, approval and execution into one inferred action.
+- Outcome learning is evidence only until an admin explicitly promotes the
+  exact reviewed candidate version. Roo never activates a rule automatically.
+- Approval is bound to run, statement source hash and exact Xero payload hash.
+  Any change requires a fresh preview and approval.
 - Roo holds no Luma/Stripe keys — mlai-backend owns API access and role enforcement.
 - The report contains buyer PII (emails); never store it permanently or echo keys.


### PR DESCRIPTION
## What changed

- routes outstanding-Xero requests into a guarded reconciliation workflow
- triggers the standalone bookkeeper so `treasurer@mlai.au` documents are synced and extracted
- preserves readiness, preview, approval, execute, outcome, and learned-rule actions
- keeps event-finance audits and Luma/Stripe reports available
- adds production URL/timeout settings and exact prompt routing examples

## Why

Roo previously refused operational reconciliation requests. It should inspect the current Xero queue, enrich the lines with monthly and treasurer evidence, and prepare exact Xero matches after explicit approval while leaving final Match/OK to the human.

## Validation

- focused router/client/reconciliation suite — 51 passed
- catalog token-budget check included