### PR TITLE
feat(points): support threaded flex deletion

### DIFF
--- a/roo-standalone/roo/agent.py
+++ b/roo-standalone/roo/agent.py
@@ -818,7 +818,13 @@ class RooAgent:
         """
         text_lower = text.lower().strip()
 
-        # 1. Explicit opt-in public contribution total.
+        # 1. Explicit opt-in contribution total and owner-only deletion.
+        if re.match(
+            r'^(?:delete my flex|remove my (?:points )?flex|delete my latest flex)$',
+            text_lower,
+        ):
+            return "delete_flex"
+
         if re.match(r'^(?:flex my points|flex points|points flex)$', text_lower):
             return "flex_points"
 
@@ -865,10 +871,10 @@ class RooAgent:
         if action is None:
             return None
 
-        if action == "flex_points":
+        if action in {"flex_points", "delete_flex"}:
             return await self._execute_fast_points(
                 user_id,
-                "flex_points",
+                action,
                 channel_id=channel_id,
                 thread_ts=thread_ts,
             )
@@ -938,12 +944,16 @@ class RooAgent:
                 internal_api_key=settings.INTERNAL_API_KEY or settings.ROO_API_KEY or settings.MLAI_API_KEY,
             )
             
-            if action == "flex_points":
+            if action in {"flex_points", "delete_flex"}:
                 msg = await self.skill_executor._handle_points_action(
                     client=client,
-                    action="flex_points",
+                    action=action,
                     params={},
-                    text="flex my points",
+                    text=(
+                        "flex my points"
+                        if action == "flex_points"
+                        else "delete my flex"
+                    ),
                     user_id=user_id,
                     channel_id=kwargs.get("channel_id"),
                     thread_ts=kwargs.get("thread_ts"),

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -942,9 +942,9 @@ async def _handle_points_flex_delete_action(
             "Only the member who shared this flex can delete it.",
             replace_original=False,
         )
-    if str(verified_channel_id or "") != deletion.channel_id:
+    if str(verified_channel_id or "") != deletion.interaction_channel_id:
         return _points_flex_action_response(
-            "This delete button only works in the channel where the flex was shared.",
+            "This delete button only works in the conversation where it was requested.",
             replace_original=False,
         )
 

--- a/roo-standalone/roo/main.py
+++ b/roo-standalone/roo/main.py
@@ -52,13 +52,16 @@ from .points_request_approval import (
 )
 from .points_flex import (
     POINTS_FLEX_ACTION_ID,
+    POINTS_FLEX_DELETE_ACTION_ID,
     PointsFlexTokenError,
     format_points_flex_public_message,
     get_points_flex_store,
     parse_lifetime_earned,
     verify_points_flex_confirmation,
+    verify_points_flex_deletion,
 )
 from .slack_client import (
+    delete_message,
     get_bot_user_id,
     get_message,
     get_recent_channel_messages,
@@ -842,6 +845,7 @@ async def _handle_points_flex_confirmation_action(
         post_response = post_message(
             channel=confirmation.channel_id,
             text=public_message,
+            thread_ts=confirmation.thread_ts,
             client_msg_id=confirmation.request_id,
         )
         post_succeeded = bool(
@@ -890,7 +894,145 @@ async def _handle_points_flex_confirmation_action(
             f"exc_type={exc.__class__.__name__}"
         )
 
-    return _points_flex_action_response("Shared your lifetime-earned Roo Points publicly.")
+    return _points_flex_action_response("Shared your lifetime-earned Roo Points in this thread.")
+
+
+def _points_flex_slack_error_code(
+    response: Any = None,
+    exc: Optional[Exception] = None,
+) -> str:
+    """Extract only Slack's bounded machine error code."""
+
+    candidates = [response, getattr(exc, "response", None)]
+    for candidate in candidates:
+        try:
+            code = str(candidate.get("error") or "").strip()
+        except Exception:
+            continue
+        if re.fullmatch(r"[a-z0-9_]{1,64}", code):
+            return code
+    return "slack_delete_failed"
+
+
+async def _handle_points_flex_delete_action(
+    *,
+    settings: Settings,
+    action_value: str,
+    verified_user_id: Optional[str],
+    verified_channel_id: Optional[str],
+) -> JSONResponse:
+    """Delete exactly one stored flex owned by the verified Slack actor."""
+
+    try:
+        deletion = verify_points_flex_deletion(
+            action_value,
+            signing_secret=settings.SLACK_SIGNING_SECRET,
+        )
+    except PointsFlexTokenError as exc:
+        if exc.code == "expired_token":
+            return _points_flex_action_response(
+                "That delete button has expired. Run `@Roo delete my flex` again."
+            )
+        return _points_flex_action_response(
+            "I couldn't verify that delete request. Run `@Roo delete my flex` again."
+        )
+
+    if str(verified_user_id or "") != deletion.slack_user_id:
+        return _points_flex_action_response(
+            "Only the member who shared this flex can delete it.",
+            replace_original=False,
+        )
+    if str(verified_channel_id or "") != deletion.channel_id:
+        return _points_flex_action_response(
+            "This delete button only works in the channel where the flex was shared.",
+            replace_original=False,
+        )
+
+    store = get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+    owner = f"roo-flex-delete-{uuid4()}"
+    try:
+        claim = store.claim_delete(deletion, owner=owner)
+    except Exception as exc:
+        print(
+            "Points flex delete state failed "
+            f"exc_type={exc.__class__.__name__}"
+        )
+        return _points_flex_action_response(
+            "I couldn't safely delete that flex. Nothing was changed; try again in a moment.",
+            replace_original=False,
+        )
+
+    state = claim.get("state")
+    if state == "deleted":
+        return _points_flex_action_response("That Roo Points flex was already deleted.")
+    if state == "deleting":
+        return _points_flex_action_response(
+            "That Roo Points flex is already being deleted.",
+            replace_original=False,
+        )
+    if state in {"not_found", "unavailable"}:
+        return _points_flex_action_response(
+            "I couldn't find that active Roo Points flex. It may already be gone."
+        )
+    if state != "claimed":
+        return _points_flex_action_response(
+            "I couldn't safely verify that flex, so nothing was deleted."
+        )
+
+    record = claim.get("record") or {}
+    # The Slack target comes only from the ownership-checked store record. It
+    # is intentionally absent from the signed button value.
+    stored_message_ts = str(record.get("message_ts") or "").strip()
+    slack_response = None
+    slack_exc = None
+    try:
+        slack_response = delete_message(
+            channel=deletion.channel_id,
+            message_ts=stored_message_ts,
+        )
+        deleted = bool(slack_response and slack_response.get("ok"))
+    except Exception as exc:
+        slack_exc = exc
+        deleted = False
+    error_code = _points_flex_slack_error_code(slack_response, slack_exc)
+    already_missing = error_code == "message_not_found"
+
+    if deleted or already_missing:
+        try:
+            store.mark_deleted(deletion.request_id, owner=owner)
+        except Exception as exc:
+            # A stale delete lease can safely retry: Slack returns
+            # message_not_found, which finalises the same record.
+            print(
+                "Points flex deleted-state persistence failed "
+                f"exc_type={exc.__class__.__name__}"
+            )
+            return _points_flex_action_response(
+                "The flex is gone from Slack, but I couldn't finish recording it. "
+                "You can safely try the same delete button again.",
+                replace_original=False,
+            )
+        if already_missing:
+            return _points_flex_action_response(
+                "That Roo Points flex was already gone, so I marked it deleted."
+            )
+        return _points_flex_action_response("Deleted your Roo Points flex.")
+
+    try:
+        store.release_delete(
+            deletion.request_id,
+            owner=owner,
+            error_code=error_code,
+        )
+    except Exception as exc:
+        print(
+            "Points flex delete release failed "
+            f"exc_type={exc.__class__.__name__}"
+        )
+    return _points_flex_action_response(
+        "I couldn't delete that flex from Slack. Nothing else was changed; try the button again.",
+        replace_original=False,
+    )
 
 
 @dataclass(frozen=True)
