### PR TITLE
feat: add private committee candidate email list

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -1468,6 +1468,25 @@ class MLAIBackendClient:
         )
         response.raise_for_status()
         return response.json()
+
+    async def list_committee_candidate_emails(
+        self,
+        requester_slack_id: str,
+    ) -> dict:
+        """Return eligible member emails for an authorised committee admin."""
+        response = await self._request(
+            "POST",
+            f"{self._points_base}/committee-candidates/emails/",
+            json={
+                "requester_slack_id": self._clean_slack_id(requester_slack_id),
+            },
+            timeout=10.0,
+            transport_retries=1,
+            retry_backoff_seconds=0.25,
+            circuit_breaker=True,
+        )
+        response.raise_for_status()
+        return response.json()
     
     async def get_history(self, slack_user_id: str, limit: int = 10) -> List[dict]:
         """Get recent ledger entries for a user."""

--- a/roo-standalone/roo/committee_candidate_emails.py
+++ b/roo-standalone/roo/committee_candidate_emails.py
@@ -1,0 +1,96 @@
+from typing import Iterable
+
+
+MAX_SECTION_CHARS = 2800
+MAX_EMAIL_SECTIONS_PER_MESSAGE = 45
+MAX_FALLBACK_EMAIL_CHARS = 3500
+MAX_FALLBACK_CHARS = 4000
+
+
+def _chunk_email_lines(emails: Iterable[str]) -> list[str]:
+    chunks: list[str] = []
+    current: list[str] = []
+    current_length = 0
+    for email in emails:
+        line = str(email or "").strip().lower()
+        if not line:
+            continue
+        added_length = len(line) + (1 if current else 0)
+        if current and current_length + added_length > MAX_SECTION_CHARS:
+            chunks.append("\n".join(current))
+            current = []
+            current_length = 0
+        current.append(line)
+        current_length += len(line) + (1 if current_length else 0)
+    if current:
+        chunks.append("\n".join(current))
+    return chunks
+
+
+def build_candidate_email_payloads(data: dict) -> list[dict]:
+    """Build one or more Slack-safe messages without dropping email addresses."""
+    emails = [
+        value.strip().lower()
+        for value in data.get("emails") or []
+        if isinstance(value, str) and value.strip()
+    ]
+    count = int(data.get("eligible_count") or len(emails))
+    if not emails:
+        message = "No active members currently have 100 or more lifetime-earned Roo Points and a usable email."
+        return [{
+            "message": message,
+            "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": message}}],
+        }]
+
+    email_sections = _chunk_email_lines(emails)
+    section_groups: list[list[str]] = []
+    current_group: list[str] = []
+    current_group_length = 0
+    for section in email_sections:
+        added_length = len(section) + (1 if current_group else 0)
+        if current_group and (
+            len(current_group) >= MAX_EMAIL_SECTIONS_PER_MESSAGE
+            or current_group_length + added_length > MAX_FALLBACK_EMAIL_CHARS
+        ):
+            section_groups.append(current_group)
+            current_group = []
+            current_group_length = 0
+        current_group.append(section)
+        current_group_length += len(section) + (1 if current_group_length else 0)
+    if current_group:
+        section_groups.append(current_group)
+
+    payloads = []
+    for sections in section_groups:
+        part = len(payloads) + 1
+        heading = (
+            f"Eligible member emails ({count})"
+            if part == 1
+            else f"Eligible member emails ({count}) - continued"
+        )
+        plain_email_list = "\n".join(sections)
+        message = f"{heading}\n{plain_email_list}"
+        if len(message) > MAX_FALLBACK_CHARS:
+            raise ValueError("Candidate email fallback exceeds Slack's text limit")
+        blocks = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": (
+                        f"*{heading}*\n"
+                        "Active MLAI users with at least 100 lifetime-earned contribution points. "
+                        "Copy these addresses into Luma:"
+                    ),
+                },
+            },
+            *[
+                {
+                    "type": "section",
+                    "text": {"type": "plain_text", "text": section},
+                }
+                for section in sections
+            ],
+        ]
+        payloads.append({"message": message, "blocks": blocks})
+    return payloads

