### PR TITLE
Make start-here intro awards flexible

### DIFF
--- a/roo-standalone/QUESTS.md
+++ b/roo-standalone/QUESTS.md
@@ -6,7 +6,7 @@ Welcome to MLAI Quests! Complete these activities to earn points and level up in
 
 | Quest Name | Description | Points | How to Complete |
 |------------|-------------|--------|-----------------|
-| **First Contact** | Introduce yourself and your startup in `#_start-here` | 4 | Make one top-level post covering both you and what your startup does. If Roo asks for more detail, edit that original post. |
+| **First Contact** | Introduce yourself or your startup in `#_start-here` | 4 | Briefly introduce yourself, your startup, project, or idea in your first top-level post. If Roo asks for more detail, edit that original post. |
 | **Warm Welcome** | Welcome a new member | 1 | React to someone else's post in `#_start-here`. |
 | **Connector** | React to 5 messages with an emoji | 2 | Add reactions to other people's posts. |
 | **Helper** | Reply to 3 threads | 2 | Join the conversation by replying to threads. |

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -2189,7 +2189,7 @@ async def slack_events(
             intro_enabled = True
             intro_channel_name = "_start-here"
         start_here_id = get_channel_id(intro_channel_name) if intro_enabled else None
-        if start_here_id and event.get("channel") == start_here_id and not event.get("subtype"):
+        if start_here_id and event.get("channel") == start_here_id:
             if event.get("thread_ts"):
                 print(f"🧵 Ignoring thread reply in #_start-here from {event.get('user')}")
                 return JSONResponse(status_code=200, content={})

--- a/roo-standalone/roo/start_here_introductions.py
+++ b/roo-standalone/roo/start_here_introductions.py
@@ -93,8 +93,7 @@ class IntroClassification:
 
     def qualifies(self, *, min_confidence: float) -> bool:
         return (
-            self.introduces_person
-            and self.describes_startup
+            (self.introduces_person or self.describes_startup)
             and self.confidence >= min_confidence
         )
 
@@ -105,7 +104,7 @@ def normalize_intro_event(event: dict[str, Any]) -> Optional[IntroEvent]:
 
     subtype = str(event.get("subtype") or "")
     is_edit = subtype == "message_changed"
-    if subtype and not is_edit:
+    if subtype not in {"", "file_share", "message_changed"}:
         return None
 
     message = event.get("message") if is_edit else event
@@ -144,13 +143,14 @@ def build_classification_messages(text: str) -> list[dict[str, str]]:
                 "Return only JSON with keys introduces_person, describes_startup, "
                 "confidence, missing_fields, and reason. "
                 "introduces_person is true when the writer shares something identifying "
-                "or personal about themselves, such as their name, role, background, skills, "
-                "location, interests, or founder journey. "
-                "describes_startup is true when they describe a startup, venture, project, "
-                "or startup idea they are building or exploring, including what it does, "
-                "the problem, intended users, or current stage. A legal company name is not required. "
-                "Both must be substantively present. Greetings, links, slogans, requests for help, "
-                "and descriptions of a company with no personal introduction do not satisfy both. "
+                "or personal about themselves, even briefly, such as their name, role, background, "
+                "skills, location, interests, founder journey, or that they are new to the community. "
+                "describes_startup is true when they introduce a startup, venture, project, or idea, "
+                "even briefly, by naming it or mentioning what they are building or exploring. Details "
+                "about the problem, users, or stage are welcome but not required. Be deliberately "
+                "generous: either a personal introduction OR a startup/project introduction is enough. "
+                "Only greeting-only posts, link-only posts, generic requests, and unrelated chatter "
+                "should have both fields false. "
                 "missing_fields must contain only 'person' and/or 'startup'."
             ),
         },
@@ -161,9 +161,11 @@ def build_classification_messages(text: str) -> list[dict[str, str]]:
                 '"Hi, I\'m Priya, a product designer in Melbourne. I\'m building a tool that helps clinics reduce appointment no-shows." '
                 '-> {"introduces_person": true, "describes_startup": true, "confidence": 0.99, "missing_fields": [], "reason": "introduces the founder and explains the startup"}\n'
                 '"Hi, I\'m Alex and I work in data science." '