@@ -4906,6 +5048,14 @@ async def slack_actions(
 
     if action_id == POINTS_FLEX_ACTION_ID:
         return await _handle_points_flex_confirmation_action(
+            settings=settings,
+            action_value=str(actions[0].get("value") or ""),
+            verified_user_id=user_id,
+            verified_channel_id=channel_id,
+        )
+
+    if action_id == POINTS_FLEX_DELETE_ACTION_ID:
+        return await _handle_points_flex_delete_action(
             settings=settings,
             action_value=str(actions[0].get("value") or ""),
             verified_user_id=user_id,

--- a/roo-standalone/roo/points_flex.py
+++ b/roo-standalone/roo/points_flex.py
@@ -26,6 +26,7 @@ _SIGNING_CONTEXT = b"roo-points-flex-v1"
 _DELETE_SIGNING_CONTEXT = b"roo-points-flex-delete-v1"
 _SLACK_USER_ID = re.compile(r"^[UW][A-Z0-9]+$")
 _SLACK_CHANNEL_ID = re.compile(r"^[CG][A-Z0-9]+$")
+_SLACK_ACTION_CHANNEL_ID = re.compile(r"^[CDG][A-Z0-9]+$")
 _SLACK_MESSAGE_TS = re.compile(r"^\d{1,16}\.\d{1,16}$")
 
 
@@ -54,6 +55,7 @@ class PointsFlexDeletion:
     channel_id: str
     issued_at: int
     expires_at: int
+    interaction_channel_id: str
 
 
 def _urlsafe_encode(value: bytes) -> str:
@@ -203,6 +205,7 @@ def issue_points_flex_deletion(
     request_id: str,
     slack_user_id: str,
     channel_id: str,
+    interaction_channel_id: Optional[str] = None,
     now: Optional[float] = None,
     ttl_seconds: int = POINTS_FLEX_CONFIRMATION_TTL_SECONDS,
 ) -> str:
@@ -218,17 +221,23 @@ def issue_points_flex_deletion(
         raise PointsFlexTokenError("invalid_user")
     if not _SLACK_CHANNEL_ID.fullmatch(cleaned_channel_id):
         raise PointsFlexTokenError("invalid_channel")
+    cleaned_interaction_channel_id = str(
+        interaction_channel_id or cleaned_channel_id
+    ).strip()
+    if not _SLACK_ACTION_CHANNEL_ID.fullmatch(cleaned_interaction_channel_id):
+        raise PointsFlexTokenError("invalid_channel")
     if not 1 <= int(ttl_seconds) <= POINTS_FLEX_CONFIRMATION_TTL_SECONDS:
         raise PointsFlexTokenError("invalid_expiry")
 
     issued_at = int(time.time() if now is None else now)
     payload = {
+        "a": cleaned_interaction_channel_id,
         "c": cleaned_channel_id,
         "exp": issued_at + int(ttl_seconds),
         "iat": issued_at,
         "rid": cleaned_request_id,
         "u": cleaned_user_id,
-        "v": 1,
+        "v": 2,
     }
     encoded_payload = _urlsafe_encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
@@ -267,24 +276,35 @@ def verify_points_flex_deletion(
 
     try:
         payload = json.loads(_urlsafe_decode(encoded_payload).decode("utf-8"))
-        if set(payload) != {"c", "exp", "iat", "rid", "u", "v"}:
+        version = int(payload["v"])
+        expected_fields = (
+            {"c", "exp", "iat", "rid", "u", "v"}
+            if version == 1
+            else {"a", "c", "exp", "iat", "rid", "u", "v"}
+        )
+        if set(payload) != expected_fields:
             raise ValueError("unexpected token fields")
+        channel_id = str(payload["c"])
         deletion = PointsFlexDeletion(
             request_id=str(UUID(str(payload["rid"]))),
             slack_user_id=str(payload["u"]),
-            channel_id=str(payload["c"]),
+            channel_id=channel_id,
             issued_at=int(payload["iat"]),
             expires_at=int(payload["exp"]),
+            interaction_channel_id=(
+                channel_id if version == 1 else str(payload["a"])
+            ),
         )
-        version = int(payload["v"])
     except (KeyError, TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise PointsFlexTokenError("invalid_token") from exc
 
-    if version != 1:
+    if version not in {1, 2}:
         raise PointsFlexTokenError("invalid_token")
     if not _SLACK_USER_ID.fullmatch(deletion.slack_user_id):
         raise PointsFlexTokenError("invalid_token")
     if not _SLACK_CHANNEL_ID.fullmatch(deletion.channel_id):
+        raise PointsFlexTokenError("invalid_token")
+    if not _SLACK_ACTION_CHANNEL_ID.fullmatch(deletion.interaction_channel_id):
         raise PointsFlexTokenError("invalid_token")
     if not 1 <= deletion.expires_at - deletion.issued_at <= POINTS_FLEX_CONFIRMATION_TTL_SECONDS:
         raise PointsFlexTokenError("invalid_token")
@@ -365,6 +385,7 @@ def build_points_flex_delete_blocks(
     *,
     records: list[dict[str, Any]],
     tokens: dict[str, str],
+    include_channel: bool = False,
 ) -> list[dict[str, Any]]:
     """Build a private, exact-record delete confirmation or selector."""
 
@@ -389,13 +410,18 @@ def build_points_flex_delete_blocks(
             if shared_at
             else "your flex post"
         )
-        thread_note = " in a thread" if record.get("thread_ts") else ""
+        location_note = (
+            f" in <#{record['channel_id']}>"
+            + (" (thread)" if record.get("thread_ts") else "")
+            if include_channel
+            else (" in a thread" if record.get("thread_ts") else "")
+        )
         blocks.append(
             {
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"Flex shared {when}{thread_note}",
+                    "text": f"Flex shared {when}{location_note}",
                 },
                 "accessory": {
                     "type": "button",
@@ -422,7 +448,12 @@ def build_points_flex_delete_blocks(
             "elements": [
                 {
                     "type": "mrkdwn",
-                    "text": "Only your flex messages in this channel are shown. Delete buttons expire in 10 minutes.",
+                    "text": (
+                        "Only your flex messages are shown. "
+                        if include_channel
+                        else "Only your flex messages in this channel are shown. "
+                    )
+                    + "Delete buttons expire in 10 minutes.",
                 }
             ],
         }
@@ -706,6 +737,30 @@ class PointsFlexShareStore:
                 LIMIT ?
                 """,
                 (str(slack_user_id), str(channel_id), bounded_limit),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def list_shared_for_user(
+        self,
+        *,
+        slack_user_id: str,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """List one member's deletable flexes across shared channels."""
+
+        self._initialise()
+        bounded_limit = min(max(int(limit), 1), 10)
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM points_flex_shares
+                WHERE slack_user_id = ?
+                  AND status = 'shared' AND message_ts IS NOT NULL
+                  AND message_ts != ''
+                ORDER BY shared_at DESC, created_at DESC
+                LIMIT ?
+                """,
+                (str(slack_user_id), bounded_limit),
             ).fetchall()
         return [dict(row) for row in rows]
 

--- a/roo-standalone/roo/points_flex.py
+++ b/roo-standalone/roo/points_flex.py
@@ -1,4 +1,4 @@
-"""Explicit, replay-safe consent for public Roo Points flex posts."""
+"""Explicit, replay-safe consent and ownership for Roo Points flex posts."""
 
 from __future__ import annotations
 
@@ -18,12 +18,15 @@ from uuid import UUID, uuid4
 
 
 POINTS_FLEX_ACTION_ID = "points_flex_confirm"
+POINTS_FLEX_DELETE_ACTION_ID = "points_flex_delete_confirm"
 POINTS_FLEX_CONFIRMATION_TTL_SECONDS = 10 * 60
 POINTS_FLEX_PROCESSING_LEASE_SECONDS = 30
 
 _SIGNING_CONTEXT = b"roo-points-flex-v1"
+_DELETE_SIGNING_CONTEXT = b"roo-points-flex-delete-v1"
 _SLACK_USER_ID = re.compile(r"^[UW][A-Z0-9]+$")
 _SLACK_CHANNEL_ID = re.compile(r"^[CG][A-Z0-9]+$")
+_SLACK_MESSAGE_TS = re.compile(r"^\d{1,16}\.\d{1,16}$")
 
 
 class PointsFlexTokenError(ValueError):
@@ -36,6 +39,16 @@ class PointsFlexTokenError(ValueError):
 
 @dataclass(frozen=True)
 class PointsFlexConfirmation:
+    request_id: str
+    slack_user_id: str
+    channel_id: str
+    issued_at: int
+    expires_at: int
+    thread_ts: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class PointsFlexDeletion:
     request_id: str
     slack_user_id: str
     channel_id: str
@@ -59,11 +72,11 @@ def _urlsafe_decode(value: str) -> bytes:
         raise PointsFlexTokenError("invalid_token") from exc
 
 
-def _signing_key(signing_secret: str) -> bytes:
+def _signing_key(signing_secret: str, *, context: bytes = _SIGNING_CONTEXT) -> bytes:
     secret = str(signing_secret or "").encode("utf-8")
     if not secret:
         raise PointsFlexTokenError("signing_unavailable")
-    return hmac.new(secret, _SIGNING_CONTEXT, hashlib.sha256).digest()
+    return hmac.new(secret, context, hashlib.sha256).digest()
 
 
 def issue_points_flex_confirmation(
@@ -71,6 +84,7 @@ def issue_points_flex_confirmation(
     signing_secret: str,
     slack_user_id: str,
     channel_id: str,
+    thread_ts: Optional[str] = None,
     now: Optional[float] = None,
     ttl_seconds: int = POINTS_FLEX_CONFIRMATION_TTL_SECONDS,
 ) -> tuple[str, PointsFlexConfirmation]:
@@ -82,6 +96,9 @@ def issue_points_flex_confirmation(
         raise PointsFlexTokenError("invalid_user")
     if not _SLACK_CHANNEL_ID.fullmatch(cleaned_channel_id):
         raise PointsFlexTokenError("invalid_channel")
+    cleaned_thread_ts = str(thread_ts or "").strip() or None
+    if cleaned_thread_ts is not None and not _SLACK_MESSAGE_TS.fullmatch(cleaned_thread_ts):
+        raise PointsFlexTokenError("invalid_thread")
     if not 1 <= int(ttl_seconds) <= POINTS_FLEX_CONFIRMATION_TTL_SECONDS:
         raise PointsFlexTokenError("invalid_expiry")
 
@@ -92,6 +109,7 @@ def issue_points_flex_confirmation(
         channel_id=cleaned_channel_id,
         issued_at=issued_at,
         expires_at=issued_at + int(ttl_seconds),
+        thread_ts=cleaned_thread_ts,
     )
     payload = {
         "c": confirmation.channel_id,
@@ -99,8 +117,10 @@ def issue_points_flex_confirmation(
         "iat": confirmation.issued_at,
         "rid": confirmation.request_id,
         "u": confirmation.slack_user_id,
-        "v": 1,
+        "v": 2,
     }
+    if confirmation.thread_ts:
+        payload["t"] = confirmation.thread_ts
     encoded_payload = _urlsafe_encode(
         json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
     )
@@ -144,14 +164,19 @@ def verify_points_flex_confirmation(
         issued_at = int(payload["iat"])
         expires_at = int(payload["exp"])
         version = int(payload["v"])
+        thread_ts = str(payload.get("t") or "").strip() or None
     except (KeyError, TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise PointsFlexTokenError("invalid_token") from exc
 
-    if version != 1:
+    if version not in {1, 2}:
         raise PointsFlexTokenError("invalid_token")
     if not _SLACK_USER_ID.fullmatch(slack_user_id):
         raise PointsFlexTokenError("invalid_token")
     if not _SLACK_CHANNEL_ID.fullmatch(channel_id):
+        raise PointsFlexTokenError("invalid_token")
+    if thread_ts is not None and not _SLACK_MESSAGE_TS.fullmatch(thread_ts):
+        raise PointsFlexTokenError("invalid_token")
+    if version == 1 and thread_ts is not None:
         raise PointsFlexTokenError("invalid_token")
     if not 1 <= expires_at - issued_at <= POINTS_FLEX_CONFIRMATION_TTL_SECONDS:
         raise PointsFlexTokenError("invalid_token")
@@ -168,7 +193,108 @@ def verify_points_flex_confirmation(
         channel_id=channel_id,
         issued_at=issued_at,
         expires_at=expires_at,
+        thread_ts=thread_ts,
     )
+
+
+def issue_points_flex_deletion(
+    *,
+    signing_secret: str,
+    request_id: str,
+    slack_user_id: str,
+    channel_id: str,
+    now: Optional[float] = None,
+    ttl_seconds: int = POINTS_FLEX_CONFIRMATION_TTL_SECONDS,
+) -> str:
+    """Create a signed delete action for one stored flex owned by one member."""
+
+    try:
+        cleaned_request_id = str(UUID(str(request_id)))
+    except (TypeError, ValueError) as exc:
+        raise PointsFlexTokenError("invalid_request") from exc
+    cleaned_user_id = str(slack_user_id or "").strip()
+    cleaned_channel_id = str(channel_id or "").strip()
+    if not _SLACK_USER_ID.fullmatch(cleaned_user_id):
+        raise PointsFlexTokenError("invalid_user")
+    if not _SLACK_CHANNEL_ID.fullmatch(cleaned_channel_id):
+        raise PointsFlexTokenError("invalid_channel")
+    if not 1 <= int(ttl_seconds) <= POINTS_FLEX_CONFIRMATION_TTL_SECONDS:
+        raise PointsFlexTokenError("invalid_expiry")
+
+    issued_at = int(time.time() if now is None else now)
+    payload = {
+        "c": cleaned_channel_id,
+        "exp": issued_at + int(ttl_seconds),
+        "iat": issued_at,
+        "rid": cleaned_request_id,
+        "u": cleaned_user_id,
+        "v": 1,
+    }
+    encoded_payload = _urlsafe_encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    signature = hmac.new(
+        _signing_key(signing_secret, context=_DELETE_SIGNING_CONTEXT),
+        encoded_payload.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return f"{encoded_payload}.{_urlsafe_encode(signature)}"
+
+
+def verify_points_flex_deletion(
+    token: str,
+    *,
+    signing_secret: str,
+    now: Optional[float] = None,
+) -> PointsFlexDeletion:
+    """Verify a delete action without accepting a channel or message timestamp."""
+
+    try:
+        encoded_payload, encoded_signature = str(token or "").split(".", 1)
+    except ValueError as exc:
+        raise PointsFlexTokenError("invalid_token") from exc
+    if not encoded_payload or not encoded_signature:
+        raise PointsFlexTokenError("invalid_token")
+
+    actual_signature = _urlsafe_decode(encoded_signature)
+    expected_signature = hmac.new(
+        _signing_key(signing_secret, context=_DELETE_SIGNING_CONTEXT),
+        encoded_payload.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    if not hmac.compare_digest(actual_signature, expected_signature):
+        raise PointsFlexTokenError("invalid_token")
+
+    try:
+        payload = json.loads(_urlsafe_decode(encoded_payload).decode("utf-8"))
+        if set(payload) != {"c", "exp", "iat", "rid", "u", "v"}:
+            raise ValueError("unexpected token fields")
+        deletion = PointsFlexDeletion(
+            request_id=str(UUID(str(payload["rid"]))),
+            slack_user_id=str(payload["u"]),
+            channel_id=str(payload["c"]),
+            issued_at=int(payload["iat"]),
+            expires_at=int(payload["exp"]),
+        )
+        version = int(payload["v"])
+    except (KeyError, TypeError, ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise PointsFlexTokenError("invalid_token") from exc
+
+    if version != 1:
+        raise PointsFlexTokenError("invalid_token")
+    if not _SLACK_USER_ID.fullmatch(deletion.slack_user_id):
+        raise PointsFlexTokenError("invalid_token")
+    if not _SLACK_CHANNEL_ID.fullmatch(deletion.channel_id):
+        raise PointsFlexTokenError("invalid_token")
+    if not 1 <= deletion.expires_at - deletion.issued_at <= POINTS_FLEX_CONFIRMATION_TTL_SECONDS:
+        raise PointsFlexTokenError("invalid_token")
+
+    current_time = int(time.time() if now is None else now)
+    if deletion.issued_at > current_time + 30:
+        raise PointsFlexTokenError("invalid_token")
+    if current_time >= deletion.expires_at:
+        raise PointsFlexTokenError("expired_token")
+    return deletion
 
 
 def parse_lifetime_earned(payload: dict[str, Any]) -> int:
@@ -195,7 +321,7 @@ def build_points_flex_preview_blocks(*, lifetime_earned: int, token: str) -> lis
             "text": {
                 "type": "mrkdwn",
                 "text": (
-                    "Share your contribution total publicly in this channel?\n\n"
+                    "Share your contribution total in this thread?\n\n"
                     f"You have earned *{lifetime_earned} Roo Points* through MLAI contributions."
                 ),
             },
@@ -220,7 +346,7 @@ def build_points_flex_preview_blocks(*, lifetime_earned: int, token: str) -> lis
                     "type": "button",
                     "action_id": POINTS_FLEX_ACTION_ID,
                     "style": "primary",
-                    "text": {"type": "plain_text", "text": "Share publicly"},
+                    "text": {"type": "plain_text", "text": "Share in thread"},
                     "value": token,
                 }
             ],
@@ -233,6 +359,75 @@ def format_points_flex_public_message(*, slack_user_id: str, lifetime_earned: in
         f"<@{slack_user_id}> has earned *{lifetime_earned} Roo Points* "
         "through MLAI contributions."
     )
+
+
+def build_points_flex_delete_blocks(
+    *,
+    records: list[dict[str, Any]],
+    tokens: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Build a private, exact-record delete confirmation or selector."""
+
+    if not records:
+        return []
+    heading = (
+        "Delete your Roo Points flex?"
+        if len(records) == 1
+        else "Choose the Roo Points flex to delete:"
+    )
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": heading},
+        }
+    ]
+    for record in records:
+        request_id = str(record["request_id"])
+        shared_at = int(float(record.get("shared_at") or 0))
+        when = (
+            f"<!date^{shared_at}^{{date_short_pretty}} at {{time}}|your flex post>"
+            if shared_at
+            else "your flex post"
+        )
+        thread_note = " in a thread" if record.get("thread_ts") else ""
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"Flex shared {when}{thread_note}",
+                },
+                "accessory": {
+                    "type": "button",
+                    "action_id": POINTS_FLEX_DELETE_ACTION_ID,
+                    "style": "danger",
+                    "text": {"type": "plain_text", "text": "Delete message"},
+                    "value": tokens[request_id],
+                    "confirm": {
+                        "title": {"type": "plain_text", "text": "Delete flex?"},
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "This removes the selected Roo Points flex from Slack.",
+                        },
+                        "confirm": {"type": "plain_text", "text": "Delete"},
+                        "deny": {"type": "plain_text", "text": "Keep it"},
+                        "style": "danger",
+                    },
+                },
+            }
+        )
+    blocks.append(
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": "Only your flex messages in this channel are shown. Delete buttons expire in 10 minutes.",
+                }
+            ],
+        }
+    )
+    return blocks
 
 
 class PointsFlexShareStore:
