### PR TITLE
feat(points): add opt-in public Roo Points flex

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,8 @@ jobs:
             roo/tests/test_slack_security.py \
             roo/tests/test_backend_identity.py \
             roo/tests/test_mlai_backend_client.py \
+            roo/tests/test_private_points_delivery.py \
+            roo/tests/test_points_flex.py \
             roo/tests/test_admin_brain.py \
             roo/tests/test_admin_brain_interactions.py \
             roo/tests/test_admin_dispatch.py \

--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -818,11 +818,15 @@ class RooAgent:
         """
         text_lower = text.lower().strip()
 
-        # 1. Balance Check: "points", "balance", "my points"
+        # 1. Explicit opt-in public contribution total.
+        if re.match(r'^(?:flex my points|flex points|points flex)$', text_lower):
+            return "flex_points"
+
+        # 2. Balance Check: "points", "balance", "my points"
         if re.match(r'^(?:points|balance|my points)$', text_lower):
             return "balance"
 
-        # 2. Earn/Tasks shortcuts
+        # 3. Earn/Tasks shortcuts
         if re.match(
             r'^(?:points\s+earn|earn\s+points|ways\s+to\s+earn|'
             r'tasks(?:\s+(?:all|mine|review|open))?|'
@@ -831,15 +835,15 @@ class RooAgent:
         ):
             return "list_tasks"
 
-        # 3. Rewards: "points rewards", "rewards"
+        # 4. Rewards: "points rewards", "rewards"
         if re.match(r'^(?:points\s+rewards|rewards)$', text_lower):
             return "list_rewards"
 
-        # 4. Coworking Book Today: "coworking book today"
+        # 5. Coworking Book Today: "coworking book today"
         if re.match(r'^coworking\s+book\s+today$', text_lower):
             return "book_coworking"
 
-        # 5. Coworking Cancel: "coworking cancel" (assumes today/upcoming)
+        # 6. Coworking Cancel: "coworking cancel" (assumes today/upcoming)
         if re.match(r'^coworking\s+cancel$', text_lower):
             return "cancel_coworking"
 
@@ -860,6 +864,14 @@ class RooAgent:
         action = self._match_fast_path(text)
         if action is None:
             return None
+
+        if action == "flex_points":
+            return await self._execute_fast_points(
+                user_id,
+                "flex_points",
+                channel_id=channel_id,
+                thread_ts=thread_ts,
+            )
 
         if action == "balance":
             return await self._execute_fast_points(
@@ -926,7 +938,19 @@ class RooAgent:
                 internal_api_key=settings.INTERNAL_API_KEY or settings.ROO_API_KEY or settings.MLAI_API_KEY,
             )
             
-            if action == "balance":
+            if action == "flex_points":
+                msg = await self.skill_executor._handle_points_action(
+                    client=client,
+                    action="flex_points",
+                    params={},
+                    text="flex my points",
+                    user_id=user_id,
+                    channel_id=kwargs.get("channel_id"),
+                    thread_ts=kwargs.get("thread_ts"),
+                    skill=skill,
+                )
+
+            elif action == "balance":
                 msg = await self.skill_executor._handle_points_action(
                     client=client,
                     action="balance",

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -50,6 +50,14 @@ from .points_request_approval import (
     get_remembered_points_request_summary,
     remember_points_request_summary,
 )
+from .points_flex import (
+    POINTS_FLEX_ACTION_ID,
+    PointsFlexTokenError,
+    format_points_flex_public_message,
+    get_points_flex_store,
+    parse_lifetime_earned,
+    verify_points_flex_confirmation,
+)
 from .slack_client import (
     get_bot_user_id,
     get_message,
@@ -707,6 +715,182 @@ def _content_factory_action_denied_response(text: str) -> JSONResponse:
             "text": text,
         },
     )
+
+
+def _points_flex_action_response(
+    text: str,
+    *,
+    replace_original: bool = True,
+) -> JSONResponse:
+    """Replace the private confirmation card with a private status message."""
+
+    return JSONResponse(
+        status_code=200,
+        content={
+            "response_type": "ephemeral",
+            "replace_original": replace_original,
+            "text": text,
+        },
+    )
+
+
+async def _handle_points_flex_confirmation_action(
+    *,
+    settings: Settings,
+    action_value: str,
+    verified_user_id: Optional[str],
+    verified_channel_id: Optional[str],
+) -> JSONResponse:
+    """Revalidate consent and publish one lifetime-earned total at most once."""
+
+    try:
+        confirmation = verify_points_flex_confirmation(
+            action_value,
+            signing_secret=settings.SLACK_SIGNING_SECRET,
+        )
+    except PointsFlexTokenError as exc:
+        if exc.code == "expired_token":
+            return _points_flex_action_response(
+                "That sharing confirmation has expired. Run `@Roo flex my points` again."
+            )
+        return _points_flex_action_response(
+            "I couldn't verify that sharing confirmation. Run `@Roo flex my points` again."
+        )
+
+    if str(verified_user_id or "") != confirmation.slack_user_id:
+        return _points_flex_action_response(
+            "Only the member who requested this flex can confirm it.",
+            replace_original=False,
+        )
+    if str(verified_channel_id or "") != confirmation.channel_id:
+        return _points_flex_action_response(
+            "This confirmation only works in the channel where it was requested.",
+            replace_original=False,
+        )
+
+    store = get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+    owner = f"roo-flex-{uuid4()}"
+    try:
+        claim = store.claim(confirmation, owner=owner)
+    except Exception as exc:
+        print(
+            "Points flex confirmation state failed "
+            f"exc_type={exc.__class__.__name__}"
+        )
+        return _points_flex_action_response(
+            "I couldn't safely confirm that share, so nothing was posted. Try again in a moment.",
+            replace_original=False,
+        )
+
+    claim_state = claim.get("state")
+    if claim_state == "shared":
+        return _points_flex_action_response("Your Roo Points flex was already shared.")
+    if claim_state == "processing":
+        return _points_flex_action_response(
+            "Your Roo Points flex is already being shared.",
+            replace_original=False,
+        )
+    if claim_state == "expired":
+        return _points_flex_action_response(
+            "That sharing confirmation has expired. Run `@Roo flex my points` again."
+        )
+    if claim_state != "claimed":
+        return _points_flex_action_response(
+            "I couldn't verify that sharing confirmation, so nothing was posted."
+        )
+
+    from .clients.mlai_backend import MLAIBackendClient
+
+    try:
+        client = MLAIBackendClient(
+            base_url=settings.MLAI_BACKEND_URL,
+            api_key=settings.ROO_API_KEY or settings.MLAI_API_KEY,
+            internal_api_key=(
+                settings.INTERNAL_API_KEY
+                or settings.ROO_API_KEY
+                or settings.MLAI_API_KEY
+            ),
+        )
+        balance_data = await client.get_balance(confirmation.slack_user_id)
+        lifetime_earned = parse_lifetime_earned(balance_data)
+    except Exception as exc:
+        print(
+            "Points flex total refresh failed "
+            f"exc_type={exc.__class__.__name__}"
+        )
+        try:
+            store.release(
+                confirmation.request_id,
+                owner=owner,
+                error_code="backend_unavailable",
+            )
+        except Exception as release_exc:
+            print(
+                "Points flex claim release failed "
+                f"exc_type={release_exc.__class__.__name__}"
+            )
+        return _points_flex_action_response(
+            "I couldn't refresh your contribution total, so nothing was posted. Try the button again in a moment.",
+            replace_original=False,
+        )
+
+    public_message = format_points_flex_public_message(
+        slack_user_id=confirmation.slack_user_id,
+        lifetime_earned=lifetime_earned,
+    )
+    try:
+        post_response = post_message(
+            channel=confirmation.channel_id,
+            text=public_message,
+            client_msg_id=confirmation.request_id,
+        )
+        post_succeeded = bool(
+            post_response
+            and (
+                post_response.get("ok")
+                or post_response.get("error") == "duplicate_message"
+            )
+        )
+    except Exception as exc:
+        print(
+            "Points flex public post failed "
+            f"exc_type={exc.__class__.__name__}"
+        )
+        post_response = None
+        post_succeeded = False
+
+    if not post_succeeded:
+        try:
+            store.release(
+                confirmation.request_id,
+                owner=owner,
+                error_code="slack_post_failed",
+            )
+        except Exception as release_exc:
+            print(
+                "Points flex claim release failed "
+                f"exc_type={release_exc.__class__.__name__}"
+            )
+        return _points_flex_action_response(
+            "I couldn't post your Roo Points flex, so nothing was shared. Try the button again.",
+            replace_original=False,
+        )
+
+    try:
+        store.mark_shared(
+            confirmation.request_id,
+            owner=owner,
+            message_ts=str((post_response or {}).get("ts") or "") or None,
+        )
+    except Exception as exc:
+        # The deterministic Slack client_msg_id still protects a retry from
+        # creating another message if state persistence fails after posting.
+        print(
+            "Points flex shared-state persistence failed "
+            f"exc_type={exc.__class__.__name__}"
+        )
+
+    return _points_flex_action_response("Shared your lifetime-earned Roo Points publicly.")
 
 
 @dataclass(frozen=True)
@@ -4719,6 +4903,14 @@ async def slack_actions(
     thread_ts = message.get("thread_ts") or message.get("ts")
     
     print(f"🖱️ Action: {action_id} from {user_id}")
+
+    if action_id == POINTS_FLEX_ACTION_ID:
+        return await _handle_points_flex_confirmation_action(
+            settings=settings,
+            action_value=str(actions[0].get("value") or ""),
+            verified_user_id=user_id,
+            verified_channel_id=channel_id,
+        )
 
     if unified_admin and action_id == ADMIN_BRAIN_INCORRECT_ACTION:
         _open_admin_brain_correction_modal(

--- a/roo-standalone/roo/points_flex.py
+++ b/roo-standalone/roo/points_flex.py
@@ -1,0 +1,467 @@
+"""Explicit, replay-safe consent for public Roo Points flex posts."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import re
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+
+POINTS_FLEX_ACTION_ID = "points_flex_confirm"
+POINTS_FLEX_CONFIRMATION_TTL_SECONDS = 10 * 60
+POINTS_FLEX_PROCESSING_LEASE_SECONDS = 30
+
+_SIGNING_CONTEXT = b"roo-points-flex-v1"
+_SLACK_USER_ID = re.compile(r"^[UW][A-Z0-9]+$")
+_SLACK_CHANNEL_ID = re.compile(r"^[CG][A-Z0-9]+$")
+
+
+class PointsFlexTokenError(ValueError):
+    """Raised when a flex confirmation token cannot be trusted."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class PointsFlexConfirmation:
+    request_id: str
+    slack_user_id: str
+    channel_id: str
+    issued_at: int
+    expires_at: int
+
+
+def _urlsafe_encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _urlsafe_decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    try:
+        return base64.b64decode(
+            value + padding,
+            altchars=b"-_",
+            validate=True,
+        )
+    except (ValueError, TypeError) as exc:
+        raise PointsFlexTokenError("invalid_token") from exc
+
+
+def _signing_key(signing_secret: str) -> bytes:
+    secret = str(signing_secret or "").encode("utf-8")
+    if not secret:
+        raise PointsFlexTokenError("signing_unavailable")
+    return hmac.new(secret, _SIGNING_CONTEXT, hashlib.sha256).digest()
+
+
+def issue_points_flex_confirmation(
+    *,
+    signing_secret: str,
+    slack_user_id: str,
+    channel_id: str,
+    now: Optional[float] = None,
+    ttl_seconds: int = POINTS_FLEX_CONFIRMATION_TTL_SECONDS,
+) -> tuple[str, PointsFlexConfirmation]:
+    """Create a signed button value bound to one member and one channel."""
+
+    cleaned_user_id = str(slack_user_id or "").strip()
+    cleaned_channel_id = str(channel_id or "").strip()
+    if not _SLACK_USER_ID.fullmatch(cleaned_user_id):
+        raise PointsFlexTokenError("invalid_user")
+    if not _SLACK_CHANNEL_ID.fullmatch(cleaned_channel_id):
+        raise PointsFlexTokenError("invalid_channel")
+    if not 1 <= int(ttl_seconds) <= POINTS_FLEX_CONFIRMATION_TTL_SECONDS:
+        raise PointsFlexTokenError("invalid_expiry")
+
+    issued_at = int(time.time() if now is None else now)
+    confirmation = PointsFlexConfirmation(
+        request_id=str(uuid4()),
+        slack_user_id=cleaned_user_id,
+        channel_id=cleaned_channel_id,
+        issued_at=issued_at,
+        expires_at=issued_at + int(ttl_seconds),
+    )
+    payload = {
+        "c": confirmation.channel_id,
+        "exp": confirmation.expires_at,
+        "iat": confirmation.issued_at,
+        "rid": confirmation.request_id,
+        "u": confirmation.slack_user_id,
+        "v": 1,
+    }
+    encoded_payload = _urlsafe_encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    signature = hmac.new(
+        _signing_key(signing_secret),
+        encoded_payload.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return f"{encoded_payload}.{_urlsafe_encode(signature)}", confirmation
+
+
+def verify_points_flex_confirmation(
+    token: str,
+    *,
+    signing_secret: str,
+    now: Optional[float] = None,
+) -> PointsFlexConfirmation:
+    """Verify and decode a flex confirmation token without trusting its fields."""
+
+    try:
+        encoded_payload, encoded_signature = str(token or "").split(".", 1)
+    except ValueError as exc:
+        raise PointsFlexTokenError("invalid_token") from exc
+    if not encoded_payload or not encoded_signature:
+        raise PointsFlexTokenError("invalid_token")
+
+    actual_signature = _urlsafe_decode(encoded_signature)
+    expected_signature = hmac.new(
+        _signing_key(signing_secret),
+        encoded_payload.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    if not hmac.compare_digest(actual_signature, expected_signature):
+        raise PointsFlexTokenError("invalid_token")
+
+    try:
+        payload = json.loads(_urlsafe_decode(encoded_payload).decode("utf-8"))
+        request_id = str(UUID(str(payload["rid"])))
+        slack_user_id = str(payload["u"])
+        channel_id = str(payload["c"])
+        issued_at = int(payload["iat"])
+        expires_at = int(payload["exp"])
+        version = int(payload["v"])
+    except (KeyError, TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PointsFlexTokenError("invalid_token") from exc
+
+    if version != 1:
+        raise PointsFlexTokenError("invalid_token")
+    if not _SLACK_USER_ID.fullmatch(slack_user_id):
+        raise PointsFlexTokenError("invalid_token")
+    if not _SLACK_CHANNEL_ID.fullmatch(channel_id):
+        raise PointsFlexTokenError("invalid_token")
+    if not 1 <= expires_at - issued_at <= POINTS_FLEX_CONFIRMATION_TTL_SECONDS:
+        raise PointsFlexTokenError("invalid_token")
+
+    current_time = int(time.time() if now is None else now)
+    if issued_at > current_time + 30:
+        raise PointsFlexTokenError("invalid_token")
+    if current_time >= expires_at:
+        raise PointsFlexTokenError("expired_token")
+
+    return PointsFlexConfirmation(
+        request_id=request_id,
+        slack_user_id=slack_user_id,
+        channel_id=channel_id,
+        issued_at=issued_at,
+        expires_at=expires_at,
+    )
+
+
+def parse_lifetime_earned(payload: dict[str, Any]) -> int:
+    """Return a trusted non-negative integer from the backend balance payload."""
+
+    value = payload.get("lifetime_earned")
+    if isinstance(value, bool):
+        raise ValueError("invalid lifetime_earned")
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("invalid lifetime_earned") from exc
+    if parsed < 0 or str(value).strip() not in {str(parsed), f"+{parsed}"}:
+        raise ValueError("invalid lifetime_earned")
+    return parsed
+
+
+def build_points_flex_preview_blocks(*, lifetime_earned: int, token: str) -> list[dict[str, Any]]:
+    """Build the private confirmation card shown before any public post."""
+
+    return [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    "Share your contribution total publicly in this channel?\n\n"
+                    f"You have earned *{lifetime_earned} Roo Points* through MLAI contributions."
+                ),
+            },
+        },
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": (
+                        "Only your lifetime-earned total will be shared. "
+                        "Your balance, purchases, spending, and history stay private. "
+                        "This confirmation expires in 10 minutes."
+                    ),
+                }
+            ],
+        },
+        {
+            "type": "actions",
+            "elements": [
+                {
+                    "type": "button",
+                    "action_id": POINTS_FLEX_ACTION_ID,
+                    "style": "primary",
+                    "text": {"type": "plain_text", "text": "Share publicly"},
+                    "value": token,
+                }
+            ],
+        },
+    ]
+
+
+def format_points_flex_public_message(*, slack_user_id: str, lifetime_earned: int) -> str:
+    return (
+        f"<@{slack_user_id}> has earned *{lifetime_earned} Roo Points* "
+        "through MLAI contributions."
+    )
+
+
+class PointsFlexShareStore:
+    """SQLite state machine preventing duplicate flex posts across workers."""
+
+    def __init__(self, database_path: str | Path):
+        self.database_path = Path(database_path)
+        self._initialised = False
+        self._initialise_lock = threading.Lock()
+
+    def _connect(self) -> sqlite3.Connection:
+        self.database_path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(
+            str(self.database_path),
+            timeout=30,
+            isolation_level=None,
+        )
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA busy_timeout=30000")
+        return connection
+
+    def _initialise(self) -> None:
+        if self._initialised:
+            return
+        with self._initialise_lock:
+            if self._initialised:
+                return
+            with self._connect() as connection:
+                connection.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS points_flex_shares (
+                        request_id TEXT PRIMARY KEY,
+                        slack_user_id TEXT NOT NULL,
+                        channel_id TEXT NOT NULL,
+                        expires_at REAL NOT NULL,
+                        status TEXT NOT NULL,
+                        locked_by TEXT,
+                        locked_until REAL,
+                        message_ts TEXT,
+                        last_error_code TEXT,
+                        created_at REAL NOT NULL,
+                        updated_at REAL NOT NULL,
+                        shared_at REAL
+                    )
+                    """
+                )
+                connection.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS points_flex_shares_expiry_idx
+                    ON points_flex_shares (expires_at)
+                    """
+                )
+            self._initialised = True
+
+    @staticmethod
+    def _row(row: sqlite3.Row | None) -> Optional[dict[str, Any]]:
+        return dict(row) if row is not None else None
+
+    def claim(
+        self,
+        confirmation: PointsFlexConfirmation,
+        *,
+        owner: Optional[str] = None,
+        now: Optional[float] = None,
+        lease_seconds: int = POINTS_FLEX_PROCESSING_LEASE_SECONDS,
+    ) -> dict[str, Any]:
+        """Atomically claim a confirmation or report its existing state."""
+
+        self._initialise()
+        current_time = time.time() if now is None else float(now)
+        owner = str(owner or f"roo-flex-{uuid4()}")
+        locked_until = current_time + int(lease_seconds)
+
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                """
+                DELETE FROM points_flex_shares
+                WHERE updated_at < ?
+                  AND (
+                    (status != 'shared' AND expires_at <= ?)
+                    OR (status = 'shared' AND shared_at < ?)
+                  )
+                """,
+                (current_time - 86400, current_time, current_time - 90 * 86400),
+            )
+            connection.execute(
+                """
+                INSERT OR IGNORE INTO points_flex_shares (
+                    request_id, slack_user_id, channel_id, expires_at, status,
+                    created_at, updated_at
+                ) VALUES (?, ?, ?, ?, 'pending', ?, ?)
+                """,
+                (
+                    confirmation.request_id,
+                    confirmation.slack_user_id,
+                    confirmation.channel_id,
+                    confirmation.expires_at,
+                    current_time,
+                    current_time,
+                ),
+            )
+            row = connection.execute(
+                "SELECT * FROM points_flex_shares WHERE request_id = ?",
+                (confirmation.request_id,),
+            ).fetchone()
+            if row is None:
+                connection.rollback()
+                raise RuntimeError("points flex share state was not created")
+
+            stored = dict(row)
+            if (
+                stored["slack_user_id"] != confirmation.slack_user_id
+                or stored["channel_id"] != confirmation.channel_id
+                or int(stored["expires_at"]) != confirmation.expires_at
+            ):
+                connection.commit()
+                return {"state": "conflict", "record": stored}
+            if stored["status"] == "shared":
+                connection.commit()
+                return {"state": "shared", "record": stored}
+            if current_time >= confirmation.expires_at:
+                connection.commit()
+                return {"state": "expired", "record": stored}
+            # A process crash could happen after Slack accepted the public post
+            # but before mark_shared persisted. Never reclaim that ambiguous
+            # state: the member can start a fresh confirmation instead.
+            if stored["status"] == "processing":
+                connection.commit()
+                return {"state": "processing", "record": stored}
+
+            cursor = connection.execute(
+                """
+                UPDATE points_flex_shares
+                SET status = 'processing', locked_by = ?, locked_until = ?,
+                    last_error_code = NULL, updated_at = ?
+                WHERE request_id = ?
+                  AND status = 'pending'
+                """,
+                (
+                    owner,
+                    locked_until,
+                    current_time,
+                    confirmation.request_id,
+                ),
+            )
+            if cursor.rowcount != 1:
+                connection.commit()
+                return {"state": "processing", "record": stored}
+            claimed = connection.execute(
+                "SELECT * FROM points_flex_shares WHERE request_id = ?",
+                (confirmation.request_id,),
+            ).fetchone()
+            connection.commit()
+            return {"state": "claimed", "record": dict(claimed)}
+
+    def mark_shared(
+        self,
+        request_id: str,
+        *,
+        owner: str,
+        message_ts: Optional[str],
+        now: Optional[float] = None,
+    ) -> dict[str, Any]:
+        self._initialise()
+        current_time = time.time() if now is None else float(now)
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            cursor = connection.execute(
+                """
+                UPDATE points_flex_shares
+                SET status = 'shared', locked_by = NULL, locked_until = NULL,
+                    message_ts = ?, last_error_code = NULL, shared_at = ?, updated_at = ?
+                WHERE request_id = ? AND status = 'processing' AND locked_by = ?
+                """,
+                (message_ts, current_time, current_time, request_id, owner),
+            )
+            row = connection.execute(
+                "SELECT * FROM points_flex_shares WHERE request_id = ?",
+                (request_id,),
+            ).fetchone()
+            connection.commit()
+            if cursor.rowcount != 1 and (row is None or row["status"] != "shared"):
+                raise RuntimeError("points flex share claim was lost")
+            return dict(row)
+
+    def release(
+        self,
+        request_id: str,
+        *,
+        owner: str,
+        error_code: str,
+        now: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Release a failed claim so the same unexpired button can be retried."""
+
+        self._initialise()
+        current_time = time.time() if now is None else float(now)
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                """
+                UPDATE points_flex_shares
+                SET status = 'pending', locked_by = NULL, locked_until = NULL,
+                    last_error_code = ?, updated_at = ?
+                WHERE request_id = ? AND status = 'processing' AND locked_by = ?
+                """,
+                (str(error_code)[:64], current_time, request_id, owner),
+            )
+            row = connection.execute(
+                "SELECT * FROM points_flex_shares WHERE request_id = ?",
+                (request_id,),
+            ).fetchone()
+            connection.commit()
+            if row is None:
+                raise RuntimeError("points flex share state is missing")
+            return dict(row)
+
+    def get(self, request_id: str) -> Optional[dict[str, Any]]:
+        self._initialise()
+        with self._connect() as connection:
+            return self._row(
+                connection.execute(
+                    "SELECT * FROM points_flex_shares WHERE request_id = ?",
+                    (str(request_id),),
+                ).fetchone()
+            )
+
+
+@lru_cache(maxsize=8)
+def get_points_flex_store(database_path: str) -> PointsFlexShareStore:
+    return PointsFlexShareStore(database_path)