-                '-> {"introduces_person": true, "describes_startup": false, "confidence": 0.98, "missing_fields": ["startup"], "reason": "no startup described"}\n'
-                '"We make AI agents for accountants." '
-                '-> {"introduces_person": false, "describes_startup": true, "confidence": 0.95, "missing_fields": ["person"], "reason": "startup described without a personal introduction"}\n'
+                '-> {"introduces_person": true, "describes_startup": false, "confidence": 0.99, "missing_fields": ["startup"], "reason": "brief personal introduction"}\n'
+                '"We\'re Acme, building AI agents for accountants." '
+                '-> {"introduces_person": false, "describes_startup": true, "confidence": 0.99, "missing_fields": ["person"], "reason": "brief startup introduction"}\n'
+                '"I\'m Mei." '
+                '-> {"introduces_person": true, "describes_startup": false, "confidence": 0.99, "missing_fields": ["startup"], "reason": "shares the writer\'s name"}\n'
                 '"Hey everyone!" '
                 '-> {"introduces_person": false, "describes_startup": false, "confidence": 0.99, "missing_fields": ["person", "startup"], "reason": "greeting only"}\n\n'
                 f"Post to classify:\n{text[:4000]}"
@@ -229,9 +231,26 @@ def parse_classification(raw_content: str) -> IntroClassification:
 
 
 def _obviously_incomplete(text: str) -> Optional[IntroClassification]:
-    words = re.findall(r"[A-Za-z0-9][A-Za-z0-9'-]*", str(text or ""))
     non_url_text = re.sub(r"https?://\S+", "", str(text or "")).strip()
-    if len(words) >= 5 and non_url_text:
+    words = [
+        word.lower()
+        for word in re.findall(r"[A-Za-z0-9][A-Za-z0-9'-]*", non_url_text)
+    ]
+    greeting_only_words = {
+        "all",
+        "day",
+        "everyone",
+        "folks",
+        "g'day",
+        "good",
+        "hello",
+        "hey",
+        "hi",
+        "morning",
+        "team",
+        "there",
+    }
+    if words and any(word not in greeting_only_words for word in words):
         return None
     return IntroClassification(
         introduces_person=False,
@@ -766,16 +785,10 @@ def is_retryable_award_exception(exc: Exception) -> bool:
 
 
 def build_incomplete_message(slack_user_id: str, missing_fields: tuple[str, ...]) -> str:
-    missing = set(missing_fields)
-    if not missing or missing == {"person", "startup"}:
-        requirement = "a short introduction to you and what your startup does"
-    elif "person" in missing:
-        requirement = "a short introduction to you"
-    else:
-        requirement = "what your startup does, the problem it tackles, or who it helps"
     return (
         f"Thanks <@{slack_user_id}>! Before I can award the 4 Roo points, "
-        f"please edit this original post to add {requirement}. "
+        "please edit this original post to briefly introduce either yourself or "
+        "your startup, project, or idea. "
         "I'll check the edit automatically—please don't create a second introduction post."
     )
 
@@ -789,7 +802,7 @@ def post_award_notification(submission: dict[str, Any]) -> None:
         thread_ts=str(submission["canonical_message_ts"]),
         text=(
             f"Welcome <@{submission['slack_user_id']}>! You've earned {points} Roo points "
-            "for introducing yourself and your startup."
+            "for introducing yourself or your startup."
         ),
     )
 

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -1899,7 +1899,8 @@ def test_linear_meeting_file_request_helper_allows_short_attached_file_prompt():
 
 
 @pytest.mark.asyncio
-async def test_slack_events_start_here_message_triggers_intro_handler(monkeypatch):
+@pytest.mark.parametrize("subtype", [None, "file_share"])
+async def test_slack_events_start_here_message_triggers_intro_handler(monkeypatch, subtype):
     handled_events = []
     scheduled_tasks = []
     real_create_task = asyncio.create_task