@@ -272,6 +467,7 @@ class PointsFlexShareStore:
                         locked_by TEXT,
                         locked_until REAL,
                         message_ts TEXT,
+                        thread_ts TEXT,
                         last_error_code TEXT,
                         created_at REAL NOT NULL,
                         updated_at REAL NOT NULL,
@@ -279,10 +475,35 @@ class PointsFlexShareStore:
                     )
                     """
                 )
+                columns = {
+                    row["name"]
+                    for row in connection.execute(
+                        "PRAGMA table_info(points_flex_shares)"
+                    ).fetchall()
+                }
+                if "thread_ts" not in columns:
+                    try:
+                        connection.execute(
+                            "ALTER TABLE points_flex_shares ADD COLUMN thread_ts TEXT"
+                        )
+                    except sqlite3.OperationalError as exc:
+                        # Separate Roo workers can discover the live schema at
+                        # the same time. The winner has already completed the
+                        # additive upgrade in this one acceptable error case.
+                        if "duplicate column name" not in str(exc).lower():
+                            raise
                 connection.execute(
                     """
                     CREATE INDEX IF NOT EXISTS points_flex_shares_expiry_idx
                     ON points_flex_shares (expires_at)
+                    """
+                )
+                connection.execute(
+                    """
+                    CREATE INDEX IF NOT EXISTS points_flex_shares_owner_idx
+                    ON points_flex_shares (
+                        slack_user_id, channel_id, status, shared_at DESC
+                    )
                     """
                 )
             self._initialised = True
@@ -313,8 +534,8 @@ class PointsFlexShareStore:
                 DELETE FROM points_flex_shares
                 WHERE updated_at < ?
                   AND (
-                    (status != 'shared' AND expires_at <= ?)
-                    OR (status = 'shared' AND shared_at < ?)
+                    (status IN ('pending', 'processing') AND expires_at <= ?)
+                    OR (status = 'deleted' AND updated_at < ?)
                   )
                 """,
                 (current_time - 86400, current_time, current_time - 90 * 86400),
@@ -322,14 +543,15 @@ class PointsFlexShareStore:
             connection.execute(
                 """
                 INSERT OR IGNORE INTO points_flex_shares (
-                    request_id, slack_user_id, channel_id, expires_at, status,
+                    request_id, slack_user_id, channel_id, thread_ts, expires_at, status,
                     created_at, updated_at
-                ) VALUES (?, ?, ?, ?, 'pending', ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, 'pending', ?, ?)
                 """,
                 (
                     confirmation.request_id,
                     confirmation.slack_user_id,
                     confirmation.channel_id,
+                    confirmation.thread_ts,
                     confirmation.expires_at,
                     current_time,
                     current_time,
@@ -347,6 +569,7 @@ class PointsFlexShareStore:
             if (
                 stored["slack_user_id"] != confirmation.slack_user_id
                 or stored["channel_id"] != confirmation.channel_id
+                or (stored.get("thread_ts") or None) != confirmation.thread_ts
                 or int(stored["expires_at"]) != confirmation.expires_at
             ):
                 connection.commit()
@@ -460,6 +683,156 @@ class PointsFlexShareStore:
                     (str(request_id),),
                 ).fetchone()
             )
