### PR TITLE
fix(points): deliver personal Roo Points details privately

### DIFF
--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -862,7 +862,12 @@ class RooAgent:
             return None
 
         if action == "balance":
-            return await self._execute_fast_points(user_id, "balance")
+            return await self._execute_fast_points(
+                user_id,
+                "balance",
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+            )
 
         if action == "list_tasks":
             return await self._execute_fast_points(
@@ -874,7 +879,12 @@ class RooAgent:
             )
 
         if action == "list_rewards":
-            return await self._execute_fast_points(user_id, "list_rewards")
+            return await self._execute_fast_points(
+                user_id,
+                "list_rewards",
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+            )
 
         if action == "book_coworking":
             today = self._get_today().isoformat()
@@ -916,16 +926,16 @@ class RooAgent:
                 internal_api_key=settings.INTERNAL_API_KEY or settings.ROO_API_KEY or settings.MLAI_API_KEY,
             )
             
-            # Re-use the executor's logic for response formatting to DRY
-            # We need to instantiate the executor just to access the helper method
-            # Note: This relies on _handle_points_action being available/public-ish
-            # Since it's protected, we might duplicate simple formatting here for speed/isolation
-            
             if action == "balance":
-                data = await client.get_balance(user_id)
-                msg = self.skill_executor._format_points_balance_summary(
-                    data,
-                    tasks_command="@Roo tasks",
+                msg = await self.skill_executor._handle_points_action(
+                    client=client,
+                    action="balance",
+                    params={},
+                    text="points",
+                    user_id=user_id,
+                    channel_id=kwargs.get("channel_id"),
+                    thread_ts=kwargs.get("thread_ts"),
+                    skill=skill,
                 )
                 
             elif action == "list_tasks":
@@ -941,14 +951,15 @@ class RooAgent:
                 )
             
             elif action == "list_rewards":