--- a/roo-standalone/roo/routing_eval/cases/blessed_regressions.yaml
+++ b/roo-standalone/roo/routing_eval/cases/blessed_regressions.yaml
@@ -19,6 +19,10 @@
   text: "my points"
   expect: {skill: mlai-points, action: balance}
   tags: [blessed, fast-path]
+- id: fast-flex-my-points
+  text: "flex my points"
+  expect: {skill: mlai-points, action: flex_points}
+  tags: [blessed, fast-path]
 - id: fast-tasks
   text: "tasks"
   expect: {skill: mlai-points, action: list_tasks}

--- a/roo-standalone/roo/routing_eval/cases/paraphrases.yaml
+++ b/roo-standalone/roo/routing_eval/cases/paraphrases.yaml
@@ -111,6 +111,14 @@
   text: "how many points do I have right now?"
   expect: {skill: mlai-points, action: balance}
   tags: [paraphrase]
+- id: para-points-flex-earned
+  text: "share my earned Roo Points publicly"
+  expect: {skill: mlai-points, action: flex_points}
+  tags: [paraphrase, points-flex]
+- id: para-points-flex-contributions
+  text: "let me flex my Roo contribution total in this channel"
+  expect: {skill: mlai-points, action: flex_points}
+  tags: [paraphrase, points-flex]
 - id: para-points-spend-on
   text: "what can I spend my roo points on?"
   expect: {skill: mlai-points}

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -65,6 +65,11 @@ from ..points_request_approval import (
     build_points_request_record,
     remember_points_request_summary,
 )