+
+    def list_shared(
+        self,
+        *,
+        slack_user_id: str,
+        channel_id: str,
+        limit: int = 10,
+    ) -> list[dict[str, Any]]:
+        """List only the requesting member's deletable flexes in one channel."""
+
+        self._initialise()
+        bounded_limit = min(max(int(limit), 1), 10)
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT * FROM points_flex_shares
+                WHERE slack_user_id = ? AND channel_id = ?
+                  AND status = 'shared' AND message_ts IS NOT NULL
+                  AND message_ts != ''
+                ORDER BY shared_at DESC, created_at DESC
+                LIMIT ?
+                """,
+                (str(slack_user_id), str(channel_id), bounded_limit),
+            ).fetchall()
+        return [dict(row) for row in rows]
+
+    def claim_delete(
+        self,
+        deletion: PointsFlexDeletion,
+        *,
+        owner: Optional[str] = None,
+        now: Optional[float] = None,
+        lease_seconds: int = POINTS_FLEX_PROCESSING_LEASE_SECONDS,
+    ) -> dict[str, Any]:
+        """Claim deletion of exactly one owned stored flex."""
+
+        self._initialise()
+        current_time = time.time() if now is None else float(now)
+        owner = str(owner or f"roo-flex-delete-{uuid4()}")
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                "SELECT * FROM points_flex_shares WHERE request_id = ?",
+                (deletion.request_id,),
+            ).fetchone()
+            if row is None:
+                connection.commit()
+                return {"state": "not_found", "record": None}
+            stored = dict(row)
+            if (
+                stored["slack_user_id"] != deletion.slack_user_id
+                or stored["channel_id"] != deletion.channel_id
+            ):
+                connection.commit()
+                return {"state": "not_found", "record": None}
+            if stored["status"] == "deleted":
+                connection.commit()
+                return {"state": "deleted", "record": stored}
+            if stored["status"] == "deleting" and float(stored.get("locked_until") or 0) > current_time:
+                connection.commit()
+                return {"state": "deleting", "record": stored}
+            if stored["status"] not in {"shared", "deleting"} or not stored.get("message_ts"):
+                connection.commit()
+                return {"state": "unavailable", "record": stored}
+
+            cursor = connection.execute(
+                """
+                UPDATE points_flex_shares
+                SET status = 'deleting', locked_by = ?, locked_until = ?,
+                    last_error_code = NULL, updated_at = ?
+                WHERE request_id = ?
+                  AND (status = 'shared' OR (status = 'deleting' AND locked_until <= ?))
+                """,
+                (
+                    owner,
+                    current_time + int(lease_seconds),
+                    current_time,
+                    deletion.request_id,
+                    current_time,
+                ),
+            )
+            claimed = connection.execute(
+                "SELECT * FROM points_flex_shares WHERE request_id = ?",
+                (deletion.request_id,),
+            ).fetchone()
+            connection.commit()
+            if cursor.rowcount != 1:
+                return {"state": "deleting", "record": dict(claimed)}
+            return {"state": "claimed", "record": dict(claimed)}
+
+    def mark_deleted(
+        self,
+        request_id: str,
+        *,
+        owner: str,
+        now: Optional[float] = None,
+    ) -> dict[str, Any]:
+        self._initialise()
+        current_time = time.time() if now is None else float(now)
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            cursor = connection.execute(
+                """
+                UPDATE points_flex_shares
+                SET status = 'deleted', locked_by = NULL, locked_until = NULL,
+                    last_error_code = NULL, updated_at = ?
+                WHERE request_id = ? AND status = 'deleting' AND locked_by = ?
+                """,
+                (current_time, str(request_id), str(owner)),
+            )
+            row = connection.execute(
+                "SELECT * FROM points_flex_shares WHERE request_id = ?",
+                (str(request_id),),
+            ).fetchone()
+            connection.commit()
+            if cursor.rowcount != 1 and (row is None or row["status"] != "deleted"):
+                raise RuntimeError("points flex delete claim was lost")
+            return dict(row)
+
+    def release_delete(
+        self,
+        request_id: str,
+        *,
+        owner: str,
+        error_code: str,
+        now: Optional[float] = None,
+    ) -> dict[str, Any]:
+        """Release a failed delete so its still-valid button can be retried."""
+
+        self._initialise()
+        current_time = time.time() if now is None else float(now)
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            connection.execute(
+                """
+                UPDATE points_flex_shares
+                SET status = 'shared', locked_by = NULL, locked_until = NULL,
+                    last_error_code = ?, updated_at = ?
+                WHERE request_id = ? AND status = 'deleting' AND locked_by = ?
+                """,
+                (str(error_code)[:64], current_time, str(request_id), str(owner)),
+            )
+            row = connection.execute(
+                "SELECT * FROM points_flex_shares WHERE request_id = ?",
+                (str(request_id),),
+            ).fetchone()
+            connection.commit()
+            if row is None:
+                raise RuntimeError("points flex share state is missing")
+            return dict(row)
 
 
 @lru_cache(maxsize=8)

--- a/roo-standalone/roo/routing_eval/cases/blessed_regressions.yaml
+++ b/roo-standalone/roo/routing_eval/cases/blessed_regressions.yaml
@@ -23,6 +23,10 @@
   text: "flex my points"
   expect: {skill: mlai-points, action: flex_points}
   tags: [blessed, fast-path]
+- id: fast-delete-my-flex
+  text: "delete my flex"
+  expect: {skill: mlai-points, action: delete_flex}
+  tags: [blessed, fast-path]
 - id: fast-tasks
   text: "tasks"
   expect: {skill: mlai-points, action: list_tasks}

--- a/roo-standalone/roo/routing_eval/cases/paraphrases.yaml
+++ b/roo-standalone/roo/routing_eval/cases/paraphrases.yaml
@@ -119,6 +119,10 @@
   text: "let me flex my Roo contribution total in this channel"
   expect: {skill: mlai-points, action: flex_points}
   tags: [paraphrase, points-flex]
+- id: para-points-delete-flex
+  text: "remove my latest Roo Points flex from this channel"
+  expect: {skill: mlai-points, action: delete_flex}
+  tags: [paraphrase, points-flex]
 - id: para-points-spend-on
   text: "what can I spend my roo points on?"
   expect: {skill: mlai-points}

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -11947,13 +11947,8 @@ Chunk {index} source: {label}
             )
 
         elif action == "delete_flex":
-            if not channel_id or str(channel_id).startswith("D"):
-                return (
-                    "Run `@Roo delete my flex` in the shared channel where the "
-                    "flex was posted. Roo will show the choices only to you."
-                )
-
-            if not str(channel_id).startswith(("C", "G")):
+            is_dm = bool(channel_id and str(channel_id).startswith("D"))
+            if not channel_id or not str(channel_id).startswith(("C", "D", "G")):
                 return {
                     "message": "",
                     "suppress_post": True,
@@ -11976,14 +11971,17 @@ Chunk {index} source: {label}
                 if mentioned_user_id != bot_user_id
             ]
             if target_mentions:
+                target_rejected_text = (
+                    "You can only delete your own Roo Points flex. "
+                    "Use `delete my flex` without tagging another member."
+                )
+                if is_dm:
+                    return target_rejected_text
                 delivered = self._post_private_points_ack(
                     channel_id=channel_id,
                     requester_user_id=user_id,
                     thread_ts=thread_ts,
-                    text=(
-                        "You can only delete your own Roo Points flex. "
-                        "Use `@Roo delete my flex` without tagging another member."
-                    ),
+                    text=target_rejected_text,
                     action="delete_flex",
                 )
                 return {
@@ -11999,10 +11997,15 @@ Chunk {index} source: {label}
 
             settings = get_settings()
             store = get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+            lookup_failed = False
             try:
-                records = store.list_shared(
-                    slack_user_id=user_id,
-                    channel_id=channel_id,
+                records = (
+                    store.list_shared_for_user(slack_user_id=user_id)
+                    if is_dm
+                    else store.list_shared(
+                        slack_user_id=user_id,
+                        channel_id=channel_id,
+                    )
                 )
             except Exception as exc:
                 print(
@@ -12010,13 +12013,25 @@ Chunk {index} source: {label}
                     f"exc_type={exc.__class__.__name__}"
                 )
                 records = []
+                lookup_failed = True
 
             if not records:
+                empty_text = (
+                    "I couldn't safely look up your Roo Points flexes. Try again in a moment."
+                    if lookup_failed
+                    else (
+                        "I couldn't find any active Roo Points flexes from you."
+                        if is_dm
+                        else "I couldn't find an active Roo Points flex from you in this channel."
+                    )
+                )
+                if is_dm:
+                    return empty_text
                 delivered = self._post_private_points_ack(
                     channel_id=channel_id,
                     requester_user_id=user_id,
                     thread_ts=thread_ts,
-                    text="I couldn't find an active Roo Points flex from you in this channel.",
+                    text=empty_text,
                     action="delete_flex",
                 )
                 return {
@@ -12034,7 +12049,8 @@ Chunk {index} source: {label}
                     signing_secret=settings.SLACK_SIGNING_SECRET,
                     request_id=str(record["request_id"]),
                     slack_user_id=user_id,
-                    channel_id=channel_id,
+                    channel_id=str(record["channel_id"]),
+                    interaction_channel_id=channel_id,
                 )
                 for record in records
             }
@@ -12043,16 +12059,28 @@ Chunk {index} source: {label}
                 if len(records) > 1
                 else "Confirm deletion of your Roo Points flex."
             )
+            preview_blocks = build_points_flex_delete_blocks(
+                records=records,
+                tokens=tokens,
+                include_channel=is_dm,
+            )
+            if is_dm:
+                return {
+                    "message": preview_text,
+                    "blocks": preview_blocks,
+                    "data": {
+                        "action": "delete_flex",
+                        "preview_ready": True,
+                        "flex_count": len(records),
+                    },
+                }
             try:
                 response = post_ephemeral(
                     channel=channel_id,
                     user=user_id,
                     text=preview_text,
                     thread_ts=thread_ts,
-                    blocks=build_points_flex_delete_blocks(
-                        records=records,
-                        tokens=tokens,
-                    ),
+                    blocks=preview_blocks,
                 )
                 preview_delivered = bool(response and response.get("ok"))
             except Exception as exc:

--- a/roo-standalone/roo/skills/executor.py
+++ b/roo-standalone/roo/skills/executor.py
@@ -66,8 +66,11 @@ from ..points_request_approval import (
     remember_points_request_summary,
 )
 from ..points_flex import (
+    build_points_flex_delete_blocks,
     build_points_flex_preview_blocks,
+    get_points_flex_store,
     issue_points_flex_confirmation,
+    issue_points_flex_deletion,
     parse_lifetime_earned,
 )
 from ..slack_client import (
@@ -11943,6 +11946,145 @@ Chunk {index} source: {label}
                 private_ack="I've sent your Roo Points summary privately.",
             )
 
+        elif action == "delete_flex":
+            if not channel_id or str(channel_id).startswith("D"):
+                return (
+                    "Run `@Roo delete my flex` in the shared channel where the "
+                    "flex was posted. Roo will show the choices only to you."
+                )
+
+            if not str(channel_id).startswith(("C", "G")):
+                return {
+                    "message": "",
+                    "suppress_post": True,
+                    "data": {
+                        "action": "delete_flex",
+                        "preview_delivered": False,
+                        "invalid_channel": True,
+                    },
+                }
+
+            from ..slack_client import get_bot_user_id
+
+            try:
+                bot_user_id = get_bot_user_id()
+            except Exception:
+                bot_user_id = None
+            target_mentions = [
+                mentioned_user_id
+                for mentioned_user_id in re.findall(r"<@([A-Z0-9]+)>", text)
+                if mentioned_user_id != bot_user_id
+            ]
+            if target_mentions:
+                delivered = self._post_private_points_ack(
+                    channel_id=channel_id,
+                    requester_user_id=user_id,
+                    thread_ts=thread_ts,
+                    text=(
+                        "You can only delete your own Roo Points flex. "
+                        "Use `@Roo delete my flex` without tagging another member."
+                    ),
+                    action="delete_flex",
+                )
+                return {
+                    "message": "",
+                    "suppress_post": True,
+                    "data": {
+                        "action": "delete_flex",
+                        "preview_delivered": False,
+                        "target_rejected": True,
+                        "ephemeral_delivered": delivered,
+                    },
+                }
+
+            settings = get_settings()
+            store = get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+            try:
+                records = store.list_shared(
+                    slack_user_id=user_id,
+                    channel_id=channel_id,
+                )
+            except Exception as exc:
+                print(
+                    "Points flex delete lookup failed "
+                    f"exc_type={exc.__class__.__name__}"
+                )
+                records = []
+
+            if not records:
+                delivered = self._post_private_points_ack(
+                    channel_id=channel_id,
+                    requester_user_id=user_id,
+                    thread_ts=thread_ts,
+                    text="I couldn't find an active Roo Points flex from you in this channel.",
+                    action="delete_flex",
+                )
+                return {
+                    "message": "",
+                    "suppress_post": True,
+                    "data": {
+                        "action": "delete_flex",
+                        "preview_delivered": delivered,
+                        "flex_count": 0,
+                    },
+                }
+
+            tokens = {
+                str(record["request_id"]): issue_points_flex_deletion(
+                    signing_secret=settings.SLACK_SIGNING_SECRET,
+                    request_id=str(record["request_id"]),
+                    slack_user_id=user_id,
+                    channel_id=channel_id,
+                )
+                for record in records
+            }
+            preview_text = (
+                "Confirm which Roo Points flex to delete."
+                if len(records) > 1
+                else "Confirm deletion of your Roo Points flex."
+            )
+            try:
+                response = post_ephemeral(
+                    channel=channel_id,
+                    user=user_id,
+                    text=preview_text,
+                    thread_ts=thread_ts,
+                    blocks=build_points_flex_delete_blocks(
+                        records=records,
+                        tokens=tokens,
+                    ),
+                )
+                preview_delivered = bool(response and response.get("ok"))
+            except Exception as exc:
+                print(
+                    "Points flex delete preview failed "
+                    f"exc_type={exc.__class__.__name__}"
+                )
+                preview_delivered = False
+
+            if not preview_delivered:
+                try:
+                    send_dm(
+                        user_id,
+                        "I couldn't show the flex deletion controls in that channel. "
+                        "Try `@Roo delete my flex` there again in a moment.",
+                    )
+                except Exception as exc:
+                    print(
+                        "Points flex delete fallback failed "
+                        f"exc_type={exc.__class__.__name__}"
+                    )
+
+            return {
+                "message": "",
+                "suppress_post": True,
+                "data": {
+                    "action": "delete_flex",
+                    "preview_delivered": preview_delivered,
+                    "flex_count": len(records),
+                },
+            }
+
         elif action == "flex_points":
             if not channel_id or str(channel_id).startswith("D"):
                 return (
@@ -11958,6 +12100,27 @@ Chunk {index} source: {label}
                         "action": "flex_points",
                         "preview_delivered": False,
                         "invalid_channel": True,
+                    },
+                }
+
+            if not thread_ts:
+                delivered = self._post_private_points_ack(
+                    channel_id=channel_id,
+                    requester_user_id=user_id,
+                    thread_ts=None,
+                    text=(
+                        "I couldn't identify the request thread, so nothing was shared. "
+                        "Run `@Roo flex my points` again."
+                    ),
+                    action="flex_points",
+                )
+                return {
+                    "message": "",
+                    "suppress_post": True,
+                    "data": {
+                        "action": "flex_points",
+                        "preview_delivered": delivered,
+                        "missing_thread": True,
                     },
                 }
 
@@ -12001,10 +12164,11 @@ Chunk {index} source: {label}
                 signing_secret=settings.SLACK_SIGNING_SECRET,
                 slack_user_id=user_id,
                 channel_id=channel_id,
+                thread_ts=thread_ts,
             )
             preview_text = (
                 "Confirm whether to share your lifetime-earned Roo Points "
-                "publicly in this channel."
+                "in this thread."
             )
             try:
                 response = post_ephemeral(
@@ -12029,8 +12193,8 @@ Chunk {index} source: {label}
                 try:
                     send_dm(
                         user_id,
-                        "I couldn't show the public sharing confirmation in that "
-                        "channel. Try `@Roo flex my points` there again in a moment.",
+                        "I couldn't show the sharing confirmation in that "
+                        "thread. Try `@Roo flex my points` there again in a moment.",
                     )
                 except Exception as exc:
                     print(

--- a/roo-standalone/roo/slack_client.py
+++ b/roo-standalone/roo/slack_client.py
@@ -121,6 +121,25 @@ def post_ephemeral(
         raise
 
 
+def delete_message(channel: str, message_ts: str) -> Dict[str, Any]:
+    """Delete a message previously posted by Roo's bot token."""
+
+    client = get_slack_client()
+    try:
+        response = client.chat_delete(channel=channel, ts=message_ts)
+        if response.get("ok"):
+            print("✅ Roo message deleted")
+        else:
+            print(
+                "❌ Failed to delete Roo message: "
+                f"error={response.get('error', 'unknown')}"
+            )
+        return response
+    except Exception as exc:
+        print(f"❌ Slack delete error: error_type={exc.__class__.__name__}")
+        raise
+
+
 def upload_file(
     channel: str,
     content: str,

--- a/roo-standalone/roo/tests/test_points_flex.py
+++ b/roo-standalone/roo/tests/test_points_flex.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sqlite3
 import time
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
@@ -13,14 +14,18 @@ os.environ.setdefault("OPENAI_API_KEY", "points-flex-openai-test")
 from roo import agent as agent_module
 from roo import main as main_module
 from roo import points_flex as flex_module
+from roo import slack_client as slack_client_module
 from roo.agent import RooAgent
 from roo.points_flex import (
     POINTS_FLEX_ACTION_ID,
+    POINTS_FLEX_DELETE_ACTION_ID,
     PointsFlexShareStore,
     PointsFlexTokenError,
     issue_points_flex_confirmation,
+    issue_points_flex_deletion,
     parse_lifetime_earned,
     verify_points_flex_confirmation,
+    verify_points_flex_deletion,
 )
 from roo.skills import executor as executor_module
 from roo.skills.executor import SkillExecutor
@@ -50,11 +55,12 @@ def _settings(tmp_path):
     )
 
 
