### PR TITLE
Fix start-here award backend route

### DIFF
--- a/roo-standalone/roo/clients/mlai_backend.py
+++ b/roo-standalone/roo/clients/mlai_backend.py
@@ -3348,7 +3348,7 @@ class MLAIBackendClient:
         channel_id: str,
     ) -> dict:
         """Award the one-time intro bonus for a user's first channel post."""
-        endpoint = "/api/v1/activity/first-post-award/"
+        endpoint = f"{self._points_base}/activity/first-post-award/"
         payload = {
             "slack_user_id": self._clean_slack_id(slack_user_id),
             "channel_id": channel_id,

--- a/roo-standalone/roo/start_here_introductions.py
+++ b/roo-standalone/roo/start_here_introductions.py
@@ -701,6 +701,24 @@ class StartHereIntroductionStore:
                 ).fetchone()
             )
 
+    def requeue_legacy_award_route_failures(self) -> int:
+        """Retry awards blocked by Roo's formerly incorrect backend route."""
+        self._ensure_schema()
+        now = _now()
+        with self._lock, self._connect() as conn:
+            cursor = conn.execute(
+                """
+                UPDATE start_here_introductions
+                SET status = 'pending_award', attempt_count = 0,
+                    next_attempt_at = ?, locked_until = NULL, locked_by = NULL,
+                    last_error = NULL, updated_at = ?
+                WHERE status = 'blocked'
+                  AND last_error LIKE '%/api/v1/activity/first-post-award/%'
+                """,
+                (now, now),
+            )
+            return int(cursor.rowcount)
+
     def due_notifications(self, *, limit: int = 50) -> list[dict[str, Any]]:
         self._ensure_schema()
         with self._connect() as conn:
@@ -960,6 +978,9 @@ async def start_here_intro_retry_loop(
     poll_seconds: Optional[float] = None,
 ) -> None:
     store = store or get_start_here_store()
+    requeued = store.requeue_legacy_award_route_failures()
+    if requeued:
+        print(f"🔄 start_here_requeued_legacy_route_failures count={requeued}")
     if poll_seconds is None:
         try:
             poll_seconds = float(

--- a/roo-standalone/roo/tests/test_points_requests.py
+++ b/roo-standalone/roo/tests/test_points_requests.py
@@ -2536,7 +2536,9 @@ async def test_backend_client_award_first_channel_post_uses_canonical_endpoint(m
     assert result == {"awarded": True, "new_balance": 4, "points_awarded": 4}
     assert len(recorder.calls) == 1
     assert recorder.calls[0]["method"] == "POST"
-    assert recorder.calls[0]["url"] == "https://backend.test/api/v1/activity/first-post-award/"
+    assert recorder.calls[0]["url"] == (
+        "https://backend.test/api/v1/points/activity/first-post-award/"
+    )
     assert recorder.calls[0]["json"] == {
         "slack_user_id": "UINTRO",
         "channel_id": "CSTART",

--- a/roo-standalone/roo/tests/test_start_here_introductions.py
+++ b/roo-standalone/roo/tests/test_start_here_introductions.py
@@ -328,3 +328,48 @@ async def test_retryable_award_failure_stays_queued_and_can_succeed(tmp_path, mo
     assert retried["status"] == "awarded"
     assert success_client.calls == [("UNEW", "CSTART")]
     assert len(notifications) == 1
+
+
+def test_requeues_only_failures_from_legacy_award_route(tmp_path, monkeypatch):
+    clock = [1000.0]
+    monkeypatch.setattr(intro, "_now", lambda: clock[0])
+    store = make_store(tmp_path)
+
+    _, legacy = store.reserve(intro.normalize_intro_event(message_event()))
+    claimed = store.claim_classification(legacy["id"], owner="classifier")
+    classified = store.mark_classified(
+        claimed["id"],
+        intro.IntroClassification(True, False, 0.99, (), "valid", "{}"),
+        min_confidence=0.8,
+    )
+    claimed = store.claim_award(classified["id"], owner="award")
+    store.mark_blocked(
+        claimed["id"],
+        error=(
+            "HTTPStatusError: Client error '404 Not Found' for url "
+            "'https://api.mlai.au/api/v1/activity/first-post-award/'"
+        ),
+    )
+
+    other_event = intro.normalize_intro_event(
+        {**message_event(ts="222.000"), "user": "UOTHER"}
+    )
+    _, other = store.reserve(other_event)
+    claimed = store.claim_classification(other["id"], owner="classifier")
+    classified = store.mark_classified(
+        claimed["id"],
+        intro.IntroClassification(True, False, 0.99, (), "valid", "{}"),
+        min_confidence=0.8,
+    )
+    claimed = store.claim_award(classified["id"], owner="award")
+    store.mark_blocked(claimed["id"], error="HTTPStatusError: 403 Forbidden")
+
+    clock[0] = 2000.0
+    assert store.requeue_legacy_award_route_failures() == 1
+    assert store.requeue_legacy_award_route_failures() == 0
+
+    repaired = store.get_for_user("CSTART", "UNEW")
+    assert repaired["status"] == "pending_award"
+    assert repaired["next_attempt_at"] == 2000.0
+    assert repaired["last_error"] is None
+    assert store.get_for_user("CSTART", "UOTHER")["status"] == "blocked"


### PR DESCRIPTION
## What changed

- route first-post intro awards through the backend's canonical `/api/v1/points/` prefix
- requeue only introduction awards blocked by the legacy 404 URL
- add regression coverage for the canonical URL and recovery filter

## Root cause

Roo called `/api/v1/activity/first-post-award/`, but `roo.urls` is mounted beneath `/api/v1/points/` in mlai-backend. Production returned 404, and the intro store treated that 4xx as a permanent blocked award without posting the Slack welcome.

## Validation

- `pytest -q roo/tests/test_start_here_introductions.py` — 11 passed
- canonical endpoint client test — passed
- Python compile check — passed
- `git diff --check` — passed

The full points-request file currently has three unrelated pre-existing failures on `main` covering coworking behavior and an LLM model expectation.