+from ..points_flex import (
+    build_points_flex_preview_blocks,
+    issue_points_flex_confirmation,
+    parse_lifetime_earned,
+)
 from ..slack_client import (
     get_channel_id,
     get_channel_name,
@@ -11937,6 +11942,111 @@ Chunk {index} source: {label}
                 action="balance",
                 private_ack="I've sent your Roo Points summary privately.",
             )
+
+        elif action == "flex_points":
+            if not channel_id or str(channel_id).startswith("D"):
+                return (
+                    "Run `@Roo flex my points` in the shared channel where you "
+                    "want Roo to post your lifetime-earned contribution total."
+                )
+
+            if not str(channel_id).startswith(("C", "G")):
+                return {
+                    "message": "",
+                    "suppress_post": True,
+                    "data": {
+                        "action": "flex_points",
+                        "preview_delivered": False,
+                        "invalid_channel": True,
+                    },
+                }
+
+            from ..slack_client import get_bot_user_id
+
+            try:
+                bot_user_id = get_bot_user_id()
+            except Exception:
+                bot_user_id = None
+            target_mentions = [
+                mentioned_user_id
+                for mentioned_user_id in re.findall(r"<@([A-Z0-9]+)>", text)
+                if mentioned_user_id != bot_user_id
+            ]
+            if target_mentions:
+                delivered = self._post_private_points_ack(
+                    channel_id=channel_id,
+                    requester_user_id=user_id,
+                    thread_ts=thread_ts,
+                    text=(
+                        "You can only flex your own lifetime-earned Roo Points. "
+                        "Use `@Roo flex my points` without tagging another member."
+                    ),
+                    action="flex_points",
+                )
+                return {
+                    "message": "",
+                    "suppress_post": True,
+                    "data": {
+                        "action": "flex_points",
+                        "preview_delivered": False,
+                        "target_rejected": True,
+                        "ephemeral_delivered": delivered,
+                    },
+                }
+
+            data = await client.get_balance(user_id)
+            lifetime_earned = parse_lifetime_earned(data)
+            settings = get_settings()
+            token, confirmation = issue_points_flex_confirmation(
+                signing_secret=settings.SLACK_SIGNING_SECRET,
+                slack_user_id=user_id,
+                channel_id=channel_id,
+            )
+            preview_text = (
+                "Confirm whether to share your lifetime-earned Roo Points "
+                "publicly in this channel."
+            )
+            try:
+                response = post_ephemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=preview_text,
+                    thread_ts=thread_ts,
+                    blocks=build_points_flex_preview_blocks(
+                        lifetime_earned=lifetime_earned,
+                        token=token,
+                    ),
+                )
+                preview_delivered = bool(response and response.get("ok"))
+            except Exception as exc:
+                print(
+                    "Points flex preview delivery failed "
+                    f"exc_type={exc.__class__.__name__}"
+                )
+                preview_delivered = False
+
+            if not preview_delivered:
+                try:
+                    send_dm(
+                        user_id,
+                        "I couldn't show the public sharing confirmation in that "
+                        "channel. Try `@Roo flex my points` there again in a moment.",
+                    )
+                except Exception as exc:
+                    print(
+                        "Points flex preview fallback failed "
+                        f"exc_type={exc.__class__.__name__}"
+                    )
+
+            return {
+                "message": "",
+                "suppress_post": True,
+                "data": {
+                    "action": "flex_points",
+                    "preview_delivered": preview_delivered,
+                    "confirmation_request_id": confirmation.request_id,
+                },
+            }
         
         elif action == "history":
             limit = params.get("limit", 10)