-def _issue(*, user="UVERIFIED", channel="CPOINTS", now=None):
+def _issue(*, user="UVERIFIED", channel="CPOINTS", thread="111.222", now=None):
     return issue_points_flex_confirmation(
         signing_secret=SIGNING_SECRET,
         slack_user_id=user,
         channel_id=channel,
+        thread_ts=thread,
         now=time.time() if now is None else now,
     )
 
@@ -75,9 +81,11 @@ def test_confirmation_token_is_bound_and_contains_no_points_data():
     assert decoded == expected
     payload_segment = token.split(".", 1)[0]
     payload = json.loads(flex_module._urlsafe_decode(payload_segment))
-    assert set(payload) == {"c", "exp", "iat", "rid", "u", "v"}
+    assert set(payload) == {"c", "exp", "iat", "rid", "t", "u", "v"}
     assert payload["u"] == "UVERIFIED"
     assert payload["c"] == "CPOINTS"
+    assert payload["t"] == "111.222"
+    assert payload["v"] == 2
 
 
 def test_confirmation_token_rejects_tampering_and_expiry():
@@ -98,6 +106,35 @@ def test_confirmation_token_rejects_tampering_and_expiry():
             signing_secret=SIGNING_SECRET,
             now=1_600,
         )
+
+
+def test_pre_deploy_v1_confirmation_remains_valid_during_rollout():
+    payload = {
+        "c": "CPOINTS",
+        "exp": 1_600,
+        "iat": 1_000,
+        "rid": "03ab2fb5-3b6a-4708-85cf-f214abb999f0",
+        "u": "UVERIFIED",
+        "v": 1,
+    }
+    encoded = flex_module._urlsafe_encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    signature = flex_module.hmac.new(
+        flex_module._signing_key(SIGNING_SECRET),
+        encoded.encode("ascii"),
+        flex_module.hashlib.sha256,
+    ).digest()
+    token = f"{encoded}.{flex_module._urlsafe_encode(signature)}"
+
+    confirmation = verify_points_flex_confirmation(
+        token,
+        signing_secret=SIGNING_SECRET,
+        now=1_001,
+    )
+
+    assert confirmation.thread_ts is None
+    assert confirmation.channel_id == "CPOINTS"
 
 
 @pytest.mark.parametrize(
@@ -261,6 +298,7 @@ async def test_flex_preview_is_private_and_uses_only_verified_actor(monkeypatch,
     )
     assert confirmation.slack_user_id == "UVERIFIED"
     assert confirmation.channel_id == "CPOINTS"
+    assert confirmation.thread_ts == "111.222"
 
 
 @pytest.mark.asyncio
@@ -281,7 +319,7 @@ async def test_flex_rejects_tagged_targets_before_balance_lookup(monkeypatch):
         text="<@UROO> flex <@UTARGET>'s points",
         user_id="UVERIFIED",
         channel_id="CPOINTS",
-        thread_ts=None,
+        thread_ts="111.222",
         skill=SimpleNamespace(name="mlai-points"),
     )
 
@@ -343,7 +381,7 @@ async def test_preview_failure_never_posts_points_and_sends_generic_dm(monkeypat
         text="flex my points",
         user_id="UVERIFIED",
         channel_id="CPOINTS",
-        thread_ts=None,
+        thread_ts="111.222",
         skill=SimpleNamespace(name="mlai-points"),
     )
 