@@ -1916,14 +1917,16 @@ async def test_slack_events_start_here_message_triggers_intro_handler(monkeypatc
     monkeypatch.setattr(main_module, "_handle_start_here_intro", fake_handle_start_here_intro)
     monkeypatch.setattr(main_module.asyncio, "create_task", fake_create_task)
 
-    payload = {
-        "event": {
-            "type": "message",
-            "user": "UINTRO",
-            "channel": "CSTART",
-            "ts": "111.222",
-        }
+    event = {
+        "type": "message",
+        "user": "UINTRO",
+        "channel": "CSTART",
+        "ts": "111.222",
+        "text": "I'm Jordan, building tools for tradies.",
     }
+    if subtype:
+        event["subtype"] = subtype
+    payload = {"event": event}
 
     class FakeRequest:
         async def json(self):

--- a/roo-standalone/roo/tests/test_start_here_introductions.py
+++ b/roo-standalone/roo/tests/test_start_here_introductions.py
@@ -53,6 +53,14 @@ async def missing_startup_llm(*args, **kwargs):
     )
 
 
+async def startup_only_llm(*args, **kwargs):
+    return FakeLLMResponse(
+        '{"introduces_person": false, "describes_startup": true, '
+        '"confidence": 0.97, "missing_fields": ["person"], '
+        '"reason": "brief startup introduction"}'
+    )
+
+
 def make_store(tmp_path):
     return intro.StartHereIntroductionStore(tmp_path / "start-here.db")
 
@@ -98,8 +106,16 @@ def test_normalize_intro_event_accepts_canonical_edits_and_rejects_threads_and_b
     bot["bot_id"] = "B123"
     assert intro.normalize_intro_event(bot) is None
 
+    file_share = message_event(text="I'm Jordan, building tools for tradies.")
+    file_share["subtype"] = "file_share"
+    assert intro.normalize_intro_event(file_share) is not None
 
-def test_parse_classification_fails_closed_for_non_boolean_true():
+    channel_join = message_event(text="Jordan joined the channel")
+    channel_join["subtype"] = "channel_join"
+    assert intro.normalize_intro_event(channel_join) is None
+
+
+def test_parse_classification_accepts_either_valid_intro_signal():
     result = intro.parse_classification(
         '{"introduces_person": "true", "describes_startup": true, '
         '"confidence": 0.99, "missing_fields": []}'
@@ -108,7 +124,43 @@ def test_parse_classification_fails_closed_for_non_boolean_true():
     assert result.introduces_person is False
     assert result.describes_startup is True
     assert "person" in result.missing_fields
+    assert result.qualifies(min_confidence=0.8) is True
+
+
+def test_parse_classification_rejects_when_neither_intro_signal_is_present():
+    result = intro.parse_classification(
+        '{"introduces_person": false, "describes_startup": false, '
+        '"confidence": 0.99, "missing_fields": ["person", "startup"]}'
+    )
+
     assert result.qualifies(min_confidence=0.8) is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("text", "llm_chat"),
+    [
+        ("I'm Jordan.", missing_startup_llm),
+        ("We're Acme, building better invoicing.", startup_only_llm),
+    ],
+)
+async def test_flexible_person_or_startup_intro_qualifies(
+    tmp_path, monkeypatch, text, llm_chat
+):
+    store = make_store(tmp_path)
+    client = FakeAwardClient()
+    monkeypatch.setattr(intro, "post_award_notification", lambda submission: None)
+
+    result = await intro.handle_start_here_intro(
+        message_event(text=text),
+        store=store,
+        client=client,
+        llm_chat=llm_chat,
+        min_confidence=0.8,
+    )
+
+    assert result["status"] == "awarded"
+    assert client.calls == [("UNEW", "CSTART")]
 
 
 @pytest.mark.asyncio
@@ -145,16 +197,15 @@ async def test_valid_first_intro_awards_four_points_once(tmp_path, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_incomplete_intro_requests_edit_without_award(tmp_path):
+async def test_greeting_only_post_requests_edit_without_award(tmp_path):
     store = make_store(tmp_path)
     client = FakeAwardClient()
     feedback = []
 
     result = await intro.handle_start_here_intro(
-        message_event(text="Hi, I'm Jordan and I work in product management."),
+        message_event(text="Hey everyone!"),
         store=store,
         client=client,
-        llm_chat=missing_startup_llm,
         min_confidence=0.8,
         post_feedback=lambda **kwargs: feedback.append(kwargs),
     )
@@ -162,7 +213,7 @@ async def test_incomplete_intro_requests_edit_without_award(tmp_path):
     assert result["status"] == "awaiting_edit"
     assert client.calls == []
     assert feedback[0]["thread_ts"] == "111.000"
-    assert "what your startup does" in feedback[0]["text"]
+    assert "either yourself or your startup" in feedback[0]["text"]
     assert "edit this original post" in feedback[0]["text"]
 
 

--- a/roo-standalone/skills/start-here-introductions/SKILL.md
+++ b/roo-standalone/skills/start-here-introductions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: start-here-introductions
-description: Validate each member's single top-level introduction in #_start-here, require information about both the person and their startup, and award 4 Roo points exactly once. Use automatically for new human posts and edits in #_start-here; do not require an @Roo mention.
+description: Generously validate each member's first top-level post in #_start-here and award 4 Roo points exactly once when it introduces either the person or their startup/project. Use automatically for new human posts and edits in #_start-here; do not require an @Roo mention.
 ---
 
 # Start Here Introductions
@@ -9,20 +9,20 @@ Process this skill from Slack message events rather than mention routing.
 
 ## Workflow
 
-1. Accept only human, top-level messages in `#_start-here`.
+1. Accept only human, top-level messages in `#_start-here`, including introductions posted with a file or image.
 2. Reserve the first message as the member's canonical introduction.
-3. Require both:
-   - a personal introduction, such as name, role, background, interests, or founder journey;
-   - a startup, venture, project, or startup idea description, such as what it does, its problem, users, or stage.
-4. If either part is missing, ask the member to edit the original post. Do not create another submission.
+3. Qualify the post generously when it contains either:
+   - even a brief personal introduction, such as a name, role, background, interest, location, or founder journey; or
+   - even a brief introduction to a startup, venture, project, or idea, including its name or what the member is building or exploring.
+4. Reject only posts with neither signal, such as greeting-only, link-only, generic request, or unrelated posts. Ask the member to edit the original post; do not create another submission.
 5. Re-check edits to the canonical post automatically.
-6. Award exactly 4 Roo points only after both requirements qualify.
+6. Award exactly 4 Roo points when either introduction signal qualifies.
 7. Treat duplicate events, later top-level posts, and post-award edits as no-ops for points.
 
 ## Safety
 
 - Keep the canonical submission and retry state durable across restarts.
-- Use the backend's one-time first-channel-post endpoint as the final award guard.
+- Use the backend's one-time first-channel-post endpoint as the final award guard so later posts cannot earn the award.
 - Fail closed on ambiguous, malformed, or unavailable classification results.
 - Retry transient award failures with the same canonical submission.
 - Never log introduction text in operational error messages.

--- a/roo-standalone/skills/start-here-introductions/routing.yaml
+++ b/roo-standalone/skills/start-here-introductions/routing.yaml
@@ -7,8 +7,12 @@ avoid_when: >
   requests to manually grant points.
 examples:
   - text: "Hi, I'm Mei, a data engineer building scheduling software for allied-health clinics."
+  - text: "Hi, I'm Mei."
+  - text: "We're Acme, building scheduling software for allied-health clinics."
   - text: "I'm Carlos, a first-time founder. We're exploring an AI tutor for apprentices."
   - text: "Hey, I'm Nisha from Melbourne. My startup helps hospitality teams reduce food waste."
 negative_examples:
+  - text: "Hey everyone!"
+    instead: ignore
   - text: "give me four Roo points"
     instead: mlai-points


### PR DESCRIPTION
## Summary

- award 4 Roo points when a member’s first top-level `#_start-here` post briefly introduces either themselves or their startup/project
- keep the durable first-post record and backend one-time award guard
- accept introductions attached to files/images while continuing to reject greeting-only, link-only, bot, thread, and later posts
- update quest and skill guidance to match the flexible rule

## Validation

- `18 passed, 83 deselected` for focused start-here and Slack event tests
- Python compilation and `git diff --check` passed
- broader selected suite: `110 passed, 3 failed`; the failures are unrelated current-main coworking/model-expectation tests (`test_admin_checkin_requires_exactly_one_target`, `test_book_coworking_with_target_mention_refuses_self_booking`, and `test_coworking_report_trends_and_recommendations_use_gpt54`)