### PR TITLE
Correct the admin routing doc's public-channel claim

### DIFF
--- a/roo-standalone/docs/admin-roo-deployment.md
+++ b/roo-standalone/docs/admin-roo-deployment.md
@@ -15,11 +15,15 @@ processes preserve the security boundary:
 1. Slack signs a mention to the existing `/slack/events` endpoint.
 2. Roo routes the task by intent. Points and other existing tasks stay Public,
    including when the caller is a committee member.
-3. For an internal-memory intent, Public Roo first rejects public `C...`
-   channels locally, then calls the backend's content-free eligibility endpoint.
+3. For an internal-memory intent, Public Roo rejects any non-Slack context
+   locally, then calls the backend's content-free eligibility endpoint.
 4. The backend permits the route only when the verified caller has active
    identity, membership, capability, pilot actor/context approval, and an
-   active `PointsAdmin` record with exact role `committee`.
+   active `PointsAdmin` record with exact role `committee`. Under policy
+   `roo-unified-routing-v2` the approved-context set is the pilot manifest's
+   `allowed_slack_contexts`, which may include explicitly approved public
+   channels; an answer delivered to a `C...` channel is prefixed with a banner
+   warning that everyone in the channel can read it.
 5. Public Roo sends a short-lived, HMAC-signed, single-use envelope to the
    internal worker. It is bound to the Slack team, user, channel, thread,
    event, request kind, and payload.


### PR DESCRIPTION
## Why

`docs/admin-roo-deployment.md` described the runtime flow as:

> For an internal-memory intent, Public Roo first rejects public `C...` channels locally, then calls the backend's content-free eligibility endpoint.

That is not what the code does. Under policy `roo-unified-routing-v2`:

- The **local** check in `_execute_unified_admin_brain` rejects non-Slack contexts (`agent.py:553` allows `C`, `D`, and `G`), not public channels.
- The **backend** decides approved context from the pilot manifest's `allowed_slack_contexts`, which may include explicitly approved public channels — `org_memory/views.py` says so directly in the `private_context_allowed` comment.
- A public-channel answer is **delivered** with a warning banner (`agent.py:640-657`), not refused. There is a test asserting exactly this (`test_unified_admin_routing.py:276`).

A doc that describes a stricter boundary than the code enforces is the dangerous direction to be wrong in: someone reading it could reasonably assume private memory can never reach a `C...` channel and approve a public channel in the manifest on that basis.

## What changed

Doc only, no behaviour change. Describes the local check accurately, names the pilot manifest as the control point for what counts as an admin channel, and states that approved public channels get the warning banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)