@@ -389,7 +427,7 @@ def confirmation_backend(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_confirmation_refetches_total_and_posts_top_level_once(
+async def test_confirmation_refetches_total_and_posts_in_request_thread_once(
     monkeypatch,
     tmp_path,
     confirmation_backend,
@@ -421,10 +459,10 @@ async def test_confirmation_refetches_total_and_posts_top_level_once(
         {
             "channel": "CPOINTS",
             "text": "<@UVERIFIED> has earned *155 Roo Points* through MLAI contributions.",
+            "thread_ts": "111.222",
             "client_msg_id": confirmation.request_id,
         }
     ]
-    assert "thread_ts" not in public_posts[0]
     assert "9" not in public_posts[0]["text"]
     assert "44" not in public_posts[0]["text"]
     assert "20" not in public_posts[0]["text"]
@@ -659,3 +697,555 @@ async def test_slack_action_endpoint_routes_verified_identity_to_flex_handler(mo
             "verified_channel_id": "CPOINTS",
         }
     ]
+
+
+def _seed_shared_flex(
+    store,
+    *,
+    user="UVERIFIED",
+    channel="CPOINTS",
+    thread="111.222",
+    message_ts="222.333",
+    now=None,
+):
+    base_time = time.time() if now is None else float(now)
+    _, confirmation = _issue(
+        user=user,
+        channel=channel,
+        thread=thread,
+        now=base_time,
+    )
+    assert store.claim(
+        confirmation,
+        owner="share-worker",
+        now=base_time + 1,
+    )["state"] == "claimed"
+    return store.mark_shared(
+        confirmation.request_id,
+        owner="share-worker",
+        message_ts=message_ts,
+        now=base_time + 2,
+    )
+
+
+def test_delete_token_is_exact_record_bound_and_contains_no_message_timestamp():
+    _, confirmation = _issue(now=1_000)
+    token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=confirmation.request_id,
+        slack_user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        now=1_010,
+    )
+
+    deletion = verify_points_flex_deletion(
+        token,
+        signing_secret=SIGNING_SECRET,
+        now=1_011,
+    )
+    payload = json.loads(flex_module._urlsafe_decode(token.split(".", 1)[0]))
+
+    assert deletion.request_id == confirmation.request_id
+    assert deletion.slack_user_id == "UVERIFIED"
+    assert deletion.channel_id == "CPOINTS"
+    assert set(payload) == {"c", "exp", "iat", "rid", "u", "v"}
+    assert "ts" not in payload
+    assert "message_ts" not in payload
+
+
+def test_delete_token_rejects_share_token_tampering_and_expiry():
+    _, confirmation = _issue(now=1_000)
+    delete_token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=confirmation.request_id,
+        slack_user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        now=1_010,
+    )
+    share_token, _ = _issue(now=1_010)
+
+    with pytest.raises(PointsFlexTokenError, match="invalid_token"):
+        verify_points_flex_deletion(
+            share_token,
+            signing_secret=SIGNING_SECRET,
+            now=1_011,
+        )
+    with pytest.raises(PointsFlexTokenError, match="expired_token"):
+        verify_points_flex_deletion(
+            delete_token,
+            signing_secret=SIGNING_SECRET,
+            now=1_610,
+        )
+
+
+def test_live_flex_database_schema_is_upgraded_without_losing_shared_rows(tmp_path):
+    database_path = tmp_path / "live-flex.db"
+    request_id = "03ab2fb5-3b6a-4708-85cf-f214abb999f0"
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE points_flex_shares (
+                request_id TEXT PRIMARY KEY,
+                slack_user_id TEXT NOT NULL,
+                channel_id TEXT NOT NULL,
+                expires_at REAL NOT NULL,
+                status TEXT NOT NULL,
+                locked_by TEXT,
+                locked_until REAL,
+                message_ts TEXT,
+                last_error_code TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                shared_at REAL
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO points_flex_shares (
+                request_id, slack_user_id, channel_id, expires_at, status,
+                message_ts, created_at, updated_at, shared_at
+            ) VALUES (?, 'UVERIFIED', 'CPOINTS', 1600, 'shared', '222.333', 1000, 1002, 1002)
+            """,
+            (request_id,),
+        )
+
+    store = PointsFlexShareStore(database_path)
+    records = store.list_shared(slack_user_id="UVERIFIED", channel_id="CPOINTS")
+
+    assert [record["request_id"] for record in records] == [request_id]
+    assert records[0]["thread_ts"] is None
+
+
+def test_delete_lookup_is_owner_and_channel_scoped_and_newest_first(tmp_path):
+    store = PointsFlexShareStore(tmp_path / "flex.db")
+    older = _seed_shared_flex(store, message_ts="200.001", now=1_000)
+    newer = _seed_shared_flex(store, message_ts="300.001", now=1_100)
+    _seed_shared_flex(store, user="UOTHER", message_ts="400.001", now=1_200)
+    _seed_shared_flex(store, channel="COTHER", message_ts="500.001", now=1_300)
+
+    records = store.list_shared(slack_user_id="UVERIFIED", channel_id="CPOINTS")
+
+    assert [record["request_id"] for record in records] == [
+        newer["request_id"],
+        older["request_id"],
+    ]
+
+
+def test_store_rejects_signed_delete_for_a_different_record_owner(tmp_path):
+    store = PointsFlexShareStore(tmp_path / "flex.db")
+    record = _seed_shared_flex(store, user="UOWNER")
+    token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=record["request_id"],
+        slack_user_id="UATTACKER",
+        channel_id="CPOINTS",
+        now=1_010,
+    )
+    deletion = verify_points_flex_deletion(
+        token,
+        signing_secret=SIGNING_SECRET,
+        now=1_011,
+    )
+
+    assert store.claim_delete(deletion, owner="attacker", now=1_012) == {
+        "state": "not_found",
+        "record": None,
+    }
+    assert store.get(record["request_id"])["status"] == "shared"
+
+
+def test_delete_claim_is_atomic_and_replay_is_idempotent(tmp_path):
+    database_path = tmp_path / "flex.db"
+    store = PointsFlexShareStore(database_path)
+    record = _seed_shared_flex(store, now=1_000)
+    token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=record["request_id"],
+        slack_user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        now=1_010,
+    )
+    deletion = verify_points_flex_deletion(
+        token,
+        signing_secret=SIGNING_SECRET,
+        now=1_011,
+    )
+
+    def claim(index):
+        return PointsFlexShareStore(database_path).claim_delete(
+            deletion,
+            owner=f"delete-{index}",
+            now=1_012,
+        )["state"]
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        states = list(pool.map(claim, range(8)))
+
+    assert states.count("claimed") == 1
+    assert states.count("deleting") == 7
+    winning_owner = f"delete-{states.index('claimed')}"
+    store.mark_deleted(record["request_id"], owner=winning_owner, now=1_013)
+    assert store.claim_delete(deletion, owner="replay", now=1_014)["state"] == "deleted"
+
+
+def test_stale_delete_can_recover_and_failed_delete_can_retry(tmp_path):
+    store = PointsFlexShareStore(tmp_path / "flex.db")
+    record = _seed_shared_flex(store, now=1_000)
+    token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=record["request_id"],
+        slack_user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        now=1_010,
+    )
+    deletion = verify_points_flex_deletion(token, signing_secret=SIGNING_SECRET, now=1_011)
+
+    assert store.claim_delete(
+        deletion,
+        owner="crashed",
+        now=1_012,
+        lease_seconds=1,
+    )["state"] == "claimed"
+    assert store.claim_delete(
+        deletion,
+        owner="recovery",
+        now=1_014,
+    )["state"] == "claimed"
+    released = store.release_delete(
+        record["request_id"],
+        owner="recovery",
+        error_code="slack_delete_failed",
+        now=1_015,
+    )
+    assert released["status"] == "shared"
+    assert store.claim_delete(
+        deletion,
+        owner="retry",
+        now=1_016,
+    )["state"] == "claimed"
+
+
+@pytest.mark.asyncio
+async def test_delete_preview_is_private_and_lists_only_verified_actors_flexes(
+    monkeypatch,
+    tmp_path,
+):
+    settings = _settings(tmp_path)
+    store = flex_module.get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+    first = _seed_shared_flex(store, message_ts="200.001")
+    second = _seed_shared_flex(store, message_ts="300.001", now=time.time() + 5)
+    _seed_shared_flex(store, user="UOTHER", message_ts="400.001", now=time.time() + 10)
+    previews = []
+    monkeypatch.setattr(executor_module, "get_settings", lambda: settings)
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "UROO")
+    monkeypatch.setattr(
+        executor_module,
+        "post_ephemeral",
+        lambda **kwargs: previews.append(kwargs) or {"ok": True},
+    )
+
+    result = await SkillExecutor()._handle_points_action(
+        client=FlexBalanceClient(),
+        action="delete_flex",
+        params={"message_ts": "999.999", "target_slack_id": "UOTHER"},
+        text="delete my flex",
+        user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts="555.666",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert result["suppress_post"] is True
+    assert result["data"]["flex_count"] == 2
+    assert previews[0]["user"] == "UVERIFIED"
+    assert previews[0]["thread_ts"] == "555.666"
+    buttons = [block["accessory"] for block in previews[0]["blocks"] if "accessory" in block]
+    assert len(buttons) == 2
+    assert all(button["action_id"] == POINTS_FLEX_DELETE_ACTION_ID for button in buttons)
+    deletions = [
+        verify_points_flex_deletion(
+            button["value"],
+            signing_secret=SIGNING_SECRET,
+        )
+        for button in buttons
+    ]
+    assert {item.request_id for item in deletions} == {
+        first["request_id"],
+        second["request_id"],
+    }
+    assert all(item.slack_user_id == "UVERIFIED" for item in deletions)
+
+
+@pytest.mark.asyncio
+async def test_delete_request_rejects_tagged_target_before_lookup(monkeypatch, tmp_path):
+    notices = []
+    monkeypatch.setattr(executor_module, "get_settings", lambda: _settings(tmp_path))
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "UROO")
+    monkeypatch.setattr(
+        executor_module,
+        "post_ephemeral",
+        lambda **kwargs: notices.append(kwargs) or {"ok": True},
+    )
+
+    result = await SkillExecutor()._handle_points_action(
+        client=FlexBalanceClient(),
+        action="delete_flex",
+        params={},
+        text="<@UROO> delete <@UOTHER>'s flex",
+        user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert result["data"]["target_rejected"] is True
+    assert "only delete your own" in notices[0]["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_in_dm_requires_original_shared_channel():
+    result = await SkillExecutor()._handle_points_action(
+        client=FlexBalanceClient(),
+        action="delete_flex",
+        params={},
+        text="delete my flex",
+        user_id="UVERIFIED",
+        channel_id="DPRIVATE",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert "shared channel" in result
+    assert "only to you" in result
+
+
+@pytest.mark.asyncio
+async def test_delete_action_uses_only_stored_target_and_is_idempotent(monkeypatch, tmp_path):
+    settings = _settings(tmp_path)
+    store = flex_module.get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+    record = _seed_shared_flex(store, message_ts="222.333")
+    _seed_shared_flex(store, message_ts="999.999", now=time.time() + 5)
+    token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=record["request_id"],
+        slack_user_id="UVERIFIED",
+        channel_id="CPOINTS",
+    )
+    deletes = []
+    monkeypatch.setattr(
+        main_module,
+        "delete_message",
+        lambda **kwargs: deletes.append(kwargs) or {"ok": True},
+    )
+
+    first = await main_module._handle_points_flex_delete_action(
+        settings=settings,
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+    replay = await main_module._handle_points_flex_delete_action(
+        settings=settings,
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+
+    assert deletes == [{"channel": "CPOINTS", "message_ts": "222.333"}]
+    assert _response_body(first)["text"] == "Deleted your Roo Points flex."
+    assert "already deleted" in _response_body(replay)["text"]
+    assert store.get(record["request_id"])["status"] == "deleted"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("actor", "channel", "message_fragment"),
+    [
+        ("UATTACKER", "CPOINTS", "Only the member"),
+        ("UVERIFIED", "COTHER", "only works in the channel"),
+    ],
+)
+async def test_delete_action_rejects_actor_and_channel_mismatch(
+    monkeypatch,
+    tmp_path,
+    actor,
+    channel,
+    message_fragment,
+):
+    settings = _settings(tmp_path)
+    store = flex_module.get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+    record = _seed_shared_flex(store)
+    token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=record["request_id"],
+        slack_user_id="UVERIFIED",
+        channel_id="CPOINTS",
+    )
+    monkeypatch.setattr(
+        main_module,
+        "delete_message",
+        lambda **kwargs: pytest.fail("no Slack deletion expected"),
+    )
+
+    response = await main_module._handle_points_flex_delete_action(
+        settings=settings,
+        action_value=token,
+        verified_user_id=actor,
+        verified_channel_id=channel,
+    )
+
+    assert message_fragment in _response_body(response)["text"]
+    assert store.get(record["request_id"])["status"] == "shared"
+
+
+@pytest.mark.asyncio
+async def test_manually_removed_flex_is_treated_as_idempotent_success(monkeypatch, tmp_path):
+    settings = _settings(tmp_path)
+    store = flex_module.get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+    record = _seed_shared_flex(store)
+    token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=record["request_id"],
+        slack_user_id="UVERIFIED",
+        channel_id="CPOINTS",
+    )
+    monkeypatch.setattr(
+        main_module,
+        "delete_message",
+        lambda **kwargs: {"ok": False, "error": "message_not_found"},
+    )
+
+    response = await main_module._handle_points_flex_delete_action(
+        settings=settings,
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+
+    assert "already gone" in _response_body(response)["text"]
+    assert store.get(record["request_id"])["status"] == "deleted"
+
+
+@pytest.mark.asyncio
+async def test_slack_delete_failure_releases_record_for_retry(monkeypatch, tmp_path):
+    settings = _settings(tmp_path)
+    store = flex_module.get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+    record = _seed_shared_flex(store)
+    token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=record["request_id"],
+        slack_user_id="UVERIFIED",
+        channel_id="CPOINTS",
+    )
+    attempts = []
+
+    def delete_message(**kwargs):
+        attempts.append(kwargs)
+        if len(attempts) == 1:
+            return {"ok": False, "error": "ratelimited"}
+        return {"ok": True}
+
+    monkeypatch.setattr(main_module, "delete_message", delete_message)
+    failed = await main_module._handle_points_flex_delete_action(
+        settings=settings,
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+    retried = await main_module._handle_points_flex_delete_action(
+        settings=settings,
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="CPOINTS",
+    )
+
+    assert _response_body(failed)["replace_original"] is False
+    assert _response_body(retried)["text"] == "Deleted your Roo Points flex."
+    assert len(attempts) == 2
+
+
+@pytest.mark.asyncio
+async def test_fast_path_routes_delete_with_verified_context(monkeypatch):
+    calls = []
+    agent = object.__new__(RooAgent)
+
+    async def execute(user_id, action, **kwargs):
+        calls.append((user_id, action, kwargs))
+        return {"message": "", "suppress_post": True}
+
+    monkeypatch.setattr(agent, "_execute_fast_points", execute)
+    result = await agent._try_fast_path(
+        "delete my flex",
+        "UVERIFIED",
+        channel_id="CPOINTS",
+        thread_ts="111.222",
+    )
+
+    assert agent._match_fast_path("remove my points flex") == "delete_flex"
+    assert agent._match_fast_path("delete my latest flex") == "delete_flex"
+    assert calls == [
+        (
+            "UVERIFIED",
+            "delete_flex",
+            {"channel_id": "CPOINTS", "thread_ts": "111.222"},
+        )
+    ]
+    assert result["suppress_post"] is True
+
+
+@pytest.mark.asyncio
+async def test_slack_action_endpoint_routes_verified_identity_to_delete_handler(
+    monkeypatch,
+    tmp_path,
+):
+    settings = _settings(tmp_path)
+    captured = []
+
+    async def handle(**kwargs):
+        captured.append(kwargs)
+        return main_module._points_flex_action_response("deleted")
+
+    monkeypatch.setattr(main_module, "_handle_points_flex_delete_action", handle)
+    payload = {
+        "type": "block_actions",
+        "user": {"id": "UVERIFIED"},
+        "channel": {"id": "CPOINTS"},
+        "actions": [
+            {"action_id": POINTS_FLEX_DELETE_ACTION_ID, "value": "signed-delete-token"}
+        ],
+    }
+
+    class FakeRequest:
+        state = SimpleNamespace(slack_duplicate=False, roo_settings=settings)
+
+        async def form(self):
+            return {"payload": json.dumps(payload)}
+
+    response = await main_module.slack_actions(FakeRequest(), _verified=True)
+
+    assert _response_body(response)["text"] == "deleted"
+    assert captured == [
+        {
+            "settings": settings,
+            "action_value": "signed-delete-token",
+            "verified_user_id": "UVERIFIED",
+            "verified_channel_id": "CPOINTS",
+        }
+    ]
+
+
+def test_delete_message_uses_roos_normal_bot_client(monkeypatch):
+    calls = []
+
+    class BotClient:
+        def chat_delete(self, **kwargs):
+            calls.append(kwargs)
+            return {"ok": True}
+
+    monkeypatch.setattr(slack_client_module, "get_slack_client", lambda: BotClient())
+
+    response = slack_client_module.delete_message("CPOINTS", "222.333")
+
+    assert response == {"ok": True}
+    assert calls == [{"channel": "CPOINTS", "ts": "222.333"}]

--- a/roo-standalone/roo/tests/test_points_flex.py
+++ b/roo-standalone/roo/tests/test_points_flex.py
@@ -735,6 +735,7 @@ def test_delete_token_is_exact_record_bound_and_contains_no_message_timestamp():
         request_id=confirmation.request_id,
         slack_user_id="UVERIFIED",
         channel_id="CPOINTS",
+        interaction_channel_id="DPRIVATE",
         now=1_010,
     )
 
@@ -748,7 +749,10 @@ def test_delete_token_is_exact_record_bound_and_contains_no_message_timestamp():
     assert deletion.request_id == confirmation.request_id
     assert deletion.slack_user_id == "UVERIFIED"
     assert deletion.channel_id == "CPOINTS"
-    assert set(payload) == {"c", "exp", "iat", "rid", "u", "v"}
+    assert deletion.interaction_channel_id == "DPRIVATE"
+    assert set(payload) == {"a", "c", "exp", "iat", "rid", "u", "v"}
+    assert payload["a"] == "DPRIVATE"
+    assert payload["v"] == 2
     assert "ts" not in payload
     assert "message_ts" not in payload
 
@@ -776,6 +780,38 @@ def test_delete_token_rejects_share_token_tampering_and_expiry():
             signing_secret=SIGNING_SECRET,
             now=1_610,
         )
+
+
+def test_v1_channel_delete_token_remains_valid_during_rollout():
+    payload = {
+        "c": "CPOINTS",
+        "exp": 1_600,
+        "iat": 1_000,
+        "rid": "03ab2fb5-3b6a-4708-85cf-f214abb999f0",
+        "u": "UVERIFIED",
+        "v": 1,
+    }
+    encoded = flex_module._urlsafe_encode(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    signature = flex_module.hmac.new(
+        flex_module._signing_key(
+            SIGNING_SECRET,
+            context=flex_module._DELETE_SIGNING_CONTEXT,
+        ),
+        encoded.encode("ascii"),
+        flex_module.hashlib.sha256,
+    ).digest()
+    token = f"{encoded}.{flex_module._urlsafe_encode(signature)}"
+
+    deletion = verify_points_flex_deletion(
+        token,
+        signing_secret=SIGNING_SECRET,
+        now=1_001,
+    )
+
+    assert deletion.channel_id == "CPOINTS"
+    assert deletion.interaction_channel_id == "CPOINTS"
 
 
 def test_live_flex_database_schema_is_upgraded_without_losing_shared_rows(tmp_path):
@@ -829,6 +865,12 @@ def test_delete_lookup_is_owner_and_channel_scoped_and_newest_first(tmp_path):
     assert [record["request_id"] for record in records] == [
         newer["request_id"],
         older["request_id"],
+    ]
+    across_channels = store.list_shared_for_user(slack_user_id="UVERIFIED")
+    assert [record["message_ts"] for record in across_channels] == [
+        "500.001",
+        "300.001",
+        "200.001",
     ]
 
 
@@ -1004,7 +1046,31 @@ async def test_delete_request_rejects_tagged_target_before_lookup(monkeypatch, t
 
 
 @pytest.mark.asyncio
-async def test_delete_in_dm_requires_original_shared_channel():
+async def test_delete_in_dm_lists_owned_flexes_across_channels(monkeypatch, tmp_path):
+    settings = _settings(tmp_path)
+    store = flex_module.get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+    first = _seed_shared_flex(store, channel="CPOINTS", message_ts="200.001")
+    second = _seed_shared_flex(
+        store,
+        channel="COTHER",
+        message_ts="300.001",
+        now=time.time() + 5,
+    )
+    _seed_shared_flex(
+        store,
+        user="UOTHER",
+        channel="CSECRET",
+        message_ts="400.001",
+        now=time.time() + 10,
+    )
+    monkeypatch.setattr(executor_module, "get_settings", lambda: settings)
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "UROO")
+    monkeypatch.setattr(
+        executor_module,
+        "post_ephemeral",
+        lambda **kwargs: pytest.fail("DM controls should use the normal private response"),
+    )
+
     result = await SkillExecutor()._handle_points_action(
         client=FlexBalanceClient(),
         action="delete_flex",
@@ -1016,8 +1082,46 @@ async def test_delete_in_dm_requires_original_shared_channel():
         skill=SimpleNamespace(name="mlai-points"),
     )
 
-    assert "shared channel" in result
-    assert "only to you" in result
+    assert result["data"]["flex_count"] == 2
+    assert result["data"]["preview_ready"] is True
+    assert "Confirm which" in result["message"]
+    selector_blocks = [block for block in result["blocks"] if "accessory" in block]
+    assert len(selector_blocks) == 2
+    selector_text = "\n".join(block["text"]["text"] for block in selector_blocks)
+    assert "<#CPOINTS>" in selector_text
+    assert "<#COTHER>" in selector_text
+    assert "CSECRET" not in selector_text
+    deletions = [
+        verify_points_flex_deletion(
+            block["accessory"]["value"],
+            signing_secret=SIGNING_SECRET,
+        )
+        for block in selector_blocks
+    ]
+    assert {item.request_id for item in deletions} == {
+        first["request_id"],
+        second["request_id"],
+    }
+    assert all(item.interaction_channel_id == "DPRIVATE" for item in deletions)
+
+
+@pytest.mark.asyncio
+async def test_delete_in_dm_with_no_flexes_replies_privately(monkeypatch, tmp_path):
+    monkeypatch.setattr(executor_module, "get_settings", lambda: _settings(tmp_path))
+    monkeypatch.setattr("roo.slack_client.get_bot_user_id", lambda: "UROO")
+
+    result = await SkillExecutor()._handle_points_action(
+        client=FlexBalanceClient(),
+        action="delete_flex",
+        params={},
+        text="delete my flex",
+        user_id="UVERIFIED",
+        channel_id="DPRIVATE",
+        thread_ts="111.222",
+        skill=SimpleNamespace(name="mlai-points"),
+    )
+
+    assert result == "I couldn't find any active Roo Points flexes from you."
 
 
 @pytest.mark.asyncio
@@ -1063,7 +1167,7 @@ async def test_delete_action_uses_only_stored_target_and_is_idempotent(monkeypat
     ("actor", "channel", "message_fragment"),
     [
         ("UATTACKER", "CPOINTS", "Only the member"),
-        ("UVERIFIED", "COTHER", "only works in the channel"),
+        ("UVERIFIED", "COTHER", "only works in the conversation"),
     ],
 )
 async def test_delete_action_rejects_actor_and_channel_mismatch(
@@ -1096,6 +1200,68 @@ async def test_delete_action_rejects_actor_and_channel_mismatch(
     )
 
     assert message_fragment in _response_body(response)["text"]
+    assert store.get(record["request_id"])["status"] == "shared"
+
+
+@pytest.mark.asyncio
+async def test_delete_action_from_dm_deletes_stored_shared_channel_message(
+    monkeypatch,
+    tmp_path,
+):
+    settings = _settings(tmp_path)
+    store = flex_module.get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+    record = _seed_shared_flex(store, channel="CPOINTS", message_ts="222.333")
+    token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=record["request_id"],
+        slack_user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        interaction_channel_id="DPRIVATE",
+    )
+    deletes = []
+    monkeypatch.setattr(
+        main_module,
+        "delete_message",
+        lambda **kwargs: deletes.append(kwargs) or {"ok": True},
+    )
+
+    response = await main_module._handle_points_flex_delete_action(
+        settings=settings,
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="DPRIVATE",
+    )
+
+    assert deletes == [{"channel": "CPOINTS", "message_ts": "222.333"}]
+    assert _response_body(response)["text"] == "Deleted your Roo Points flex."
+
+
+@pytest.mark.asyncio
+async def test_delete_action_from_different_dm_is_rejected(monkeypatch, tmp_path):
+    settings = _settings(tmp_path)
+    store = flex_module.get_points_flex_store(settings.SLACK_RECEIPTS_DB_PATH)
+    record = _seed_shared_flex(store)
+    token = issue_points_flex_deletion(
+        signing_secret=SIGNING_SECRET,
+        request_id=record["request_id"],
+        slack_user_id="UVERIFIED",
+        channel_id="CPOINTS",
+        interaction_channel_id="DPRIVATE",
+    )
+    monkeypatch.setattr(
+        main_module,
+        "delete_message",
+        lambda **kwargs: pytest.fail("no Slack deletion expected"),
+    )
+
+    response = await main_module._handle_points_flex_delete_action(
+        settings=settings,
+        action_value=token,
+        verified_user_id="UVERIFIED",
+        verified_channel_id="DOTHER",
+    )
+
+    assert "only works in the conversation" in _response_body(response)["text"]
     assert store.get(record["request_id"])["status"] == "shared"
 
 

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -27,7 +27,9 @@ actions:
   - name: balance
     description: Privately show the user their current points balance.
   - name: flex_points
-    description: Confirm sharing the user's own lifetime-earned total publicly.
+    description: Share the user's own lifetime-earned total in the request thread.
+  - name: delete_flex
+    description: Delete the user's flex in this channel.
   - name: history
     description: Privately show the user their recent points transactions.
     params:
@@ -141,6 +143,7 @@ This skill enables Roo to interact with the MLAI Points System via API, allowing
 
 ### Member Actions
 - Check points balance and history
+- Flex a lifetime-earned total in the request thread and delete your own flex later
 - Request points for yourself in Slack for admin approval
 - View task queues and claim open tasks
 - Submit completed work for approval
@@ -357,10 +360,13 @@ so fresh buttons can be created safely in that conversation.
   balances as personal data. In a shared channel or thread, send those details to
   the verified requester by DM and use only a private ephemeral acknowledgement.
 - The only public lifetime-total flow is `flex_points`. It must be requested by the
-  member for themselves in the destination channel and confirmed through Roo's
-  private **Share publicly** button. Never treat a balance request as consent, never
-  accept a tagged target, and never share balance, purchase, spending, or history
-  fields. The eventual public post is top-level in the selected channel, not a thread.
+  member for themselves and confirmed through Roo's private **Share in thread**
+  button. Never treat a balance request as consent, never accept a tagged target,
+  and never share balance, purchase, spending, or history fields. Post the flex only
+  in the request thread.
+- For `delete_flex`, privately show only the verified member's stored flexes from the
+  current channel. Delete only the exact stored Roo message selected through a signed,
+  expiring button. Never accept another member or a model-provided message target.
 - In a Roo DM, return personal points details directly without opening another DM.
 - Public booking and award confirmations may state the action and points charged or
   awarded, but must not include anyone's remaining or resulting balance.

--- a/roo-standalone/skills/mlai_points/SKILL.md
+++ b/roo-standalone/skills/mlai_points/SKILL.md
@@ -29,7 +29,7 @@ actions:
   - name: flex_points
     description: Share the user's own lifetime-earned total in the request thread.
   - name: delete_flex
-    description: Delete the user's flex in this channel.
+    description: Privately delete the user's flex.
   - name: history
     description: Privately show the user their recent points transactions.
     params:
@@ -364,9 +364,10 @@ so fresh buttons can be created safely in that conversation.
   button. Never treat a balance request as consent, never accept a tagged target,
   and never share balance, purchase, spending, or history fields. Post the flex only
   in the request thread.
-- For `delete_flex`, privately show only the verified member's stored flexes from the
-  current channel. Delete only the exact stored Roo message selected through a signed,
-  expiring button. Never accept another member or a model-provided message target.
+- For `delete_flex`, a shared-channel request privately shows that member's flexes
+  from the current channel; a Roo DM privately shows their flexes across channels.
+  Delete only the exact stored Roo message selected through a signed, expiring
+  button. Never accept another member or a model-provided message target.
 - In a Roo DM, return personal points details directly without opening another DM.
 - Public booking and award confirmations may state the action and points charged or
   awarded, but must not include anyone's remaining or resulting balance.


### PR DESCRIPTION
## Summary

- post confirmed Roo Points flexes in the request thread instead of the channel timeline
- let members privately find and delete their own flex messages with signed, 10-minute Slack controls
- support deletion from a shared channel or directly from a Roo DM
- bind sharing and deletion to the verified Slack actor and channel, with exact-record idempotency and safe retry handling
- preserve compatibility with live flex records and already-issued v1 sharing confirmations

## Why

The initial flex flow stored only a channel and always posted at the top level. It also had no owner-facing removal flow. Members should be able to keep flexes inside the request thread and later remove only flex messages they own without exposing controls or status publicly.

## Behavior

- `@Roo flex my points` shows a private confirmation and posts the confirmed total in that request's thread.
- `@Roo delete my flex`, `@Roo remove my points flex`, and `@Roo delete my latest flex` show private deletion controls.
- In a shared channel Roo shows only the member's flexes from that channel. In a Roo DM it shows that member's recent flexes across channels and identifies each originating channel.
- One matching flex gets a confirmation; multiple flexes get a private, time-labelled selector.
- A successful deletion has no public follow-up. Manually removed messages and repeated button clicks are idempotent.
- Delete tokens never contain a Slack message timestamp. Roo resolves the target only from the owner-scoped stored flex record and uses its normal bot token, which can delete only Roo-authored messages.

## Validation

- `57 passed`: flex, routing catalog, and routing gate tests
- deterministic routing: 242 cases, 0 misroutes, no baseline regressions
- exact GitHub PR security gate: `488 passed`
- full repository suite: `837 passed, 22 failed`; the 22 failures are the existing unrelated baseline failures in content factory, jobs scheduler, points requests, and coworking reporting
- `python -m compileall -q roo bridge`
- `git diff --check`