@@ -11982,7 +12092,6 @@ Chunk {index} source: {label}
                 return "What are you requesting the points for? Try `request 5 points for helping at the event`."
 
             from ..slack_client import get_bot_user_id
-            import re
 
             try:
                 bot_id = get_bot_user_id()
@@ -12164,7 +12273,6 @@ Chunk {index} source: {label}
             
             if not submission_text:
                 # Extract text after the task ID
-                import re
                 match = re.search(r'(?:task\s+)?(?:ROO-\d+|#?\d+)\s+(.+)', text, re.IGNORECASE)
                 if match:
                     submission_text = match.group(1)
@@ -12368,7 +12476,6 @@ Chunk {index} source: {label}
                     booking_date = (today + timedelta(days=1)).isoformat()
             
             if not booking_date and not booking_id:
-                import re
                 match = re.search(r'(\d{4}-\d{2}-\d{2})', text)
                 if match:
                     booking_date = match.group(1)
@@ -12403,7 +12510,6 @@ Chunk {index} source: {label}
             quantity = params.get("quantity", 1)
             
             if not reward_code:
-                import re
                 match = re.search(r'request\s+(\w+)', text, re.IGNORECASE)
                 if match:
                     reward_code = match.group(1).upper()
@@ -12762,7 +12868,6 @@ Chunk {index} source: {label}
             
             # Get Roo's bot ID to filter it from target users
             # Extract ALL user mentions from the text (excluding Roo)