--- a/roo-standalone/roo/config.py
+++ b/roo-standalone/roo/config.py
@@ -16,6 +16,7 @@ class Settings(BaseSettings):
 
     PUBLIC_DEFAULT_SKILLS: ClassVar[frozenset[str]] = frozenset(
         {
+            "committee-candidate-emails",
             "connect-users",
             "content-factory",
             "github-integration",

--- a/roo-standalone/roo/routing_eval/cases/paraphrases.yaml
+++ b/roo-standalone/roo/routing_eval/cases/paraphrases.yaml
@@ -92,6 +92,20 @@
   expect: {skill: content-factory}
   tags: [paraphrase]
 
+# --- committee-candidate-emails ---
+- id: para-committee-list-eligible
+  text: "show me all MLAI emails for people with at least 100 earned Roo points"
+  expect: {skill: committee-candidate-emails, action: list_eligible_emails}
+  tags: [paraphrase]
+- id: para-committee-email-export
+  text: "give me the email list for eligible committee contributors"
+  expect: {skill: committee-candidate-emails, action: list_eligible_emails}
+  tags: [paraphrase]
+- id: para-committee-luma-copy
+  text: "export emails for members with 100 or more lifetime earned points so Alisa can invite them in Luma"
+  expect: {skill: committee-candidate-emails, action: list_eligible_emails}
+  tags: [paraphrase]
+
 # --- mlai-points ---
 - id: para-points-how-many
   text: "how many points do I have right now?"

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -231,6 +231,13 @@ class SkillExecutor:
                         or kwargs.get("current_message_ts")
                     ),
                 )
+            elif skill.name == "committee-candidate-emails":
+                result = await self._execute_committee_candidate_emails(
+                    text=text,
+                    params=params,
+                    user_id=user_id,
+                    channel_id=channel_id,
+                )
             elif skill.name == "mlai-data-query":
                 result = await self._execute_mlai_data_query(skill, text, params, user_id)
             elif skill.name == "github-integration":
@@ -311,6 +318,111 @@ class SkillExecutor:
                 message="Sorry, I ran into a problem executing that skill. Can you try again?",
                 error=str(e)
             )