-                rewards = await client.list_rewards(user_id)
-                balance_summary = await self.skill_executor._get_points_balance_summary_for_rewards(
-                    client,
-                    user_id,
-                )
-                msg = self.skill_executor._format_rewards_catalog(
-                    rewards,
-                    balance_summary=balance_summary,
+                msg = await self.skill_executor._handle_points_action(
+                    client=client,
+                    action="list_rewards",
+                    params={},
+                    text="rewards",
+                    user_id=user_id,
+                    channel_id=kwargs.get("channel_id"),
+                    thread_ts=kwargs.get("thread_ts"),
+                    skill=skill,
                 )
             
             elif action == "book_coworking":
@@ -973,20 +984,30 @@ class RooAgent:
             else:
                 msg = "Unknown fast action."
 
+            if isinstance(msg, dict):
+                data = dict(msg.get("data") or {})
+                data.setdefault("action", action)
+                return {
+                    "message": msg.get("message", ""),
+                    "skill_used": "mlai-points (fast)",
+                    "data": data,
+                    "blocks": msg.get("blocks"),
+                    "suppress_post": bool(msg.get("suppress_post", False)),
+                }
             return {
                 "message": msg,
                 "skill_used": "mlai-points (fast)",
-                "data": {"action": action}
+                "data": {"action": action},
             }
             
         except Exception as e:
-            print(f"❌ Fast path error: {e}")
+            print(f"❌ Fast path error: exc_type={e.__class__.__name__}")
             # Fallback to normal flow if fast path fails? Or just return error?
             # Return None to let LLM try? No, if we matched regex, we should probably fail gracefully here.
             return {
                 "message": "Sorry mate, having trouble connecting to the points system right now. Try again in a tic!",
                 "skill_used": "mlai-points (fast-error)",
-                "data": {"error": str(e)}
+                "data": {"error": "points_backend_unavailable"},
             }
 
     def _clean_mention(self, text: str) -> str:

--- a/roo-standalone/roo/boost_moderation.py
+++ b/roo-standalone/roo/boost_moderation.py
@@ -871,11 +871,9 @@ def _rejection_from_code(code: str, payload: dict[str, Any]) -> tuple[str, str] 
 
 def _approval_notice(admission: dict[str, Any]) -> str:
     charged = int(admission.get("charged_points") or 0)
-    balance = admission.get("new_balance")
     discount = bool(admission.get("discount_applied"))
     discount_text = " Your Australian startup monthly-update discount was applied." if discount else ""
-    balance_text = f" New balance: {balance}." if balance is not None else ""
-    return f":white_check_mark: Approved — {charged} Roo points deducted.{discount_text}{balance_text}"
+    return f":white_check_mark: Approved — {charged} Roo points deducted.{discount_text}"
 
 
 def _backend_result(admission: dict[str, Any]) -> dict[str, Any]:
@@ -890,11 +888,8 @@ def _rejection_notice(admission: dict[str, Any]) -> str:
     if status == "rejected_insufficient_points":
         result = _backend_result(admission)
         required = result.get("charged_points")
-        available = result.get("new_balance", result.get("balance_before"))
-        if required is not None and available is not None:
-            balance_detail = (
-                f"This boost costs {required} Roo points, and you currently have {available}. "
-            )
+        if required is not None:
+            balance_detail = f"This boost costs {required} Roo points. "
         else:
             balance_detail = "Your Roo points balance is below the price of this boost. "
         discount_detail = (
@@ -1244,9 +1239,8 @@ async def handle_boost_recheck_reaction(
         updated = store.mark_recheck_insufficient(int(claimed["id"]), result)
         backend_result = _backend_result(updated)
         required = backend_result.get("charged_points")
-        available = backend_result.get("new_balance", backend_result.get("balance_before"))
-        if required is not None and available is not None:
-            detail = f"You currently have {available}; this boost needs {required} Roo points. "
+        if required is not None:
+            detail = f"This boost needs {required} Roo points. "
         else:
             detail = "Your balance is still below this boost's Roo points price. "
         _post_recheck_feedback(

--- a/roo-standalone/roo/link_love.py
+++ b/roo-standalone/roo/link_love.py
@@ -742,11 +742,7 @@ def _build_notification_text(awards: list[dict[str, Any]]) -> str:
     lines = [heading]
     for award in awards:
         user_id = award.get("slack_user_id")
-        new_balance = award.get("new_balance")
-        if new_balance is None:
-            lines.append(f":white_check_mark: <@{user_id}>: awarded 2 pts")
-        else:
-            lines.append(f":white_check_mark: <@{user_id}>: now has {new_balance} pts")
+        lines.append(f":white_check_mark: <@{user_id}>: awarded 2 pts")
     return "\n".join(lines)
 
 

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -2548,15 +2548,36 @@ async def _handle_reaction_added(event: dict):
         points = result.get("points_awarded", request_record.get("points", 0))
         reason = request_record.get("reason", "No reason provided")
         new_balance = result.get("new_balance")
-        balance_line = f"\nNew balance: {new_balance} pts" if new_balance is not None else ""
         thread_ts = request_record.get("slack_thread_ts") or message_ts
+
+        if requester:
+            balance_line = (
+                f"\nYour new balance is {new_balance} points."
+                if new_balance is not None
+                else ""
+            )
+            try:
+                dm_response = send_dm(
+                    requester,
+                    (
+                        f"✅ Your points request was approved. You received {points} points.\n"
+                        f"Reason: {reason}{balance_line}"
+                    ),
+                )
+                if not dm_response or not dm_response.get("ok"):
+                    print("⚠️ Points approval recipient DM was not delivered")
+            except Exception as exc:
+                print(
+                    "⚠️ Points approval recipient DM failed "
+                    f"exc_type={exc.__class__.__name__}"
+                )
 
         post_message(
             channel=channel_id,
             text=(
                 f"✅ Points request approved by <@{reactor_user_id}>.\n\n"
                 f"<@{requester}> received {points} points.\n"
-                f"Reason: {reason}{balance_line}"
+                f"Reason: {reason}"
             ),
             thread_ts=thread_ts,
         )

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -68,6 +68,7 @@ from ..points_request_approval import (
 from ..slack_client import (
     get_channel_id,
     get_channel_name,
+    post_ephemeral,
     post_message,
     send_dm,
     upload_file,
@@ -7273,8 +7274,8 @@ Chunk {index} source: {label}
         balance = int(balance_data.get("balance") or 0)
         if balance < cost_points:
             return (
-                f"Creating an article costs {cost_points} Roo points, and you currently have "
-                f"{balance}. Earn a few more Roo points first, then ask me again."
+                f"Creating an article costs {cost_points} Roo points, and your balance is below "
+                "that amount. DM Roo `points` to view your balance privately."
             )
 
         return None
@@ -9831,7 +9832,9 @@ Chunk {index} source: {label}
             if e.response.status_code == 403:
                 return "Sorry mate, you're not authorized to do that. Only Points Admins can perform that action. 🔒"
             elif e.response.status_code == 409:
-                error_detail = self._extract_http_error_detail(e)
+                error_detail = self._redact_points_balance_error(
+                    self._extract_http_error_detail(e)
+                )
                 return error_detail or (
                     "That task changed while you were editing it. Refresh it and try again."
                 )
@@ -9848,29 +9851,40 @@ Chunk {index} source: {label}
                 # Handle bad requests (e.g. insufficient funds)
                 try:
                     error_detail = self._extract_http_error_detail(e)
-                    
-                    # If it's a balance issue, fetch current balance to be helpful
-                    if "balance" in error_detail.lower() or "insufficient" in error_detail.lower():
+                    safe_detail = self._redact_points_balance_error(error_detail)
+
+                    if self._is_points_balance_error(error_detail):
                         try:
                             balance_data = await client.get_balance(user_id)
                             current_balance = balance_data.get("balance", 0)
-                            return f"🛑 Computer says no: {error_detail}\n\nYour current balance is **{current_balance} points**."
+                            return self._deliver_personal_points_message(
+                                recipient_user_id=user_id,
+                                requester_user_id=user_id,
+                                channel_id=channel_id,
+                                thread_ts=thread_ts,
+                                private_message=(
+                                    f"🛑 Computer says no: {safe_detail}\n\n"
+                                    f"Your current balance is **{current_balance} points**."
+                                ),
+                                public_message=f"🛑 Computer says no: {safe_detail}",
+                                action=action or "points_error",
+                            )
                         except Exception:
-                            pass
-                            
-                    return f"🛑 {error_detail}"
+                            return f"🛑 Computer says no: {safe_detail}"
+
+                    return f"🛑 {safe_detail}"
                 except Exception:
                     return f"Ran into a snag with that request (400 Bad Request)."
             elif e.response.status_code >= 500:
                 return self._points_backend_unavailable_message(action)
             else:
-                error_detail = self._extract_http_error_detail(e)
-                return f"Ran into a snag: {error_detail or str(e)}"
+                error_detail = self._redact_points_balance_error(
+                    self._extract_http_error_detail(e)
+                )
+                return f"Ran into a snag: {error_detail or 'The points request was rejected.'}"
         except Exception as e:
-            print(f"Points skill error: {e}")
-            import traceback
-            traceback.print_exc()
-            return f"Had some trouble with the points system: {str(e)}"
+            print(f"Points skill error: exc_type={e.__class__.__name__}")
+            return "Had some trouble with the points system. Try again shortly."
 
 
     def _resolve_topup_pack_id(self, text: str, params: dict) -> tuple[Optional[str], Optional[int]]:
@@ -10523,6 +10537,136 @@ Chunk {index} source: {label}
             f"🛒 **Lifetime Purchased:** {purchased} points\n\n"
             f"Nice work! Check out `{tasks_command}` to earn more 🦘"
         )
+
+    @staticmethod
+    def _is_points_balance_error(error_detail: str) -> bool:
+        detail = str(error_detail or "").lower()
+        return (
+            "balance" in detail
+            or ("insufficient" in detail and ("point" in detail or "fund" in detail))
+            or ("not enough" in detail and "point" in detail)
+            or bool(
+                re.search(
+                    r"\b(?:has|have|available|remaining|current)\b[^\n]*"
+                    r"\d+\s*(?:roo\s+)?points?\b",
+                    detail,
+                )
+            )
+            or bool(re.search(r"\d+\s*<\s*\d+", detail))
+        )
+
+    @classmethod
+    def _redact_points_balance_error(cls, error_detail: str) -> str:
+        detail = str(error_detail or "").strip()
+        if cls._is_points_balance_error(detail) and re.search(r"\d", detail):
+            return "There are not enough Roo Points for this action."
+        return detail
+
+    def _deliver_personal_points_message(
+        self,
+        *,
+        recipient_user_id: str,
+        requester_user_id: str,
+        channel_id: Optional[str],
+        thread_ts: Optional[str],
+        private_message: str,
+        action: str,
+        public_message: Optional[str] = None,
+        private_ack: str = "I've sent your Roo Points details privately.",
+    ) -> dict:
+        """Deliver personal points data without a shared-channel fallback."""
+        result_data = {
+            "action": action,
+            "delivery": "direct_message",
+            "private_points": True,
+        }
+        requester_dm = bool(
+            channel_id
+            and str(channel_id).startswith("D")
+            and recipient_user_id == requester_user_id
+        )
+        if requester_dm:
+            return {
+                "message": private_message,
+                "data": {**result_data, "delivery": "current_direct_message"},
+            }
+
+        try:
+            response = send_dm(recipient_user_id, private_message)
+            dm_delivered = bool(response and response.get("ok"))
+        except Exception as exc:
+            print(
+                "⚠️ Private Roo Points delivery failed "
+                f"action={action} exc_type={exc.__class__.__name__}"
+            )
+            dm_delivered = False
+        result_data["dm_delivered"] = dm_delivered
+
+        if public_message is not None:
+            if not dm_delivered and recipient_user_id == requester_user_id:
+                self._post_private_points_ack(
+                    channel_id=channel_id,
+                    requester_user_id=requester_user_id,
+                    thread_ts=thread_ts,
+                    text=(
+                        "I couldn't send your private points details. "
+                        "DM Roo `points` to view them safely."
+                    ),
+                    action=action,
+                )
+            return {
+                "message": public_message,
+                "data": result_data,
+            }
+
+        acknowledgement = (
+            private_ack
+            if dm_delivered
+            else "I couldn't send you a DM. DM Roo `points` to view your points privately."
+        )
+        result_data["ephemeral_delivered"] = self._post_private_points_ack(
+            channel_id=channel_id,
+            requester_user_id=requester_user_id,
+            thread_ts=thread_ts,
+            text=acknowledgement,
+            action=action,
+        )
+        if not dm_delivered:
+            result_data["delivery_failed"] = True
+
+        # Personal data must never fall back to a shared Slack response, even
+        # when both the DM and private acknowledgement fail.
+        return {
+            "message": "",
+            "suppress_post": True,
+            "data": result_data,
+        }
+
+    @staticmethod
+    def _post_private_points_ack(
+        *,
+        channel_id: Optional[str],
+        requester_user_id: str,
+        thread_ts: Optional[str],
+        text: str,
+        action: str,
+    ) -> bool:
+        if not channel_id or str(channel_id).startswith("D") or not requester_user_id:
+            return False
+        try:
+            response = post_ephemeral(
+                channel=channel_id,
+                user=requester_user_id,
+                text=text,
+                thread_ts=thread_ts,
+            )
+            return bool(response and response.get("ok"))
+        except Exception as exc:
+            print(
+                "⚠️ Private Roo Points acknowledgement failed "
+                f"action={action} exc_type={exc.__class__.__name__}"
+            )
+            return False
 
     async def _get_points_balance_summary_for_rewards(self, client, user_id: str) -> Optional[dict]:
         try:
@@ -11403,10 +11547,15 @@ Chunk {index} source: {label}
         new_balance: Optional[int],
         admin_checkin: bool,
         discount_applied: bool = False,
+        include_balance: bool = True,
     ) -> str:
         point_word = "point" if cost == 1 else "points"
         if admin_checkin:
-            balance_line = f"\nTheir balance: {new_balance} pts" if new_balance is not None else ""
+            balance_line = (
+                f"\nTheir balance: {new_balance} pts"
+                if include_balance and new_balance is not None
+                else ""
+            )
             return (
                 f"You beauty! 🎉\n\n"
                 f"Checked <@{target_user_id}> in for **{booking_date}** at the coworking space.\n"
@@ -11414,7 +11563,7 @@ Chunk {index} source: {label}
             )
 
         balance_line = ""
-        if new_balance is not None:
+        if include_balance and new_balance is not None:
             balance_line = f" (Balance remaining: {new_balance} points)"
 
         message = (
@@ -11443,16 +11592,10 @@ Chunk {index} source: {label}
         target_user_id: str,
         exc: httpx.HTTPStatusError,
     ) -> str:
-        error_detail = self._extract_http_error_detail(exc) or "Bad request"
-        balance_line = ""
-        if "balance" in error_detail.lower() or "insufficient" in error_detail.lower():
-            try:
-                balance_data = await client.get_balance(target_user_id)
-                current_balance = balance_data.get("balance", 0)
-                balance_line = f"\n\nTheir current balance is **{current_balance} points**."
-            except Exception:
-                pass
-        return f"🛑 I couldn't check <@{target_user_id}> in: {error_detail}{balance_line}"
+        error_detail = self._redact_points_balance_error(
+            self._extract_http_error_detail(exc) or "Bad request"
+        )
+        return f"🛑 I couldn't check <@{target_user_id}> in: {error_detail}"
 
     def _format_admin_coworking_batch_success(
         self,
@@ -11499,7 +11642,9 @@ Chunk {index} source: {label}
         booking_date: str,
         exc: httpx.HTTPStatusError,
     ) -> str:
-        error_detail = self._extract_http_error_detail(exc) or "The booking request was rejected."
+        error_detail = self._redact_points_balance_error(
+            self._extract_http_error_detail(exc) or "The booking request was rejected."
+        )
         per_target_errors: list[dict] = []
         try:
             payload = exc.response.json()
@@ -11517,7 +11662,14 @@ Chunk {index} source: {label}
         for item in per_target_errors[:10]:
             slack_user_id = str(item.get("slack_user_id") or "").strip()
             target_label = f"<@{slack_user_id}>" if slack_user_id else "Target"
-            reason = str(item.get("error") or item.get("detail") or item.get("message") or "Rejected").strip()
+            reason = self._redact_points_balance_error(
+                str(
+                    item.get("error")
+                    or item.get("detail")
+                    or item.get("message")
+                    or "Rejected"
+                ).strip()
+            )
             lines.append(f"• {target_label}: {reason}")
         return "\n".join(lines)
 
@@ -11529,7 +11681,7 @@ Chunk {index} source: {label}
         target_user_ids: list[str],
         booking_date: str,
         channel_id: Optional[str],
-    ) -> str:
+    ) -> Any:
         try:
             result = await client.book_coworking_many(
                 admin_slack_user_id=admin_user_id,
@@ -11643,13 +11795,31 @@ Chunk {index} source: {label}
         except MLAIBackendUnavailableError:
             pass
 
-        return self._format_coworking_booking_success(
+        private_message = self._format_coworking_booking_success(
             booking_date=booking_date,
             target_user_id=target_user_id,
             cost=cost,
             new_balance=new_balance,
+            admin_checkin=False,
+            discount_applied=discount_applied,
+        )
+        public_message = self._format_coworking_booking_success(
+            booking_date=booking_date,
+            target_user_id=target_user_id,
+            cost=cost,
+            new_balance=None,
             admin_checkin=admin_checkin,
             discount_applied=discount_applied,
+            include_balance=False,
+        )
+        return self._deliver_personal_points_message(
+            recipient_user_id=target_user_id,
+            requester_user_id=requested_by_user_id,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            private_message=private_message,
+            public_message=public_message,
+            action="book_coworking",
         )
 
     async def _handle_points_action(
@@ -11757,23 +11927,40 @@ Chunk {index} source: {label}
 
         if action == "balance":
             data = await client.get_balance(user_id)
-            return self._format_points_balance_summary(data, tasks_command="tasks")
+            message = self._format_points_balance_summary(data, tasks_command="tasks")
+            return self._deliver_personal_points_message(
+                recipient_user_id=user_id,
+                requester_user_id=user_id,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                private_message=message,
+                action="balance",
+                private_ack="I've sent your Roo Points summary privately.",
+            )
         
         elif action == "history":
             limit = params.get("limit", 10)
             entries = await client.get_history(user_id, limit)
             
             if not entries:
-                return "No transactions yet! Start earning points by claiming some tasks 💪"
-            
-            lines = ["📜 **Your Recent Transactions:**\n"]
-            for entry in entries[:10]:
-                delta = entry.get("delta", 0)
-                emoji = "➕" if delta > 0 else "➖"
-                desc = entry.get("description", "")[:50]
-                lines.append(f"{emoji} {delta:+d} pts - {desc}")
-            
-            return "\n".join(lines)
+                message = "No transactions yet! Start earning points by claiming some tasks 💪"
+            else:
+                lines = ["📜 **Your Recent Transactions:**\n"]
+                for entry in entries[:10]:
+                    delta = entry.get("delta", 0)
+                    emoji = "➕" if delta > 0 else "➖"
+                    desc = entry.get("description", "")[:50]
+                    lines.append(f"{emoji} {delta:+d} pts - {desc}")
+                message = "\n".join(lines)
+            return self._deliver_personal_points_message(
+                recipient_user_id=user_id,
+                requester_user_id=user_id,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                private_message=message,
+                action="history",
+                private_ack="I've sent your Roo Points history privately.",
+            )
         
         elif action == "request_points":
             if not channel_id:
@@ -12200,7 +12387,16 @@ Chunk {index} source: {label}
         elif action == "list_rewards":
             rewards = await client.list_rewards(user_id)
             balance_summary = await self._get_points_balance_summary_for_rewards(client, user_id)
-            return self._format_rewards_catalog(rewards, balance_summary=balance_summary)
+            message = self._format_rewards_catalog(rewards, balance_summary=balance_summary)
+            return self._deliver_personal_points_message(
+                recipient_user_id=user_id,
+                requester_user_id=user_id,
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+                private_message=message,
+                action="list_rewards",
+                private_ack="I've sent your personalised Roo Rewards list privately.",
+            )
         
         elif action == "request_reward":
             reward_code = params.get("reward_code", "").upper()
@@ -12684,10 +12880,33 @@ Chunk {index} source: {label}
                         print(f"⚠️ User linking failed (continuing to award): {e}")
 
                     result = await client.award_points(user_id, target_id, int(points), reason)
-                    new_balance = result.get("new_balance", 0)
-                    results.append({"user": target_id, "new_balance": new_balance})
+                    new_balance = result.get("new_balance")
+                    results.append({"user": target_id})
+                    balance_line = (
+                        f"\nYour new balance is {new_balance} points."
+                        if new_balance is not None
+                        else ""
+                    )
+                    try:
+                        send_dm(
+                            target_id,
+                            (
+                                f"You received {int(points)} Roo Points.\n"
+                                f"Reason: {reason}{balance_line}"
+                            ),
+                        )
+                    except Exception as exc:
+                        print(
+                            "⚠️ Award recipient DM failed "
+                            f"exc_type={exc.__class__.__name__}"
+                        )
                 except Exception as e:
-                    errors.append({"user": target_id, "error": str(e)})
+                    errors.append(
+                        {
+                            "user": target_id,
+                            "error": self._redact_points_balance_error(str(e)),
+                        }
+                    )
             
             # Build response
             emoji = "🎉" if points > 0 else "📉"
@@ -12695,11 +12914,11 @@ Chunk {index} source: {label}
             
             if len(results) == 1 and not errors:
                 r = results[0]
-                return f"{emoji} {verb} {abs(points)} points to <@{r['user']}>.\n\nReason: {reason}\nTheir new balance: {r['new_balance']} pts"
+                return f"{emoji} {verb} {abs(points)} points to <@{r['user']}>.\n\nReason: {reason}"
             
             lines = [f"{emoji} {verb} {abs(points)} points each!\n\nReason: {reason}\n"]
             for r in results:
-                lines.append(f"✅ <@{r['user']}>: now has {r['new_balance']} pts")
+                lines.append(f"✅ <@{r['user']}>: points awarded")
             for e in errors:
                 lines.append(f"❌ <@{e['user']}>: {e['error']}")
             

--- a/roo-standalone/roo/tests/test_boost_moderation.py
+++ b/roo-standalone/roo/tests/test_boost_moderation.py
@@ -134,7 +134,7 @@ def test_invalid_post_notice_explains_internal_validation_and_retry() -> None:
     assert "create a new top-level post" in notice
 
 
-def test_insufficient_points_notice_shows_price_balance_and_discount() -> None:
+def test_insufficient_points_notice_shows_price_and_discount_without_balance() -> None:
     notice = module._rejection_notice(
         {
             "poster_slack_id": "UPOSTER1",
@@ -150,7 +150,8 @@ def test_insufficient_points_notice_shows_price_balance_and_discount() -> None:
     )
 
     assert "costs 4 Roo points" in notice
-    assert "currently have 3" in notice
+    assert "currently have 3" not in notice
+    assert "new balance" not in notice.lower()
     assert "50% Australian-startup monthly-update discount" in notice
     assert "engaging with other founders' posts" in notice
     assert "DMing me `topup`" in notice
@@ -454,7 +455,8 @@ async def test_still_insufficient_recheck_keeps_post_removed_and_explains_next_s
 
     assert result["status"] == "still_insufficient"
     assert store.get("CBOOST123", "1800000000.123456")["status"] == "deleted"
-    assert "currently have 6" in posted[-1]["text"]
+    assert "currently have 6" not in posted[-1]["text"]
+    assert "needs 8 Roo points" in posted[-1]["text"]
     assert "react ✅ again" in posted[-1]["text"]
 
 

--- a/roo-standalone/roo/tests/test_content_factory_article_flow.py
+++ b/roo-standalone/roo/tests/test_content_factory_article_flow.py
@@ -1756,7 +1756,9 @@ async def test_content_factory_blocks_when_user_has_insufficient_points(monkeypa
     )
 
     assert "Creating an article costs 4 Roo points" in result
-    assert "currently have 3" in result
+    assert "currently have 3" not in result
+    assert "balance is below that amount" in result
+    assert "DM Roo `points`" in result
     assert FakeContentFactoryClient.last_instance.trigger_calls == []
     assert FakeContentFactoryClient.last_instance.balance_checks == ["U999FREE"]
 

--- a/roo-standalone/roo/tests/test_coworking_admin_batch.py
+++ b/roo-standalone/roo/tests/test_coworking_admin_batch.py
@@ -178,4 +178,5 @@ async def test_backend_batch_failure_formats_no_bookings_created_response():
 
     assert "No bookings were created" in result
     assert "One or more users have insufficient Roo Points" in result
-    assert "<@U2>: Insufficient balance: 4 < 8 required" in result
+    assert "<@U2>: There are not enough Roo Points for this action" in result
+    assert "4 < 8" not in result

--- a/roo-standalone/roo/tests/test_link_love.py
+++ b/roo-standalone/roo/tests/test_link_love.py
@@ -592,8 +592,8 @@ async def test_batched_notification_groups_awarded_users_in_root_thread(tmp_path
             "thread_ts": "111.000",
             "text": (
                 ":tada: Awarded 2 points each for link-love.\n"
-                ":white_check_mark: <@UONE>: now has 12 pts\n"
-                ":white_check_mark: <@UTWO>: now has 18 pts"
+                ":white_check_mark: <@UONE>: awarded 2 pts\n"
+                ":white_check_mark: <@UTWO>: awarded 2 pts"
             ),
         }
     ]

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -589,11 +589,12 @@ async def test_balance_summary_includes_lifetime_purchased():
         params={},
         text="points",
         user_id="U123",
-        channel_id="C123",
+        channel_id="D123",
         thread_ts="111.222",
         skill=SimpleNamespace(name="mlai-points"),
     )
 
+    result = result["message"]
     assert "Current Balance:** 15 points" in result
     assert "Lifetime Earned:** 42 points" in result
     assert "Lifetime Spent:** 27 points" in result
@@ -644,11 +645,12 @@ async def test_list_rewards_response_includes_catalog_context():
         params={},
         text="rewards",
         user_id="U123",
-        channel_id="C123",
+        channel_id="D123",
         thread_ts="111.222",
         skill=SimpleNamespace(name="mlai-points"),
     )
 
+    result = result["message"]
     assert client.list_rewards_user_id == "U123"
     assert client.balance_user_id == "U123"
     assert "Your balance: **12 points**" in result
@@ -692,11 +694,12 @@ async def test_list_rewards_still_renders_when_balance_lookup_fails():
         params={},
         text="rewards",
         user_id="U123",
-        channel_id="C123",
+        channel_id="D123",
         thread_ts="111.222",
         skill=SimpleNamespace(name="mlai-points"),
     )
 
+    result = result["message"]
     assert client.balance_user_id == "U123"
     assert "Your balance: **10 points**" in result
     assert "Free Community Event Ticket" in result
@@ -1682,7 +1685,7 @@ async def test_reaction_approval_posts_confirmation(monkeypatch):
     monkeypatch.setattr(
         main_module,
         "send_dm",
-        lambda user_id, text, **kwargs: direct_messages.append((user_id, text)),
+        lambda user_id, text, **kwargs: direct_messages.append((user_id, text)) or {"ok": True},
     )
 
     await main_module._handle_reaction_added(
@@ -1698,7 +1701,14 @@ async def test_reaction_approval_posts_confirmation(monkeypatch):
     assert posted_messages[0]["thread_ts"] == "111.222"
     assert "approved by <@UADMIN>" in posted_messages[0]["text"]
     assert "<@UREQUESTER> received 5 points" in posted_messages[0]["text"]
-    assert direct_messages == []
+    assert "17" not in posted_messages[0]["text"]
+    assert direct_messages == [
+        (
+            "UREQUESTER",
+            "✅ Your points request was approved. You received 5 points.\n"
+            "Reason: helping at the event\nYour new balance is 17 points.",
+        )
+    ]
 
 
 @pytest.mark.asyncio
@@ -1804,7 +1814,7 @@ async def test_reaction_approval_uses_cached_summary_mapping_when_backend_lookup
     monkeypatch.setattr(
         main_module,
         "send_dm",
-        lambda user_id, text, **kwargs: direct_messages.append((user_id, text)),
+        lambda user_id, text, **kwargs: direct_messages.append((user_id, text)) or {"ok": True},
     )
 
     await main_module._handle_reaction_added(
@@ -1819,8 +1829,11 @@ async def test_reaction_approval_uses_cached_summary_mapping_when_backend_lookup
     assert LookupMissApprovalClient.last_instance.approve_args == (9, "UADMIN")
     assert posted_messages[0]["thread_ts"] == "111.222"
     assert "<@UREQUESTER> received 5 points" in posted_messages[0]["text"]
+    assert "17" not in posted_messages[0]["text"]
     assert approval_module.get_remembered_points_request_summary("C123", "222.333") is None
-    assert direct_messages == []
+    assert direct_messages
+    assert direct_messages[0][0] == "UREQUESTER"
+    assert "Your new balance is 17 points" in direct_messages[0][1]
 
 
 @pytest.mark.asyncio
@@ -1864,7 +1877,7 @@ async def test_reaction_approval_uses_message_metadata_for_heavy_check_mark(monk
     monkeypatch.setattr(
         main_module,
         "send_dm",
-        lambda user_id, text, **kwargs: direct_messages.append((user_id, text)),
+        lambda user_id, text, **kwargs: direct_messages.append((user_id, text)) or {"ok": True},
     )
 
     await main_module._handle_reaction_added(
@@ -1879,7 +1892,10 @@ async def test_reaction_approval_uses_message_metadata_for_heavy_check_mark(monk
     assert LookupMissApprovalClient.last_instance.approve_args == (12, "UADMIN")
     assert posted_messages[0]["thread_ts"] == "111.222"
     assert "<@UREQUESTER> received 5 points" in posted_messages[0]["text"]
-    assert direct_messages == []
+    assert "17" not in posted_messages[0]["text"]
+    assert direct_messages
+    assert direct_messages[0][0] == "UREQUESTER"
+    assert "Your new balance is 17 points" in direct_messages[0][1]
 
 
 @pytest.mark.asyncio
@@ -2619,6 +2635,7 @@ async def test_book_coworking_still_succeeds_when_balance_refresh_times_out(tmp_
     executor = SkillExecutor()
     monkeypatch.setattr("roo.utils.get_current_date", lambda: __import__("datetime").date(2026, 4, 9))
     monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(executor_module, "send_dm", lambda *args, **kwargs: {"ok": True})
 
     try:
         result = await executor._handle_points_action(
@@ -2634,8 +2651,8 @@ async def test_book_coworking_still_succeeds_when_balance_refresh_times_out(tmp_
     finally:
         monkeypatch.undo()
 
-    assert "Booked you in for **2026-04-09**" in result
-    assert "Balance remaining" not in result
+    assert "Booked you in for **2026-04-09**" in result["message"]
+    assert "Balance remaining" not in result["message"]
 
 
 @pytest.mark.asyncio
@@ -2659,6 +2676,7 @@ async def test_book_coworking_defaults_missing_date_to_today(tmp_path, monkeypat
     executor = SkillExecutor()
     monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
     monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(executor_module, "send_dm", lambda *args, **kwargs: {"ok": True})
 
     result = await executor._handle_points_action(
         client=client,
@@ -2672,7 +2690,7 @@ async def test_book_coworking_defaults_missing_date_to_today(tmp_path, monkeypat
     )
 
     intent = store.get_by_key("coworking:U123:2026-05-04")
-    assert "Booked you in for **2026-05-04**" in result
+    assert "Booked you in for **2026-05-04**" in result["message"]
     assert client.book_args == ("U123", "2026-05-04", "C123")
     assert client.balance_args == "U123"
     assert intent["requested_by_slack_id"] == "U123"
@@ -2718,6 +2736,12 @@ async def test_admin_checkin_books_target_for_today(tmp_path, monkeypatch):
     monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
     monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
     monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+    direct_messages = []
+    monkeypatch.setattr(
+        executor_module,
+        "send_dm",
+        lambda user_id, text, **kwargs: direct_messages.append((user_id, text)) or {"ok": True},
+    )
 
     result = await executor._handle_points_action(
         client=client,
@@ -2731,8 +2755,10 @@ async def test_admin_checkin_books_target_for_today(tmp_path, monkeypatch):
     )
 
     intent = store.get_by_key("coworking:UTARGET:2026-05-04")
-    assert "Checked <@UTARGET> in for **2026-05-04**" in result
-    assert "Their balance: 13 pts" in result
+    assert "Checked <@UTARGET> in for **2026-05-04**" in result["message"]
+    assert "Their balance" not in result["message"]
+    assert direct_messages[0][0] == "UTARGET"
+    assert "Balance remaining: 13 points" in direct_messages[0][1]
     assert client.book_args == ("UTARGET", "2026-05-04", "C123")
     assert client.balance_args == "UTARGET"
     assert intent["requested_by_slack_id"] == "UADMIN"
@@ -2746,6 +2772,7 @@ async def test_admin_checkin_book_mention_phrase_books_target_for_today(tmp_path
     monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
     monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
     monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+    monkeypatch.setattr(executor_module, "send_dm", lambda *args, **kwargs: {"ok": True})
 
     action = executor._resolve_routed_points_action(
         {"action": "book_coworking", "target_users": ["<@UTARGET>"]},
@@ -2764,7 +2791,8 @@ async def test_admin_checkin_book_mention_phrase_books_target_for_today(tmp_path
 
     intent = store.get_by_key("coworking:UTARGET:2026-05-04")
     assert action == "admin_checkin_coworking"
-    assert "Checked <@UTARGET> in for **2026-05-04**" in result
+    assert "Checked <@UTARGET> in for **2026-05-04**" in result["message"]
+    assert "balance" not in result["message"].lower()
     assert client.book_args == ("UTARGET", "2026-05-04", "C123")
     assert client.balance_args == "UTARGET"
     assert intent["requested_by_slack_id"] == "UADMIN"
@@ -2777,6 +2805,7 @@ async def test_admin_checkin_honors_explicit_date(tmp_path, monkeypatch):
     executor = SkillExecutor()
     monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
     monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
+    monkeypatch.setattr(executor_module, "send_dm", lambda *args, **kwargs: {"ok": True})
 
     result = await executor._handle_points_action(
         client=client,
@@ -2789,7 +2818,8 @@ async def test_admin_checkin_honors_explicit_date(tmp_path, monkeypatch):
         skill=SimpleNamespace(name="mlai-points"),
     )
 
-    assert "Checked <@UTARGET> in for **2026-06-01**" in result
+    assert "Checked <@UTARGET> in for **2026-06-01**" in result["message"]
+    assert "balance" not in result["message"].lower()
     assert client.book_args == ("UTARGET", "2026-06-01", "C123")
 
 
@@ -2857,6 +2887,7 @@ async def test_book_coworking_with_target_mention_refuses_self_booking(tmp_path,
     executor = SkillExecutor()
     monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
     monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(executor_module, "send_dm", lambda *args, **kwargs: {"ok": True})
     monkeypatch.setattr(slack_client_module, "get_bot_user_id", lambda: "UROO")
 
     result = await executor._handle_points_action(
@@ -2906,8 +2937,10 @@ async def test_admin_checkin_insufficient_balance_message_names_target(tmp_path,
 
     intent = store.get_by_key("coworking:UTARGET:2026-05-04")
     assert "I couldn't check <@UTARGET> in" in result
-    assert "Their current balance is **0 points**" in result
+    assert "There are not enough Roo Points" in result
+    assert "0 points" not in result
     assert "UADMIN" not in result
+    assert client.balance_args is None
     assert intent["status"] == "blocked"
 
 
@@ -3519,6 +3552,7 @@ async def test_book_coworking_nudges_founder_when_charged_standard_price(tmp_pat
     executor = SkillExecutor()
     monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
     monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(executor_module, "send_dm", lambda *args, **kwargs: {"ok": True})
 
     result = await executor._handle_points_action(
         client=FakeCoworkingClient(),
@@ -3531,10 +3565,11 @@ async def test_book_coworking_nudges_founder_when_charged_standard_price(tmp_pat
         skill=SimpleNamespace(name="mlai-points"),
     )
 
-    assert "Booked you in for **2026-05-04**" in result
-    assert "Cost: 8 points" in result
-    assert "submit a monthly update" in result
-    assert "https://mlai.au/platform/login?app=founder-tools&next=/founder-tools" in result
+    assert "Booked you in for **2026-05-04**" in result["message"]
+    assert "Cost: 8 points" in result["message"]
+    assert "Balance remaining" not in result["message"]
+    assert "submit a monthly update" in result["message"]
+    assert "https://mlai.au/platform/login?app=founder-tools&next=/founder-tools" in result["message"]
 
 
 @pytest.mark.asyncio
@@ -3551,6 +3586,7 @@ async def test_book_coworking_omits_nudge_when_discount_applied(tmp_path, monkey
     executor = SkillExecutor()
     monkeypatch.setattr("roo.utils.get_current_date", lambda: date(2026, 5, 4))
     monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+    monkeypatch.setattr(executor_module, "send_dm", lambda *args, **kwargs: {"ok": True})
 
     result = await executor._handle_points_action(
         client=FakeCoworkingClient(),
@@ -3563,7 +3599,8 @@ async def test_book_coworking_omits_nudge_when_discount_applied(tmp_path, monkey
         skill=SimpleNamespace(name="mlai-points"),
     )
 
-    assert "Booked you in for **2026-05-04**" in result
-    assert "Cost: 4 points" in result
-    assert "submit a monthly update" not in result
-    assert "founder-tools" not in result
+    assert "Booked you in for **2026-05-04**" in result["message"]
+    assert "Cost: 4 points" in result["message"]
+    assert "Balance remaining" not in result["message"]
+    assert "submit a monthly update" not in result["message"]
+    assert "founder-tools" not in result["message"]

--- a/roo-standalone/roo/tests/test_private_points_delivery.py
+++ b/roo-standalone/roo/tests/test_private_points_delivery.py
@@ -1,0 +1,510 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("SLACK_BOT_TOKEN", "xoxb-private-points-test")
+os.environ.setdefault("SLACK_SIGNING_SECRET", "private-points-signing-test")
+
+from roo import agent as agent_module
+from roo import coworking_booking_intents as coworking_module
+from roo.agent import RooAgent
+from roo.skills import executor as executor_module
+from roo.skills.executor import SkillExecutor
+
+
+@pytest.mark.parametrize(
+    ("detail", "expected"),
+    [
+        (
+            "One or more users have insufficient Roo Points",
+            "One or more users have insufficient Roo Points",
+        ),
+        (
+            "Insufficient balance: 4 < 8 required",
+            "There are not enough Roo Points for this action.",
+        ),
+        (
+            "You have 4 Roo Points but need 8",
+            "There are not enough Roo Points for this action.",
+        ),
+    ],
+)
+def test_points_error_redaction_preserves_reason_without_exposing_balance(
+    detail,
+    expected,
+):
+    assert SkillExecutor._redact_points_balance_error(detail) == expected
+
+
+class PersonalPointsClient:
+    def __init__(self):
+        self.balance_users = []
+        self.history_users = []
+        self.reward_users = []
+
+    async def get_balance(self, slack_user_id):
+        self.balance_users.append(slack_user_id)
+        return {
+            "balance": 37,
+            "lifetime_earned": 140,
+            "lifetime_spent": 103,
+            "lifetime_purchased": 0,
+        }
+
+    async def get_history(self, slack_user_id, limit):
+        self.history_users.append((slack_user_id, limit))
+        return [{"delta": -4, "description": "Coworking booking"}]
+
+    async def list_rewards(self, slack_user_id):
+        self.reward_users.append(slack_user_id)
+        return [
+            {
+                "code": "STICKER",
+                "name": "Sticker",
+                "cost_points": 1,
+                "can_afford": True,
+                "user_balance": 37,
+            }
+        ]
+
+
+def _capture_private_delivery(monkeypatch, *, dm_ok=True, ephemeral_ok=True):
+    direct_messages = []
+    ephemeral_messages = []
+
+    def fake_send_dm(user_id, text, **kwargs):
+        direct_messages.append({"user": user_id, "text": text, **kwargs})
+        if isinstance(dm_ok, Exception):
+            raise dm_ok
+        return {"ok": dm_ok}
+
+    def fake_post_ephemeral(**kwargs):
+        ephemeral_messages.append(kwargs)
+        if isinstance(ephemeral_ok, Exception):
+            raise ephemeral_ok
+        return {"ok": ephemeral_ok}
+
+    monkeypatch.setattr(executor_module, "send_dm", fake_send_dm)
+    monkeypatch.setattr(executor_module, "post_ephemeral", fake_post_ephemeral)
+    return direct_messages, ephemeral_messages
+
+
+@pytest.mark.asyncio
+async def test_routed_balance_in_channel_uses_verified_actor_and_private_delivery(monkeypatch):
+    direct_messages, ephemeral_messages = _capture_private_delivery(monkeypatch)
+    client = PersonalPointsClient()
+
+    result = await SkillExecutor()._handle_points_action(
+        client=client,
+        action="balance",
+        params={"target_slack_id": "UFORGED"},
+        text="show <@UFORGED>'s balance",
+        user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert client.balance_users == ["UVERIFIED"]
+    assert result["message"] == ""
+    assert result["suppress_post"] is True
+    assert direct_messages[0]["user"] == "UVERIFIED"
+    assert "Current Balance:** 37 points" in direct_messages[0]["text"]
+    assert ephemeral_messages == [
+        {
+            "channel": "CPOINTS",
+            "user": "UVERIFIED",
+            "text": "I've sent your Roo Points summary privately.",
+            "thread_ts": "111.222",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_routed_balance_in_roo_dm_replies_without_opening_another_dm(monkeypatch):
+    direct_messages, ephemeral_messages = _capture_private_delivery(monkeypatch)
+
+    result = await SkillExecutor()._handle_points_action(
+        client=PersonalPointsClient(),
+        action="balance",
+        params={},
+        text="points",
+        user_id="UVERIFIED",
+        channel_id="DPRIVATE",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "Current Balance:** 37 points" in result["message"]
+    assert result.get("suppress_post") is None
+    assert result["data"]["delivery"] == "current_direct_message"
+    assert direct_messages == []
+    assert ephemeral_messages == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("dm_outcome", "ephemeral_outcome"),
+    [
+        (False, True),
+        (RuntimeError("dm unavailable"), RuntimeError("ephemeral unavailable")),
+    ],
+)
+async def test_balance_delivery_failures_never_fall_back_to_public_message(
+    monkeypatch,
+    dm_outcome,
+    ephemeral_outcome,
+):
+    _, ephemeral_messages = _capture_private_delivery(
+        monkeypatch,
+        dm_ok=dm_outcome,
+        ephemeral_ok=ephemeral_outcome,
+    )
+
+    result = await SkillExecutor()._handle_points_action(
+        client=PersonalPointsClient(),
+        action="balance",
+        params={},
+        text="points",
+        user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert result["message"] == ""
+    assert result["suppress_post"] is True
+    assert result["data"]["delivery_failed"] is True
+    if ephemeral_messages:
+        assert "DM Roo `points`" in ephemeral_messages[0]["text"]
+        assert "37" not in ephemeral_messages[0]["text"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("action", "private_fragment"),
+    [
+        ("history", "Coworking booking"),
+        ("list_rewards", "Your balance: **37 points**"),
+    ],
+)
+async def test_history_and_personalised_rewards_are_private(
+    monkeypatch,
+    action,
+    private_fragment,
+):
+    direct_messages, ephemeral_messages = _capture_private_delivery(monkeypatch)
+
+    result = await SkillExecutor()._handle_points_action(
+        client=PersonalPointsClient(),
+        action=action,
+        params={"limit": 5},
+        text=action,
+        user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert result["message"] == ""
+    assert result["suppress_post"] is True
+    assert private_fragment in direct_messages[0]["text"]
+    assert ephemeral_messages[0]["user"] == "UVERIFIED"
+
+
+@pytest.mark.asyncio
+async def test_fast_path_forwards_channel_context_and_preserves_private_result(monkeypatch):
+    agent = object.__new__(RooAgent)
+    calls = []
+
+    async def fake_execute_fast_points(user_id, action, **kwargs):
+        calls.append((user_id, action, kwargs))
+        return {
+            "message": "",
+            "skill_used": "mlai-points (fast)",
+            "data": {"action": action},
+            "suppress_post": True,
+        }
+
+    monkeypatch.setattr(agent, "_execute_fast_points", fake_execute_fast_points)
+
+    result = await agent._try_fast_path(
+        "points",
+        "UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+    )
+
+    assert calls == [
+        (
+            "UVERIFIED",
+            "balance",
+            {"channel_id": "CPOINTS", "thread_ts": "111.222"},
+        )
+    ]
+    assert result["suppress_post"] is True
+
+
+@pytest.mark.asyncio
+async def test_fast_executor_keeps_private_delivery_metadata(monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            captured["client_init"] = kwargs
+
+    class FakeSkill:
+        name = "mlai-points"
+
+        @staticmethod
+        def get_client_class(name):
+            assert name == "MLAIBackendClient"
+            return FakeClient
+
+    class FakeExecutor:
+        async def _handle_points_action(self, **kwargs):
+            captured["handler"] = kwargs
+            return {
+                "message": "",
+                "data": {"delivery": "direct_message"},
+                "suppress_post": True,
+            }
+
+    agent = object.__new__(RooAgent)
+    agent.skills = [FakeSkill()]
+    agent.skill_executor = FakeExecutor()
+    monkeypatch.setattr(
+        agent_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-key",
+            INTERNAL_API_KEY="internal-key",
+        ),
+    )
+
+    result = await agent._execute_fast_points(
+        "UVERIFIED",
+        "balance",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+    )
+
+    assert captured["handler"]["user_id"] == "UVERIFIED"
+    assert captured["handler"]["channel_id"] == "CPOINTS"
+    assert captured["handler"]["thread_ts"] == "111.222"
+    assert result["message"] == ""
+    assert result["suppress_post"] is True
+    assert result["data"] == {"delivery": "direct_message", "action": "balance"}
+
+
+@pytest.mark.asyncio
+async def test_balance_backend_failure_returns_no_personal_data(monkeypatch):
+    direct_messages, ephemeral_messages = _capture_private_delivery(monkeypatch)
+
+    class FailingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def get_balance(self, slack_user_id):
+            raise RuntimeError("balance=37 for UVERIFIED")
+
+    monkeypatch.setattr("roo.clients.mlai_backend.MLAIBackendClient", FailingClient)
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-key",
+            INTERNAL_API_KEY="internal-key",
+        ),
+    )
+
+    result = await SkillExecutor()._execute_mlai_points(
+        skill=SimpleNamespace(name="mlai-points"),
+        text="points",
+        params={"action": "balance"},
+        user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+    )
+
+    assert "trouble with the points system" in result
+    assert "37" not in result
+    assert "UVERIFIED" not in result
+    assert direct_messages == []
+    assert ephemeral_messages == []
+
+
+@pytest.mark.asyncio
+async def test_fast_balance_failure_does_not_return_raw_backend_error(monkeypatch):
+    class FailingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def get_balance(self, slack_user_id):
+            raise RuntimeError("balance=37 for UVERIFIED")
+
+    class FakeSkill:
+        name = "mlai-points"
+
+        @staticmethod
+        def get_client_class(name):
+            assert name == "MLAIBackendClient"
+            return FailingClient
+
+    agent = object.__new__(RooAgent)
+    agent.skills = [FakeSkill()]
+    agent.skill_executor = SkillExecutor()
+    monkeypatch.setattr(
+        agent_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-key",
+            INTERNAL_API_KEY="internal-key",
+        ),
+    )
+
+    result = await agent._execute_fast_points(
+        "UVERIFIED",
+        "balance",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+    )
+
+    assert result["data"] == {"error": "points_backend_unavailable"}
+    assert "37" not in result["message"]
+    assert "UVERIFIED" not in result["message"]
+
+
+class CoworkingClient:
+    def __init__(self, *, balance=9):
+        self.balance = balance
+
+    async def book_coworking(self, slack_user_id, booking_date, slack_channel_id=None):
+        return {
+            "points_cost": 4,
+            "monthly_update_discount_applied": True,
+        }
+
+    async def get_balance(self, slack_user_id):
+        return {"balance": self.balance}
+
+
+@pytest.mark.asyncio
+async def test_channel_coworking_confirmation_keeps_remaining_balance_in_member_dm(
+    monkeypatch,
+    tmp_path,
+):
+    direct_messages, _ = _capture_private_delivery(monkeypatch)
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "coworking.db")
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+
+    result = await SkillExecutor()._book_coworking_with_intent(
+        client=CoworkingClient(balance=9),
+        target_user_id="UMEMBER",
+        requested_by_user_id="UMEMBER",
+        booking_date="2026-08-14",
+        text="book coworking tomorrow",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+        admin_checkin=False,
+    )
+
+    assert "Booked you in" in result["message"]
+    assert "Balance remaining" not in result["message"]
+    assert direct_messages[0]["user"] == "UMEMBER"
+    assert "Balance remaining: 9 points" in direct_messages[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_dm_coworking_confirmation_returns_remaining_balance_directly(
+    monkeypatch,
+    tmp_path,
+):
+    direct_messages, _ = _capture_private_delivery(monkeypatch)
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "coworking.db")
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+
+    result = await SkillExecutor()._book_coworking_with_intent(
+        client=CoworkingClient(balance=9),
+        target_user_id="UMEMBER",
+        requested_by_user_id="UMEMBER",
+        booking_date="2026-08-14",
+        text="book coworking tomorrow",
+        channel_id="DPRIVATE",
+        thread_ts="111.222",
+        admin_checkin=False,
+    )
+
+    assert "Balance remaining: 9 points" in result["message"]
+    assert direct_messages == []
+
+
+@pytest.mark.asyncio
+async def test_admin_coworking_confirmation_never_exposes_target_balance(
+    monkeypatch,
+    tmp_path,
+):
+    direct_messages, _ = _capture_private_delivery(monkeypatch)
+    store = coworking_module.CoworkingBookingIntentStore(tmp_path / "coworking.db")
+    monkeypatch.setattr(executor_module, "get_coworking_intent_store", lambda: store)
+
+    result = await SkillExecutor()._book_coworking_with_intent(
+        client=CoworkingClient(balance=13),
+        target_user_id="UTARGET",
+        requested_by_user_id="UADMIN",
+        booking_date="2026-08-14",
+        text="check <@UTARGET> in tomorrow",
+        channel_id="CADMIN",
+        thread_ts="111.222",
+        admin_checkin=True,
+    )
+
+    assert "Checked <@UTARGET> in" in result["message"]
+    assert "13" not in result["message"]
+    assert "Their balance" not in result["message"]
+    assert direct_messages[0]["user"] == "UTARGET"
+    assert "Balance remaining: 13 points" in direct_messages[0]["text"]
+
+
+class AwardClient:
+    async def get_admin_details(self, slack_user_id):
+        return {"slack_user_id": slack_user_id, "role": "admin"}
+
+    async def get_admin_allowance(self, slack_user_id):
+        return {"remaining": 100, "allowance": 100}
+
+    async def get_user_by_slack_id(self, slack_user_id):
+        return "user-id"
+
+    async def award_points(self, requester_slack_id, target_slack_id, points, reason):
+        return {"points_awarded": points, "new_balance": 88}
+
+
+@pytest.mark.asyncio
+async def test_manual_award_keeps_resulting_balance_out_of_public_confirmation(monkeypatch):
+    direct_messages, _ = _capture_private_delivery(monkeypatch)
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "UROO")
+
+    result = await SkillExecutor()._handle_points_action(
+        client=AwardClient(),
+        action="award_points",
+        params={"points": 5, "reason": "helping at the event"},
+        text="award <@UTARGET> 5 points for helping at the event",
+        user_id="UADMIN",
+        channel_id="CADMIN",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "Awarded 5 points to <@UTARGET>" in result
+    assert "88" not in result
+    assert "new balance" not in result.lower()
+    assert direct_messages[0]["user"] == "UTARGET"
+    assert "new balance is 88 points" in direct_messages[0]["text"]

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -26,9 +26,9 @@ routing:
     - {text: "how many people came to our last event?", instead: luma-events}
 actions:
   - name: balance
-    description: Show the user's current points balance.
+    description: Privately show the user their current points balance.
   - name: history
-    description: Show recent points transactions.
+    description: Privately show the user their recent points transactions.
     params:
       days: {type: integer, description: "How many days back (default 7)."}
       limit: {type: integer, description: "Max entries (default 10)."}
@@ -352,6 +352,14 @@ so fresh buttons can be created safely in that conversation.
 - Be encouraging about earning points
 - Keep responses concise but informative
 - Use formatting (bold, lists) for clarity
+- Treat balances, lifetime totals, transaction history, affordability, and resulting
+  balances as personal data. In a shared channel or thread, send those details to
+  the verified requester by DM and use only a private ephemeral acknowledgement.
+- In a Roo DM, return personal points details directly without opening another DM.
+- Public booking and award confirmations may state the action and points charged or
+  awarded, but must not include anyone's remaining or resulting balance.
+- If private delivery fails, never fall back to posting personal points data publicly;
+  privately tell the requester to DM Roo `points` instead.
 
 ## Example Responses
 


### PR DESCRIPTION
## Summary

- Deliver balance summaries, transaction history, and personalised rewards privately.
- In shared channels and threads, DM the verified Slack requester and send only an ephemeral acknowledgement.
- In Roo DMs, reply directly without opening another conversation.
- Keep remaining/resulting balances out of public coworking, approval, award, boost, link-love, and Content Factory messages.
- Redact numeric balance details from public backend errors and fail closed when private delivery is unavailable.
- Reuse the same delivery path for exact fast-path and normally routed points commands.

No backend or schema changes are required.

## User impact

`@Roo points`, `@Roo balance`, points history, and personalised rewards no longer expose personal totals in a channel or thread. Public action confirmations may still say what happened and how many points were charged or awarded, but not the member's resulting balance.

## Validation

- Privacy and affected-flow regression suite: **70 passed**
- Production security/admin workflow gate: **420 passed**
- Routing evaluation: **237 cases, no baseline regressions**
- `python -m compileall -q roo bridge`: passed
- Full branch suite: **786 passed, 22 failed**
- Untouched `origin/main`: **769 passed, 22 failed**

The 22 full-suite failures are identical on this branch and current `main`: 17 stale Content Factory test settings, 2 stale jobs scheduler settings, 2 stale coworking expectations, and 1 stale model-version assertion. This branch adds no new full-suite failures.