-            import re
             all_mentions = re.findall(r'<@([A-Z0-9]+)>', text)
             target_slack_ids = [uid for uid in all_mentions if uid != bot_id]
             

--- a/roo-standalone/roo/tests/test_points_flex.py
+++ b/roo-standalone/roo/tests/test_points_flex.py
@@ -1,0 +1,661 @@
+import json
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+
+os.environ.setdefault("SLACK_BOT_TOKEN", "xoxb-points-flex-test")
+os.environ.setdefault("SLACK_SIGNING_SECRET", "points-flex-signing-test")
+os.environ.setdefault("OPENAI_API_KEY", "points-flex-openai-test")
+
+from roo import agent as agent_module
+from roo import main as main_module
+from roo import points_flex as flex_module
+from roo.agent import RooAgent
+from roo.points_flex import (
+    POINTS_FLEX_ACTION_ID,
+    PointsFlexShareStore,
+    PointsFlexTokenError,
+    issue_points_flex_confirmation,
+    parse_lifetime_earned,
+    verify_points_flex_confirmation,
+)
+from roo.skills import executor as executor_module
+from roo.skills.executor import SkillExecutor
+from roo.slack_security import SlackRequestReceiptStore
+
+
+SIGNING_SECRET = "points-flex-test-secret"
+
+
+@pytest.fixture(autouse=True)
+def clear_flex_store_cache():
+    flex_module.get_points_flex_store.cache_clear()
+    yield
+    flex_module.get_points_flex_store.cache_clear()
+
+
+def _settings(tmp_path):
+    return SimpleNamespace(
+        SLACK_SIGNING_SECRET=SIGNING_SECRET,
+        SLACK_RECEIPTS_DB_PATH=str(tmp_path / "slack-state.db"),
+        MLAI_BACKEND_URL="https://backend.test",
+        MLAI_API_KEY="api-key",
+        ROO_API_KEY="roo-key",
+        INTERNAL_API_KEY="internal-key",
+        ROO_SURFACE="public",
+        ROO_UNIFIED_ADMIN_ROUTING_ENABLED=False,
+    )
+
+
+def _issue(*, user="UVERIFIED", channel="CPOINTS", now=None):
+    return issue_points_flex_confirmation(
+        signing_secret=SIGNING_SECRET,
+        slack_user_id=user,
+        channel_id=channel,
+        now=time.time() if now is None else now,
+    )
+
+
+def _response_body(response):
+    return json.loads(response.body.decode("utf-8"))
+
+
+def test_confirmation_token_is_bound_and_contains_no_points_data():
+    token, expected = _issue(now=1_000)
+
+    decoded = verify_points_flex_confirmation(
+        token,
+        signing_secret=SIGNING_SECRET,
+        now=1_001,
+    )
+
+    assert decoded == expected
+    payload_segment = token.split(".", 1)[0]
+    payload = json.loads(flex_module._urlsafe_decode(payload_segment))
+    assert set(payload) == {"c", "exp", "iat", "rid", "u", "v"}
+    assert payload["u"] == "UVERIFIED"
+    assert payload["c"] == "CPOINTS"
+
+
+def test_confirmation_token_rejects_tampering_and_expiry():
+    token, _ = _issue(now=1_000)
+    payload, signature = token.split(".", 1)
+    tampered_payload = ("A" if payload[0] != "A" else "B") + payload[1:]
+
+    with pytest.raises(PointsFlexTokenError, match="invalid_token"):
+        verify_points_flex_confirmation(
+            f"{tampered_payload}.{signature}",
+            signing_secret=SIGNING_SECRET,
+            now=1_001,
+        )
+
+    with pytest.raises(PointsFlexTokenError, match="expired_token"):
+        verify_points_flex_confirmation(
+            token,
+            signing_secret=SIGNING_SECRET,
+            now=1_600,
+        )
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(0, 0), (142, 142), ("142", 142), ("+142", 142)],
+)
+def test_lifetime_earned_parser_accepts_only_integral_nonnegative_values(value, expected):
+    assert parse_lifetime_earned({"lifetime_earned": value}) == expected
+
+
+@pytest.mark.parametrize("value", [None, True, -1, 1.5, "1.5", "001"])
+def test_lifetime_earned_parser_rejects_malformed_values(value):
+    with pytest.raises(ValueError, match="invalid lifetime_earned"):
+        parse_lifetime_earned({"lifetime_earned": value})
+
+
+def test_flex_store_claim_is_atomic_across_store_instances(tmp_path):
+    _, confirmation = _issue(now=1_000)
+    database_path = tmp_path / "flex.db"
+
+    def claim(index):
+        store = PointsFlexShareStore(database_path)
+        return store.claim(
+            confirmation,
+            owner=f"worker-{index}",
+            now=1_001,
+        )["state"]
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        states = list(pool.map(claim, range(8)))
+
+    assert states.count("claimed") == 1
+    assert states.count("processing") == 7
+
+
+def test_flex_store_release_allows_retry_and_shared_state_is_final(tmp_path):
+    _, confirmation = _issue(now=1_000)
+    store = PointsFlexShareStore(tmp_path / "flex.db")
+
+    assert store.claim(confirmation, owner="worker-1", now=1_001)["state"] == "claimed"
+    released = store.release(
+        confirmation.request_id,
+        owner="worker-1",
+        error_code="slack_post_failed",
+        now=1_002,
+    )
+    assert released["status"] == "pending"
+    assert released["last_error_code"] == "slack_post_failed"
+
+    assert store.claim(confirmation, owner="worker-2", now=1_003)["state"] == "claimed"
+    shared = store.mark_shared(
+        confirmation.request_id,
+        owner="worker-2",
+        message_ts="123.456",
+        now=1_004,
+    )
+    assert shared["status"] == "shared"
+    assert store.claim(confirmation, owner="worker-3", now=1_005)["state"] == "shared"
+
+
+def test_flex_store_never_reclaims_ambiguous_stale_processing_state(tmp_path):
+    _, confirmation = _issue(now=1_000)
+    store = PointsFlexShareStore(tmp_path / "flex.db")
+
+    assert store.claim(
+        confirmation,
+        owner="crashed-worker",
+        now=1_001,
+        lease_seconds=1,
+    )["state"] == "claimed"
+
+    assert store.claim(
+        confirmation,
+        owner="retry-worker",
+        now=1_003,
+    )["state"] == "processing"
+
+
+def test_flex_and_slack_receipts_can_claim_the_shared_database_concurrently(tmp_path):
+    _, confirmation = _issue(now=1_000)
+    database_path = tmp_path / "shared-slack-state.db"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        flex_future = pool.submit(
+            PointsFlexShareStore(database_path).claim,
+            confirmation,
+            owner="flex-worker",
+            now=1_001,
+        )
+        receipt_future = pool.submit(
+            SlackRequestReceiptStore(database_path).claim,
+            "a" * 64,
+            now=1_001,
+            ttl_seconds=600,
+        )
+
+    assert flex_future.result()["state"] == "claimed"
+    assert receipt_future.result() is True
+
+
+class FlexBalanceClient:
+    def __init__(self, lifetime_earned=142):
+        self.lifetime_earned = lifetime_earned
+        self.balance_users = []
+
+    async def get_balance(self, slack_user_id):
+        self.balance_users.append(slack_user_id)
+        return {
+            "balance": 37,
+            "lifetime_earned": self.lifetime_earned,
+            "lifetime_spent": 105,
+            "lifetime_purchased": 12,
+        }
+
+
+@pytest.mark.asyncio
+async def test_flex_preview_is_private_and_uses_only_verified_actor(monkeypatch, tmp_path):
+    client = FlexBalanceClient()
+    previews = []
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: _settings(tmp_path),
+    )
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "UROO")
+    monkeypatch.setattr(
+        executor_module,
+        "post_ephemeral",
+        lambda **kwargs: previews.append(kwargs) or {"ok": True},
+    )
+
+    result = await SkillExecutor()._handle_points_action(
+        client=client,
+        action="flex_points",
+        params={"target_slack_id": "UFORGED"},
+        text="flex my points",
+        user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert client.balance_users == ["UVERIFIED"]
+    assert result["message"] == ""
+    assert result["suppress_post"] is True
+    assert previews[0]["user"] == "UVERIFIED"
+    assert previews[0]["channel"] == "CPOINTS"
+    assert previews[0]["thread_ts"] == "111.222"
+    section_text = previews[0]["blocks"][0]["text"]["text"]
+    context_text = previews[0]["blocks"][1]["elements"][0]["text"]
+    assert "142 Roo Points" in section_text
+    assert "37" not in section_text
+    assert "105" not in section_text
+    assert "12" not in section_text
+    assert "balance, purchases, spending, and history stay private" in context_text
+    button = previews[0]["blocks"][2]["elements"][0]
+    assert button["action_id"] == POINTS_FLEX_ACTION_ID
+    confirmation = verify_points_flex_confirmation(
+        button["value"],
+        signing_secret=SIGNING_SECRET,
+    )
+    assert confirmation.slack_user_id == "UVERIFIED"
+    assert confirmation.channel_id == "CPOINTS"
+
+
+@pytest.mark.asyncio
+async def test_flex_rejects_tagged_targets_before_balance_lookup(monkeypatch):
+    client = FlexBalanceClient()
+    notices = []
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "UROO")
+    monkeypatch.setattr(
+        executor_module,
+        "post_ephemeral",
+        lambda **kwargs: notices.append(kwargs) or {"ok": True},
+    )
+
+    result = await SkillExecutor()._handle_points_action(
+        client=client,
+        action="flex_points",
+        params={},
+        text="<@UROO> flex <@UTARGET>'s points",
+        user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts=None,
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert client.balance_users == []
+    assert result["suppress_post"] is True
+    assert result["data"]["target_rejected"] is True
+    assert "only flex your own" in notices[0]["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_flex_in_dm_redirects_to_destination_channel_without_lookup(monkeypatch):
+    client = FlexBalanceClient()
+    monkeypatch.setattr(
+        executor_module,
+        "post_ephemeral",
+        lambda **kwargs: pytest.fail("no ephemeral message expected in a DM"),
+    )
+
+    result = await SkillExecutor()._handle_points_action(
+        client=client,
+        action="flex_points",
+        params={},
+        text="flex my points",
+        user_id="UVERIFIED",
+        channel_id="DPRIVATE",
+        thread_ts=None,
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert client.balance_users == []
+    assert "shared channel" in result
+    assert "lifetime-earned" in result
+
+
+@pytest.mark.asyncio
+async def test_preview_failure_never_posts_points_and_sends_generic_dm(monkeypatch, tmp_path):
+    direct_messages = []
+    monkeypatch.setattr(
+        executor_module,
+        "get_settings",
+        lambda: _settings(tmp_path),
+    )
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "UROO")
+    monkeypatch.setattr(
+        executor_module,
+        "post_ephemeral",
+        lambda **kwargs: (_ for _ in ()).throw(RuntimeError("Slack unavailable")),
+    )
+    monkeypatch.setattr(
+        executor_module,
+        "send_dm",
+        lambda user_id, text, **kwargs: direct_messages.append((user_id, text)) or {"ok": True},
+    )
+
+    result = await SkillExecutor()._handle_points_action(
+        client=FlexBalanceClient(),
+        action="flex_points",
+        params={},
+        text="flex my points",
+        user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts=None,
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert result["message"] == ""
+    assert result["suppress_post"] is True
+    assert result["data"]["preview_delivered"] is False
+    assert direct_messages[0][0] == "UVERIFIED"
+    assert "142" not in direct_messages[0][1]
+    assert "37" not in direct_messages[0][1]
+
+
+class ConfirmationBackendClient:
+    balance_users = []
+    payload = {"balance": 9, "lifetime_earned": 155, "lifetime_spent": 44}
+    failures_remaining = 0
+
+    def __init__(self, *args, **kwargs):
+        self.init_kwargs = kwargs
+
+    async def get_balance(self, slack_user_id):
+        type(self).balance_users.append(slack_user_id)
+        if type(self).failures_remaining:
+            type(self).failures_remaining -= 1
+            raise RuntimeError("backend unavailable")
+        return dict(type(self).payload)
+
+
+@pytest.fixture
+def confirmation_backend(monkeypatch):
+    ConfirmationBackendClient.balance_users = []
+    ConfirmationBackendClient.failures_remaining = 0
+    ConfirmationBackendClient.payload = {
+        "balance": 9,
+        "lifetime_earned": 155,
+        "lifetime_spent": 44,
+        "lifetime_purchased": 20,
+    }
+    monkeypatch.setattr(
+        "roo.clients.mlai_backend.MLAIBackendClient",
+        ConfirmationBackendClient,
+    )
+    return ConfirmationBackendClient
+
+
+@pytest.mark.asyncio
+async def test_confirmation_refetches_total_and_posts_top_level_once(
+    monkeypatch,
+    tmp_path,
+    confirmation_backend,
+):
+    settings = _settings(tmp_path)
+    token, confirmation = _issue()
+    public_posts = []
+    monkeypatch.setattr(
+        main_module,
+        "post_message",
+        lambda **kwargs: public_posts.append(kwargs) or {"ok": True, "ts": "123.456"},
+    )
+
+    first = await main_module._handle_points_flex_confirmation_action(
+        settings=settings,
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+    second = await main_module._handle_points_flex_confirmation_action(
+        settings=settings,
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+
+    assert confirmation_backend.balance_users == ["UVERIFIED"]
+    assert public_posts == [
+        {
+            "channel": "CPOINTS",
+            "text": "<@UVERIFIED> has earned *155 Roo Points* through MLAI contributions.",
+            "client_msg_id": confirmation.request_id,
+        }
+    ]
+    assert "thread_ts" not in public_posts[0]
+    assert "9" not in public_posts[0]["text"]
+    assert "44" not in public_posts[0]["text"]
+    assert "20" not in public_posts[0]["text"]
+    assert "Shared" in _response_body(first)["text"]
+    assert "already shared" in _response_body(second)["text"]
+    record = flex_module.get_points_flex_store(
+        settings.SLACK_RECEIPTS_DB_PATH
+    ).get(confirmation.request_id)
+    assert record["status"] == "shared"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("actor", "channel", "message_fragment"),
+    [
+        ("UATTACKER", "CPOINTS", "Only the member"),
+        ("UVERIFIED", "COTHER", "only works in the channel"),
+    ],
+)
+async def test_confirmation_rejects_actor_or_channel_mismatch_before_lookup(
+    monkeypatch,
+    tmp_path,
+    confirmation_backend,
+    actor,
+    channel,
+    message_fragment,
+):
+    token, _ = _issue()
+    monkeypatch.setattr(
+        main_module,
+        "post_message",
+        lambda **kwargs: pytest.fail("no public post expected"),
+    )
+
+    response = await main_module._handle_points_flex_confirmation_action(
+        settings=_settings(tmp_path),
+        action_value=token,
+        verified_user_id=actor,
+        verified_channel_id=channel,
+    )
+
+    assert confirmation_backend.balance_users == []
+    assert message_fragment in _response_body(response)["text"]
+
+
+@pytest.mark.asyncio
+async def test_backend_failure_releases_confirmation_for_safe_retry(
+    monkeypatch,
+    tmp_path,
+    confirmation_backend,
+):
+    confirmation_backend.failures_remaining = 1
+    token, _ = _issue()
+    public_posts = []
+    monkeypatch.setattr(
+        main_module,
+        "post_message",
+        lambda **kwargs: public_posts.append(kwargs) or {"ok": True, "ts": "123.456"},
+    )
+
+    failed = await main_module._handle_points_flex_confirmation_action(
+        settings=_settings(tmp_path),
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+    retried = await main_module._handle_points_flex_confirmation_action(
+        settings=_settings(tmp_path),
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+
+    assert "nothing was posted" in _response_body(failed)["text"]
+    assert _response_body(failed)["replace_original"] is False
+    assert "Shared" in _response_body(retried)["text"]
+    assert _response_body(retried)["replace_original"] is True
+    assert len(public_posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_slack_post_failure_releases_confirmation_for_safe_retry(
+    monkeypatch,
+    tmp_path,
+    confirmation_backend,
+):
+    token, _ = _issue()
+    attempts = []
+
+    def post_message(**kwargs):
+        attempts.append(kwargs)
+        if len(attempts) == 1:
+            return {"ok": False, "error": "temporary_error"}
+        return {"ok": True, "ts": "123.456"}
+
+    monkeypatch.setattr(main_module, "post_message", post_message)
+
+    failed = await main_module._handle_points_flex_confirmation_action(
+        settings=_settings(tmp_path),
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+    retried = await main_module._handle_points_flex_confirmation_action(
+        settings=_settings(tmp_path),
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+
+    assert "nothing was shared" in _response_body(failed)["text"]
+    assert _response_body(failed)["replace_original"] is False
+    assert "Shared" in _response_body(retried)["text"]
+    assert len(attempts) == 2
+    assert attempts[0]["client_msg_id"] == attempts[1]["client_msg_id"]
+
+
+@pytest.mark.asyncio
+async def test_fast_path_routes_flex_with_verified_channel_context(monkeypatch):
+    calls = []
+    agent = object.__new__(RooAgent)
+
+    async def execute(user_id, action, **kwargs):
+        calls.append((user_id, action, kwargs))
+        return {"message": "", "suppress_post": True}
+
+    monkeypatch.setattr(agent, "_execute_fast_points", execute)
+
+    result = await agent._try_fast_path(
+        "flex my points",
+        "UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+    )
+
+    assert agent._match_fast_path("flex my points") == "flex_points"
+    assert agent._match_fast_path("points flex") == "flex_points"
+    assert calls == [
+        (
+            "UVERIFIED",
+            "flex_points",
+            {"channel_id": "CPOINTS", "thread_ts": "111.222"},
+        )
+    ]
+    assert result["suppress_post"] is True
+
+
+@pytest.mark.asyncio
+async def test_fast_executor_invokes_flex_action_without_model_parameters(monkeypatch):
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, *args, **kwargs):
+            captured["client"] = kwargs
+
+    class FakeSkill:
+        name = "mlai-points"
+
+        @staticmethod
+        def get_client_class(name):
+            assert name == "MLAIBackendClient"
+            return FakeClient
+
+    class FakeExecutor:
+        async def _handle_points_action(self, **kwargs):
+            captured["handler"] = kwargs
+            return {"message": "", "suppress_post": True}
+
+    agent = object.__new__(RooAgent)
+    agent.skills = [FakeSkill()]
+    agent.skill_executor = FakeExecutor()
+    monkeypatch.setattr(
+        agent_module,
+        "get_settings",
+        lambda: SimpleNamespace(
+            MLAI_BACKEND_URL="https://backend.test",
+            MLAI_API_KEY="api-key",
+            ROO_API_KEY="roo-key",
+            INTERNAL_API_KEY="internal-key",
+        ),
+    )
+
+    result = await agent._execute_fast_points(
+        "UVERIFIED",
+        "flex_points",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+    )
+
+    assert captured["handler"]["action"] == "flex_points"
+    assert captured["handler"]["params"] == {}
+    assert captured["handler"]["user_id"] == "UVERIFIED"
+    assert captured["handler"]["channel_id"] == "CPOINTS"
+    assert result["message"] == ""
+    assert result["suppress_post"] is True
+
+
+@pytest.mark.asyncio
+async def test_slack_action_endpoint_routes_verified_identity_to_flex_handler(monkeypatch, tmp_path):
+    settings = _settings(tmp_path)
+    captured = []
+
+    async def handle(**kwargs):
+        captured.append(kwargs)
+        return main_module._points_flex_action_response("handled")
+
+    monkeypatch.setattr(main_module, "_handle_points_flex_confirmation_action", handle)
+    payload = {
+        "type": "block_actions",
+        "user": {"id": "UVERIFIED"},
+        "channel": {"id": "CPOINTS"},
+        "actions": [{"action_id": POINTS_FLEX_ACTION_ID, "value": "signed-token"}],
+    }
+
+    class FakeRequest:
+        state = SimpleNamespace(
+            slack_duplicate=False,
+            roo_settings=settings,
+        )
+
+        async def form(self):
+            return {"payload": json.dumps(payload)}
+
+    response = await main_module.slack_actions(FakeRequest(), _verified=True)
+
+    assert _response_body(response)["text"] == "handled"
+    assert captured == [
+        {
+            "settings": settings,
+            "action_value": "signed-token",
+            "verified_user_id": "UVERIFIED",
+            "verified_channel_id": "CPOINTS",
+        }
+    ]

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -13,13 +13,12 @@ routing:
   examples:
     - {text: "how do I earn points?", action: list_tasks}
     - {text: "what's my balance", action: balance}
+    - {text: "flex my points", action: flex_points}
     - {text: "book me in for coworking tomorrow", action: book_coworking}
     - {text: "book me in", action: book_coworking}
     - {text: "claim task ROO-12", action: claim_task}
     - {text: "how busy was the coworking space in may?", action: coworking_report}
     - {text: "give 10 points to @member for organising the meetup", action: award_points}
-    - {text: "I need more points", action: topup_points}
-    - {text: "add roo points", action: topup_points}
   negative_examples:
     - {text: "add a task to linear to fix the login bug", instead: linear-meeting-actions}
     - {text: "book club is meeting thursday, can you remind the channel?", instead: respond_in_chat}
@@ -27,6 +26,8 @@ routing:
 actions:
   - name: balance
     description: Privately show the user their current points balance.
+  - name: flex_points
+    description: Confirm sharing the user's own lifetime-earned total publicly.
   - name: history
     description: Privately show the user their recent points transactions.
     params:
@@ -355,6 +356,11 @@ so fresh buttons can be created safely in that conversation.
 - Treat balances, lifetime totals, transaction history, affordability, and resulting
   balances as personal data. In a shared channel or thread, send those details to
   the verified requester by DM and use only a private ephemeral acknowledgement.
+- The only public lifetime-total flow is `flex_points`. It must be requested by the
+  member for themselves in the destination channel and confirmed through Roo's
+  private **Share publicly** button. Never treat a balance request as consent, never
+  accept a tagged target, and never share balance, purchase, spending, or history
+  fields. The eventual public post is top-level in the selected channel, not a thread.
 - In a Roo DM, return personal points details directly without opening another DM.
 - Public booking and award confirmations may state the action and points charged or
   awarded, but must not include anyone's remaining or resulting balance.


### PR DESCRIPTION
## Summary

Adds an explicit opt-in `flex_points` action to the existing Roo Points skill.

A member can run `@Roo flex my points` in a shared channel, privately preview exactly what will be disclosed, and confirm with a **Share publicly** button. Roo then posts only the member's latest `lifetime_earned` contribution total as a new top-level channel message.

Linear: [MLA-1772](https://linear.app/mlai-aus/issue/MLA-1772/let-members-publicly-flex-their-lifetime-earned-roo-points)

## Privacy and safety

- normal balance, history, and rewards flows remain private
- only the verified Slack actor can flex their own points
- tagged-user flex requests are rejected before lookup
- confirmation is signed, expires after 10 minutes, and is bound to the actor and channel
- confirmation re-fetches `lifetime_earned`; balance, purchases, spending, and history are never posted
- durable SQLite claims and Slack `client_msg_id` protect against retries, concurrent clicks, restarts, and duplicate posts
- ambiguous post state fails closed
- public output is top-level in the chosen channel, never in a thread
- no backend or database migration is required

## Validation

- 29 dedicated flex tests
- 69 flex/privacy/Slack/routing tests passed
- 465 production security and PR workflow tests passed
- deterministic routing: 240 cases, 0 misroutes, no baseline regressions
- Python compilation passed
- full suite: 812 passed, with the same 22 unrelated failures already present on `main`

The PR workflow now includes the private-points and flex suites so this behavior remains gated in CI.