+
+    async def _execute_committee_candidate_emails(
+        self,
+        *,
+        text: str,
+        params: dict,
+        user_id: str,
+        channel_id: Optional[str],
+    ) -> dict:
+        """Privately return copy-ready emails selected by the backend."""
+        from roo.clients.mlai_backend import (
+            MLAIBackendClient,
+            MLAIBackendUnavailableError,
+        )
+        from roo.committee_candidate_emails import build_candidate_email_payloads
+
+        action = str(params.get("action") or "").strip().lower()
+        if action != "list_eligible_emails":
+            return {
+                "message": (
+                    "Ask me to list the emails of members with at least 100 "
+                    "lifetime-earned Roo Points."
+                ),
+                "data": {"action": action or None},
+            }
+
+        settings = get_settings()
+        if not settings.MLAI_BACKEND_URL:
+            return {
+                "message": "The MLAI backend isn't configured, so I can't load candidates.",
+                "data": {"action": action},
+            }
+        client = MLAIBackendClient(
+            base_url=settings.MLAI_BACKEND_URL,
+            api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY,
+            internal_api_key=(
+                settings.INTERNAL_API_KEY
+                or settings.ROO_API_KEY
+                or settings.MLAI_API_KEY
+            ),
+        )
+        try:
+            data = await client.list_committee_candidate_emails(user_id)
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code in {401, 403}:
+                return {
+                    "message": (
+                        "Only active Points Admins with the admin or committee role "
+                        "can access this email list."
+                    ),
+                    "data": {"action": action, "authorised": False},
+                }
+            return {
+                "message": "I couldn't load the eligible email list right now.",
+                "data": {"action": action},
+            }
+        except (MLAIBackendUnavailableError, ValueError):
+            return {
+                "message": "I couldn't reach the MLAI backend. Try again shortly.",
+                "data": {"action": action},
+            }
+
+        payloads = build_candidate_email_payloads(data)
+        result_data = {
+            "action": action,
+            "eligible_count": int(data.get("eligible_count") or 0),
+            "delivery": "direct_message",
+        }
+
+        is_direct_message = bool(channel_id and channel_id.startswith("D"))
+        deliver_with_dm = not is_direct_message or len(payloads) > 1
+        if deliver_with_dm:
+            try:
+                delivered = all(
+                    bool(
+                        (send_dm(user_id, payload["message"], blocks=payload["blocks"]) or {}).get("ok")
+                    )
+                    for payload in payloads
+                )
+            except Exception:
+                delivered = False
+            if not delivered:
+                return {
+                    "message": (
+                        "I couldn't deliver the private email list. DM Roo `committee candidate emails` "
+                        "and I'll show the list there."
+                    ),
+                    "data": {**result_data, "delivery_failed": True},
+                }
+            if is_direct_message:
+                return {
+                    "message": "",
+                    "suppress_post": True,
+                    "data": result_data,
+                }
+            return {
+                "message": "I've sent the eligible email list privately.",
+                "data": result_data,
+            }
+        response = payloads[0]
+        return {
+            "message": response["message"],
+            "blocks": response["blocks"],
+            "data": result_data,
+        }
 
     async def _execute_admin_brain(
         self,

--- a/roo-standalone/roo/tests/test_committee_candidate_emails.py
+++ b/roo-standalone/roo/tests/test_committee_candidate_emails.py
@@ -1,0 +1,289 @@
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+os.environ.setdefault("SLACK_BOT_TOKEN", "xoxb-committee-test")
+os.environ.setdefault("SLACK_SIGNING_SECRET", "committee-signing-test")
+os.environ.setdefault("OPENAI_API_KEY", "committee-openai-test")
+
+from roo import committee_candidate_emails as email_module
+from roo.clients.mlai_backend import MLAIBackendClient
+from roo.skills import executor as executor_module
+from roo.skills.executor import SkillExecutor
+
+
+def _candidate_data(emails=None):
+    if emails is None:
+        emails = ["alpha@example.com", "beta@example.com"]
+    return {
+        "eligible_count": len(emails),
+        "threshold": 100,
+        "metric": "lifetime_earned",
+        "emails": emails,
+    }
+
+
+def _settings():
+    return SimpleNamespace(
+        MLAI_BACKEND_URL="https://backend.test",
+        ROO_API_KEY="roo-key",
+        MLAI_API_KEY=None,
+        INTERNAL_API_KEY=None,
+        ROO_SURFACE="public",
+        ROO_UNIFIED_ADMIN_ROUTING_ENABLED=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_backend_client_uses_private_email_export_contract(monkeypatch):
+    client = MLAIBackendClient(base_url="https://backend.test", api_key="roo-key")
+    calls = []
+
+    async def fake_request(method, endpoint, **kwargs):
+        calls.append((method, endpoint, kwargs))
+        request = httpx.Request(method, f"https://backend.test{endpoint}")
+        return httpx.Response(200, request=request, json=_candidate_data())
+
+    monkeypatch.setattr(client, "_request", fake_request)
+
+    result = await client.list_committee_candidate_emails("<@UADMIN>")
+
+    assert result == _candidate_data()
+    assert calls == [
+        (
+            "POST",
+            "/api/v1/points/committee-candidates/emails/",
+            {
+                "json": {"requester_slack_id": "UADMIN"},
+                "timeout": 10.0,
+                "transport_retries": 1,
+                "retry_backoff_seconds": 0.25,
+                "circuit_breaker": True,
+            },
+        )
+    ]
+
+
+def test_formatter_returns_copy_ready_email_only_list():
+    payloads = email_module.build_candidate_email_payloads(_candidate_data())
+
+    assert len(payloads) == 1
+    assert payloads[0]["message"].splitlines() == [
+        "Eligible member emails (2)",
+        "alpha@example.com",
+        "beta@example.com",
+    ]
+    rendered = str(payloads[0]["blocks"])
+    assert payloads[0]["blocks"][1]["text"] == {
+        "type": "plain_text",
+        "text": "alpha@example.com\nbeta@example.com",
+    }
+    assert "Slack" not in rendered
+    assert "point balance" not in rendered
+
+
+def test_formatter_preserves_every_address_across_large_slack_payloads():
+    emails = [f"member-{index:05d}@example.com" for index in range(6000)]
+    payloads = email_module.build_candidate_email_payloads(_candidate_data(emails))
+
+    assert len(payloads) > 1
+    rendered_emails = []
+    for payload in payloads:
+        assert len(payload["blocks"]) <= email_module.MAX_EMAIL_SECTIONS_PER_MESSAGE + 1
+        assert len(payload["message"]) <= email_module.MAX_FALLBACK_CHARS
+        for block in payload["blocks"][1:]:
+            section = block["text"]["text"]
+            assert len(section) <= 3000
+            assert block["text"]["type"] == "plain_text"
+            rendered_emails.extend(section.splitlines())
+    assert rendered_emails == emails
+
+
+def test_formatter_handles_no_eligible_members():
+    payloads = email_module.build_candidate_email_payloads(_candidate_data([]))
+
+    assert len(payloads) == 1
+    assert "No active members" in payloads[0]["message"]
+    assert "@" not in payloads[0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_public_request_sends_private_email_list_using_event_actor(monkeypatch):
+    captured = {"dms": []}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            captured["client_kwargs"] = kwargs
+
+        async def list_committee_candidate_emails(self, requester_slack_id):
+            captured["requester"] = requester_slack_id
+            return _candidate_data()
+
+    def fake_send_dm(user_id, text, **kwargs):
+        captured["dms"].append((user_id, text, kwargs.get("blocks")))
+        return {"ok": True}
+
+    monkeypatch.setattr(executor_module, "get_settings", _settings)
+    monkeypatch.setattr("roo.clients.mlai_backend.MLAIBackendClient", FakeClient)
+    monkeypatch.setattr(executor_module, "send_dm", fake_send_dm)
+
+    result = await SkillExecutor()._execute_committee_candidate_emails(
+        text="list members with 100 earned points",
+        params={"action": "list_eligible_emails", "requester_slack_id": "UFORGED"},
+        user_id="UADMIN",
+        channel_id="CGENERAL",
+    )
+
+    assert captured["requester"] == "UADMIN"
+    assert captured["dms"][0][0] == "UADMIN"
+    assert "alpha@example.com" in captured["dms"][0][1]
+    assert result["message"] == "I've sent the eligible email list privately."
+    assert "@example.com" not in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_direct_message_returns_list_without_second_dm(monkeypatch):
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def list_committee_candidate_emails(self, requester_slack_id):
+            return _candidate_data()
+
+    monkeypatch.setattr(executor_module, "get_settings", _settings)
+    monkeypatch.setattr("roo.clients.mlai_backend.MLAIBackendClient", FakeClient)
+    monkeypatch.setattr(
+        executor_module,
+        "send_dm",
+        lambda *args, **kwargs: pytest.fail("A one-message DM result should render directly"),
+    )
+
+    result = await SkillExecutor()._execute_committee_candidate_emails(
+        text="committee candidate emails",
+        params={"action": "list_eligible_emails"},
+        user_id="UADMIN",
+        channel_id="DPRIVATE",
+    )
+
+    assert "alpha@example.com" in result["message"]
+    assert result["blocks"]
+    assert result["data"]["eligible_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_missing_channel_fails_closed_to_private_dm(monkeypatch):
+    captured = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def list_committee_candidate_emails(self, requester_slack_id):
+            return _candidate_data()
+
+    monkeypatch.setattr(executor_module, "get_settings", _settings)
+    monkeypatch.setattr("roo.clients.mlai_backend.MLAIBackendClient", FakeClient)
+    monkeypatch.setattr(
+        executor_module,
+        "send_dm",
+        lambda user_id, text, **kwargs: captured.append((user_id, text)) or {"ok": True},
+    )
+
+    result = await SkillExecutor()._execute_committee_candidate_emails(
+        text="committee candidate emails",
+        params={"action": "list_eligible_emails"},
+        user_id="UADMIN",
+        channel_id=None,
+    )
+
+    assert captured and captured[0][0] == "UADMIN"
+    assert "@example.com" not in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_dm_failure_never_returns_emails_to_public_channel(monkeypatch):
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def list_committee_candidate_emails(self, requester_slack_id):
+            return _candidate_data()
+
+    monkeypatch.setattr(executor_module, "get_settings", _settings)
+    monkeypatch.setattr("roo.clients.mlai_backend.MLAIBackendClient", FakeClient)
+    monkeypatch.setattr(executor_module, "send_dm", lambda *args, **kwargs: {"ok": False})
+
+    result = await SkillExecutor()._execute_committee_candidate_emails(
+        text="committee candidate emails",
+        params={"action": "list_eligible_emails"},
+        user_id="UADMIN",
+        channel_id="CGENERAL",
+    )
+
+    assert result["data"]["delivery_failed"] is True
+    assert "@example.com" not in result["message"]
+    assert "DM Roo" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_permission_denial_and_backend_failure_are_safe(monkeypatch):
+    class DeniedClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def list_committee_candidate_emails(self, requester_slack_id):
+            request = httpx.Request("POST", "https://backend.test/candidates")
+            response = httpx.Response(403, request=request, json={"error": "denied"})
+            raise httpx.HTTPStatusError("denied", request=request, response=response)
+
+    monkeypatch.setattr(executor_module, "get_settings", _settings)
+    monkeypatch.setattr("roo.clients.mlai_backend.MLAIBackendClient", DeniedClient)
+    denied = await SkillExecutor()._execute_committee_candidate_emails(
+        text="committee candidate emails",
+        params={"action": "list_eligible_emails"},
+        user_id="UPARTNER",
+        channel_id="DPRIVATE",
+    )
+    assert "admin or committee role" in denied["message"]
+    assert denied["data"]["authorised"] is False
+
+    class FailingClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def list_committee_candidate_emails(self, requester_slack_id):
+            raise ValueError("backend response was invalid")
+
+    monkeypatch.setattr("roo.clients.mlai_backend.MLAIBackendClient", FailingClient)
+    failed = await SkillExecutor()._execute_committee_candidate_emails(
+        text="committee candidate emails",
+        params={"action": "list_eligible_emails"},
+        user_id="UADMIN",
+        channel_id="DPRIVATE",
+    )
+    assert "reach the MLAI backend" in failed["message"]
+    assert "@" not in failed["message"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_action_does_not_call_backend(monkeypatch):
+    monkeypatch.setattr(
+        "roo.clients.mlai_backend.MLAIBackendClient",
+        lambda **kwargs: pytest.fail("Unknown action must not call the backend"),
+    )
+
+    result = await SkillExecutor()._execute_committee_candidate_emails(
+        text="send invitations",
+        params={"action": "send_invitations"},
+        user_id="UADMIN",
+        channel_id="DPRIVATE",
+    )
+
+    assert "list the emails" in result["message"]
+    assert "send" not in result["data"]

--- a/roo-standalone/skills/committee_candidate_emails/SKILL.md
+++ b/roo-standalone/skills/committee_candidate_emails/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: committee-candidate-emails
+description: List emails for members with 100+ lifetime-earned Roo Points
+routing:
+  use_when: >
+    An admin wants emails for members with 100+ earned Roo Points.
+  avoid_when: >
+    Personal points, Luma attendee data, or sending event invitations.
+  examples:
+    - {text: "list members with 100 or more earned points", action: list_eligible_emails}
+    - {text: "give me the committee candidate emails", action: list_eligible_emails}
+    - {text: "export emails for members with at least 100 earned Roo Points", action: list_eligible_emails}
+  negative_examples:
+    - {text: "what is my Roo points balance", instead: mlai-points}
+    - {text: "show me attendees for this Luma event", instead: luma-events}
+actions:
+  - name: list_eligible_emails
+    description: Privately return the copy-ready eligible email list.
+---
+
+# Committee Candidate Emails
+
+- The backend is the source of truth for eligibility and permissions.
+- Eligibility is `lifetime_earned >= 100`; purchased and spendable balances do not count.
+- Return only the backend-provided email addresses and eligible count.
+- Public requests receive only an acknowledgement after private DM delivery.
+- The requester is always the verified Slack event actor, never a model parameter.
+- Roo does not collect meeting details, create Luma events, or send invitations.


### PR DESCRIPTION
## Summary

- Add one Roo skill action, `list_eligible_emails`, for requests such as `@Roo list members with 100 or more earned points`.
- Derive the requester from the verified Slack event and let the backend enforce the active `admin` or `committee` role.
- Send the email list privately when invoked in a public channel; the public response contains only an acknowledgement.
- Return the list directly in a Roo DM, with Slack-safe chunking for long lists and no dropped or duplicated addresses.
- Fail closed if private delivery fails and tell the requester to DM Roo without exposing emails publicly.

## Scope reduction

The meeting form, previews, confirmation buttons, interactive handlers, invitation sending, and retry workflow have been removed. Roo only lists eligible emails; Alisa copies them into Luma and sends invitations manually.

## Validation

- 43 focused feature, privacy, surface-security, router, catalog, and deterministic routing tests pass.
- A 6,000-address test verifies Slack-safe chunking without loss or duplication.
- Python compilation and diff checks pass.
- The full suite has 731 passes and 22 failures reproduced unchanged on current `main`; this branch adds no full-suite regression.

Requires backend PR: https://github.com/MLAI-AUS-Inc/mlai-backend/pull/704
Linear: https://linear.app/mlai-aus/issue/MLA-1763/let-roo-list-emails-of-members-with-100-or-more-earned-points
